### PR TITLE
Fixes navbar spacing so that it does not overlap subsequent content

### DIFF
--- a/sources/server/src/ui/chrome.css
+++ b/sources/server/src/ui/chrome.css
@@ -23,3 +23,13 @@
  * within the "editor" module.
  *
  */
+
+/**
+ * Offsets the content following the navbar to account for the navbar height.
+ *
+ * Spacer element is preferred over body margin because the latter will force scrollbars to be
+ * always-on for any 100% height content within the page.
+ */
+.datalab-navbar-spacer {
+  margin-top: 50px;
+}

--- a/sources/server/src/ui/index.html
+++ b/sources/server/src/ui/index.html
@@ -30,6 +30,7 @@
         </div>
       </div>
     </nav>
+    <div class="datalab-navbar-spacer">
   </header>
 
   <div ng-view></div>


### PR DESCRIPTION
This is an expected adjustment that comes with using the fixed navbar.  This is the same css correction that is applied in the [various bootstrap starter templates](http://getbootstrap.com/examples/starter-template/starter-template.css):
