### PR TITLE
Feature/nbs logging3

### DIFF
--- a/sources/server/src/ui/scripts/app/App.ts
+++ b/sources/server/src/ui/scripts/app/App.ts
@@ -18,7 +18,6 @@
  */
 /// <reference path="../../../../typedefs/angularjs/angular.d.ts" />
 /// <reference path="../../../../typedefs/angularjs/angular-route.d.ts" />
-/// <reference path="../../../../typedefs/app/app.d.ts" />
 /// <amd-dependency path="angularRoute" />
 import angular = require('angular');
 import constants = require('app/common/Constants');

--- a/sources/server/src/ui/scripts/app/common/Constants.ts
+++ b/sources/server/src/ui/scripts/app/common/Constants.ts
@@ -27,11 +27,20 @@ export var scriptPaths = {
 
 export var appModuleName = 'app';
 
-// Angular injectable names
+// Angular component names used for dependency injection
 export var notebooks = {
   pageControllerName: 'NotebooksPageController',
-
   edit: {
     pageControllerName: 'EditPageController'
+  }
+};
+
+// Logging scope names
+export var scopes = {
+  notebooks: {
+    page: 'notebooks.page',
+    edit: {
+      page: 'notebooks.edit.page'
+    }
   }
 };

--- a/sources/server/src/ui/scripts/app/common/Interfaces.ts
+++ b/sources/server/src/ui/scripts/app/common/Interfaces.ts
@@ -22,4 +22,11 @@ declare module app {
     controller(name: string, constructor: Function): void;
   }
 
+  interface ILogger {
+    debug (...objects: Object []): void;
+    info (...objects: Object []): void;
+    warn (...objects: Object []): void;
+    error (...objects: Object []): void;
+  }
+
 }

--- a/sources/server/src/ui/scripts/app/common/Logging.ts
+++ b/sources/server/src/ui/scripts/app/common/Logging.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+/**
+ * Logging API
+ */
+/// <reference path="Interfaces.ts" />
+
+
+/**
+ * Logger that supports levels and scopes.
+ *
+ * TODO(bryantd): detect support for console.<level> methods and delegate if available.
+ * TODO(bryantd): add support for configuring the log levels externally
+ * TODO(bryantd): add support configuring log output by scope
+ */
+class Logger implements app.ILogger {
+  /**
+   * Name of the scope under which logs will be emitted
+   */
+  private _scope: string;
+  
+  /**
+   * Creates a new logger instance
+   *
+   * @param scope logging scope name
+   */
+  constructor (scope: string) {
+    this._scope = scope;
+  }
+
+  /**
+   * Logs the given objects at the DEBUG level
+   *
+   * @param ...objects one or more objects
+   */
+  debug (...objects: Object []) {
+    this._log.apply(this, objects);
+  }
+
+  /**
+   * Logs the given objects at the INFO level
+   *
+   * @param ...objects one or more objects
+   */
+  info (...objects: Object []) {
+    this._log.apply(this, objects);
+  }
+
+  /**
+   * Logs the given objects at the WARN level
+   *
+   * @param ...objects one or more objects
+   */
+  warn (...objects: Object []) {
+    this._log.apply(this, objects);
+  }
+
+  /**
+   * Logs the given objects at the ERROR level
+   *
+   * @param ...objects one or more objects
+   */
+  error (...objects: Object []) {
+    this._log.apply(this, objects);
+  }
+
+  /**
+   * Delegates all logging to console.log.
+   *
+   * Applies scope prefix to logged messages.
+   * @param {Object []} ...objects [description]
+   */
+  private _log (...objects: Object []) {
+    var scopePrefix: Object[] = [ '[' + this._scope + ']' ];
+    console.log.apply(console, scopePrefix.concat(objects));
+  }
+}
+
+/**
+ * Get a logging instance for the given scope
+ *
+ * @param scope logging scope to use
+ * @return Logger instance
+ */
+export function getLogger (scope: string): app.ILogger {
+  return new Logger(scope);
+}

--- a/sources/server/src/ui/scripts/app/notebooks/NotebooksPageController.ts
+++ b/sources/server/src/ui/scripts/app/notebooks/NotebooksPageController.ts
@@ -13,12 +13,16 @@
  */
 
 
-/// <reference path="../common/Interfaces.ts" />
+/**
+ * Top-level page controller for the notebook index page
+ */
+import logging = require('app/common/Logging');
 import constants = require('app/common/Constants');
 import app = require('app/App');
 
 
-console.log('Loading notebooks controller function');
+var log = logging.getLogger(constants.scopes.notebooks.page);
+
 export class NotebooksPageController {
   /**
    * Constructor and arguments for Angular to inject
@@ -26,7 +30,9 @@ export class NotebooksPageController {
   static $inject: string[] = [];
   constructor () {
     // TODO(bryantd): Add controller logic
+    log.debug('Constructed notebooks page controller');
   }
 }
 
 app.registrar.controller(constants.notebooks.pageControllerName, NotebooksPageController);
+log.debug('Registered ', constants.notebooks.pageControllerName);

--- a/sources/server/src/ui/scripts/app/notebooks/edit/EditPageController.ts
+++ b/sources/server/src/ui/scripts/app/notebooks/edit/EditPageController.ts
@@ -13,11 +13,17 @@
  */
 
 
-/// <reference path="../../common/Interfaces.ts" />
+/**
+ * Top-level page controller for the notebook editing page
+ */
+/// <reference path="../../../../../../typedefs/angularjs/angular.d.ts" />
+import logging = require('app/common/Logging');
 import constants = require('app/common/Constants');
 import app = require('app/App');
 
-console.log('Loading edit controller function');
+
+var log = logging.getLogger(constants.scopes.notebooks.edit.page);
+
 export class EditPageController {
   /**
    * The ID of the notebook to edit
@@ -31,7 +37,9 @@ export class EditPageController {
   constructor (routeParams: ng.route.IRouteParamsService) {
     this.notebookId = routeParams['notebookId'];
     // TODO(bryantd): Add controller logic
+    log.debug('Constructed edit page controller');
   }
 }
 
 app.registrar.controller(constants.notebooks.edit.pageControllerName, EditPageController);
+log.debug('Registered ', constants.notebooks.edit.pageControllerName);


### PR DESCRIPTION
Copying a comment from the abandoned review on the nbs-logging2 branch below 

---

So the issue with not having the ILogger interface is that we then have to export/make public the Logger class.  This is because the Logger type is private otherwise.

```
error TS2058: Return type of exported function has or is using private type 'Logger'.
```

I'd rather just have the single public getLogger(scope) method rather than expose the Logger implementation class just for the purposes of fixing the typing issues.  This to ensure that all calling code is not constructing loggers directly, but instead just requesting an instance from the factory method.
