### PR TITLE
Adds a nav bar to the page chrome with link to GCP developers console.

### DIFF
--- a/sources/server/src/ui/index.html
+++ b/sources/server/src/ui/index.html
@@ -20,7 +20,15 @@
 </head>
 <body>
   <header>
-  <!-- TODO(bryantd): Add header content -->
+    <nav class="navbar navbar-default navbar-fixed-top">
+      <div class="container-fluid">
+        <div class="navbar-header">
+          <a class="navbar-brand" href="#">
+            Google DataLab
+          </a>
+        </div>
+      </div>
+    </nav>
   </header>
 
   <div ng-view></div>
@@ -29,7 +37,6 @@
     <!-- TODO(bryantd): Add footer content -->
   </footer>
 
-  <!-- TODO(bryantd): JS content -->
   <script data-main="scripts/main.js" type="text/javascript"
     src="//cdnjs.cloudflare.com/ajax/libs/require.js/2.1.14/require.min.js"></script>
 </body>


### PR DESCRIPTION
We will need a real logo at some point, but am using "Google DataLab" in lieu for now.

What this will look like (click image to see larger version):
![screen shot 2014-09-09 at 10 49 17 am](https://cloud.githubusercontent.com/assets/8355852/4206339/310dae5a-384a-11e4-87be-a257af060740.png)
