### PR TITLE
IJava: Added implementation of three basic ipython messages.

### DIFF
--- a/sources/kernels/ijava/kernel/src/com/google/cloud/ijava/communication/Message.java
+++ b/sources/kernels/ijava/kernel/src/com/google/cloud/ijava/communication/Message.java
@@ -297,19 +297,17 @@ class Message<T extends Message.Content> {
   }
 
   static class KernelInfoReply extends Message.Content.Reply {
-    String banner;
-    String implementation;
-    String[] implementation_version;
-    String language;
+    String[] protocol_version;
+    String[] ipython_version;
     String[] language_version;
+    String language;
 
-    KernelInfoReply(String language, String[] language_version, String implementation,
-        String[] implementation_version, String banner) {
-      this.language = language;
+    KernelInfoReply(String[] protocol_version, String[] ipython_version, String[] language_version,
+        String language) {
+      this.protocol_version = protocol_version;
+      this.ipython_version = ipython_version;
       this.language_version = language_version;
-      this.implementation = implementation;
-      this.implementation_version = implementation_version;
-      this.banner = banner;
+      this.language = language;
     }
   }
 

--- a/sources/kernels/ijava/kernel/src/com/google/cloud/ijava/communication/MessageHandlers.java
+++ b/sources/kernels/ijava/kernel/src/com/google/cloud/ijava/communication/MessageHandlers.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.ijava.communication;
+
+import com.google.cloud.ijava.communication.Message.ConnectReply;
+import com.google.cloud.ijava.communication.Message.ConnectRequest;
+import com.google.cloud.ijava.communication.Message.ExecuteRequest;
+import com.google.cloud.ijava.communication.Message.ExecutionState;
+import com.google.cloud.ijava.communication.Message.KernelInfoRequest;
+import com.google.cloud.ijava.communication.Message.MessageType;
+import com.google.cloud.ijava.communication.Message.ShutdownReply;
+import com.google.cloud.ijava.communication.Message.ShutdownRequest;
+import com.google.cloud.ijava.communication.Message.Stream.StreamName;
+import com.google.cloud.ijava.runner.JavaExecutionEngine;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * This class contains implementation of different types message handlers.
+ */
+class MessageHandlers {
+  private static Logger LOGGER = Logger.getLogger(MessageHandlers.class.getName());
+
+  /**
+   * This class handles the {@code kernel_info_request} message. <blockquote
+   * cite="http://ipython.org/ipython-doc/2/development/messaging.html#kernel-info"> If a client
+   * needs to know information about the kernel, it can make a request of the kernel's information.
+   * This message can be used to fetch core information of the kernel, including language (e.g.,
+   * Java), language version number and protocol version. </blockquote>
+   */
+  static class KernelInfoHandler extends MessageHandler<Message<Message.KernelInfoRequest>> {
+
+    @Override
+    public void handle(Message<KernelInfoRequest> message, CommunicationChannel socket,
+        KernelCommunicationHandler communicationHandler, ConnectionProfile connectionProfile,
+        JavaExecutionEngine javaExecutionEngine) throws CommunicationException {
+      Preconditions.checkArgument(message.header.msg_type == MessageType.kernel_info_request);
+      String[] javaVersion = System.getProperty("java.version").split("\\.");
+      communicationHandler.send(socket, message.reply(
+          MessageType.kernel_info_reply, new Message.KernelInfoReply(new String[] {"1", "0"},
+              new String[] {}, javaVersion, "Java"), Message.emptyMetadata()));
+    }
+  }
+
+  /**
+   * This class handles the {@code connect_request}. <blockquote
+   * cite="http://ipython.org/ipython-doc/2/development/messaging.html#connect"> When a client
+   * connects to the request/reply socket of the kernel, it can issue a connect request to get basic
+   * information about the kernel, such as the ports the other ZeroMQ sockets are listening on. This
+   * allows clients to only have to know about a single port (the shell channel) to connect to a
+   * kernel. </blockquote>
+   */
+  static class ConnectHandler extends MessageHandler<Message<Message.ConnectRequest>> {
+
+    @Override
+    public void handle(Message<ConnectRequest> message, CommunicationChannel socket,
+        KernelCommunicationHandler communicationHandler, ConnectionProfile connectionProfile,
+        JavaExecutionEngine javaExecutionEngine) throws CommunicationException {
+      Preconditions.checkArgument(message.header.msg_type == MessageType.connect_request);
+      communicationHandler.send(socket, message.reply(MessageType.connect_reply, new ConnectReply(
+          connectionProfile.getShell_port(), connectionProfile.getIopub_port(),
+          connectionProfile.getStdin_port(), connectionProfile.getHb_port()),
+          Message.emptyMetadata()));
+    }
+  }
+
+  /**
+   * This class handles the shutdown request. See <a
+   * href="http://ipython.org/ipython-doc/2/development/messaging.html#kernel-shutdown">Kernel
+   * Shutdown</a> for more information.
+   */
+  static class ShutdownHandler extends MessageHandler<Message<ShutdownRequest>> {
+
+    /**
+     * This field exists for testing purposes. We do not want to shutdown the JVM during test!
+     */
+    private boolean doShutdown = true;
+
+    ShutdownHandler() {
+      this(true);
+    }
+
+    @VisibleForTesting
+    ShutdownHandler(boolean doShutdown) {
+      this.doShutdown = doShutdown;
+    }
+
+    @Override
+    public void handle(Message<ShutdownRequest> message, CommunicationChannel socket,
+        KernelCommunicationHandler communicationHandler, ConnectionProfile connectionProfile,
+        JavaExecutionEngine javaExecutionEngine) throws CommunicationException {
+      Preconditions.checkArgument(message.header.msg_type == MessageType.shutdown_request);
+      communicationHandler.send(socket, message.reply(MessageType.shutdown_reply,
+          new ShutdownReply(message.content.restart), Message.emptyMetadata()));
+      LOGGER.fine("Shutting down.");
+      // The shutdown hook that we setup when we run the kernel will do the required things before
+      // shutdown.
+      if (doShutdown) {
+        System.exit(0);
+      }
+    }
+  }
+}

--- a/sources/kernels/ijava/kernel/tests/com/google/cloud/ijava/communication/FakeCommunicationChannel.java
+++ b/sources/kernels/ijava/kernel/tests/com/google/cloud/ijava/communication/FakeCommunicationChannel.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.ijava.communication;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+class FakeCommunicationChannel implements CommunicationChannel {
+
+  Queue<String> toReceive;
+  Queue<String> sent;
+
+  /**
+   * @param isPipe when true this channel will send the data from sent queue to the receive queue.
+   */
+  FakeCommunicationChannel(boolean isPipe) {
+    sent = new ArrayDeque<>();
+    if (isPipe) {
+      toReceive = sent;
+    }
+  }
+
+  FakeCommunicationChannel() {
+    this(false);
+  }
+
+  @Override
+  public String recvStr() throws CommunicationException {
+    return toReceive.poll();
+  }
+
+  @Override
+  public boolean send(String data) throws CommunicationException {
+    return sent.offer(data);
+  }
+
+  @Override
+  public boolean sendMore(String data) throws CommunicationException {
+    return sent.offer(data);
+  }
+
+  @Override
+  public void close() throws CommunicationException {}
+}

--- a/sources/kernels/ijava/kernel/tests/com/google/cloud/ijava/communication/KernelCommunicationHandlerTest.java
+++ b/sources/kernels/ijava/kernel/tests/com/google/cloud/ijava/communication/KernelCommunicationHandlerTest.java
@@ -36,8 +36,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Queue;
 import java.util.UUID;
 
 /**
@@ -91,33 +89,5 @@ public class KernelCommunicationHandlerTest extends TestCase {
     assertThat(publishChannel.sent, hasItem("id1"));
     assertThat(publishChannel.sent, hasItem(KernelJsonConverter.GSON.toJson(header)));
     assertThat(publishChannel.sent, hasItem(KernelJsonConverter.GSON.toJson(content)));
-  }
-
-  static class FakeCommunicationChannel implements CommunicationChannel {
-
-    Queue<String> toReceive;
-    List<String> sent;
-
-    FakeCommunicationChannel() {
-      sent = new ArrayList<>();
-    }
-
-    @Override
-    public String recvStr() throws CommunicationException {
-      return toReceive.poll();
-    }
-
-    @Override
-    public boolean send(String data) throws CommunicationException {
-      return sent.add(data);
-    }
-
-    @Override
-    public boolean sendMore(String data) throws CommunicationException {
-      return sent.add(data);
-    }
-
-    @Override
-    public void close() throws CommunicationException {}
   }
 }

--- a/sources/kernels/ijava/kernel/tests/com/google/cloud/ijava/communication/MessageHandlersTest.java
+++ b/sources/kernels/ijava/kernel/tests/com/google/cloud/ijava/communication/MessageHandlersTest.java
@@ -1,0 +1,144 @@
+package com.google.cloud.ijava.communication;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.ijava.communication.Message.*;
+import com.google.cloud.ijava.runner.FragmentCodeRunner;
+import com.google.cloud.ijava.runner.JavaExecutionEngine;
+
+import junit.framework.TestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Tests for {@link MessageHandlers}.
+ */
+@RunWith(JUnit4.class)
+public class MessageHandlersTest extends TestCase {
+
+  private FakeCommunicationChannel publishChannel, shellChannel;
+  private KernelCommunicationHandler kernelCommunicationHandler;
+  private ConnectionProfile profile;
+  private JavaExecutionEngine javaExecutionEngine;
+
+  @Override
+  @Before
+  public void setUp() throws InvalidKeyException, NoSuchAlgorithmException {
+    shellChannel = new FakeCommunicationChannel(true);
+    publishChannel = new FakeCommunicationChannel(true);
+    profile = new ConnectionProfile("", "", 1, 2, 3, 4, 5, "", null);
+    kernelCommunicationHandler =
+        new KernelCommunicationHandler(publishChannel, shellChannel, profile, "testuser");
+    javaExecutionEngine = new FragmentCodeRunner();
+  }
+
+  @Test
+  public void testKernelInfoRequest() throws CommunicationException {
+    MessageHandlers.KernelInfoHandler handler = new MessageHandlers.KernelInfoHandler();
+    Message.Header header = new Message.Header(UUID.randomUUID(), "testuser", UUID.randomUUID(),
+        Message.MessageType.kernel_info_request);
+    handler.handle(new Message<Message.KernelInfoRequest>(Arrays.asList("id1"), header,
+        new Message.Header(), Message.emptyMetadata(), new Message.KernelInfoRequest()),
+        shellChannel, kernelCommunicationHandler, profile, javaExecutionEngine);
+    Message<? extends Content.Reply> reply = receiveReply(shellChannel);
+    assertThat(reply.content, instanceOf(KernelInfoReply.class));
+    KernelInfoReply kernelInfo = (KernelInfoReply) reply.content;
+    assertThat(kernelInfo.language, is("Java"));
+    String[] javaVersion = System.getProperty("java.version").split("\\.");
+    assertThat(kernelInfo.language_version, is(javaVersion));
+  }
+
+  @Test
+  public void testConnectRequest() throws CommunicationException {
+    MessageHandlers.ConnectHandler handler = new MessageHandlers.ConnectHandler();
+    Message.Header header = new Message.Header(UUID.randomUUID(), "testuser", UUID.randomUUID(),
+        Message.MessageType.connect_request);
+    handler.handle(new Message<Message.ConnectRequest>(Arrays.asList("id1"), header,
+        new Message.Header(), Message.emptyMetadata(), new Message.ConnectRequest()), shellChannel,
+        kernelCommunicationHandler, profile, javaExecutionEngine);
+    Message<? extends Content.Reply> reply = receiveReply(shellChannel);
+    assertThat(reply.content, instanceOf(ConnectReply.class));
+    ConnectReply connectReply = (ConnectReply) reply.content;
+    assertThat(connectReply.hb_port, is(profile.getHb_port()));
+    assertThat(connectReply.iopub_port, is(profile.getIopub_port()));
+    assertThat(connectReply.shell_port, is(profile.getShell_port()));
+    assertThat(connectReply.stdin_port, is(profile.getStdin_port()));
+  }
+
+  @Test
+  public void testShutdownRequest() throws CommunicationException {
+    MessageHandlers.ShutdownHandler handler = new MessageHandlers.ShutdownHandler(false);
+    Message.Header header = new Message.Header(UUID.randomUUID(), "testuser", UUID.randomUUID(),
+        Message.MessageType.shutdown_request);
+    handler.handle(new Message<Message.ShutdownRequest>(Arrays.asList("id1"), header,
+        new Message.Header(), Message.emptyMetadata(), new Message.ShutdownRequest()), shellChannel,
+        kernelCommunicationHandler, profile, javaExecutionEngine);
+    Message<? extends Content.Reply> reply = receiveReply(shellChannel);
+    assertThat(reply.content, instanceOf(ShutdownReply.class));
+  }
+
+  /**
+   * Helper method to convert a sent reply into a message that is sent on a channel. This is similar
+   * to {@link KernelCommunicationHandler#receive(CommunicationChannel)} implementation except that
+   * this is for receiving replies.
+   */
+  private Message<? extends Content.Reply> receiveReply(CommunicationChannel channel)
+      throws CommunicationException {
+    List<String> identities = new ArrayList<>();
+    @SuppressWarnings("unused")
+    String signatureJSON;
+    String headerJSON;
+    String parentHeaderJSON;
+    String metadataJSON;
+    String contentJSON;
+    synchronized (channel) {
+      for (String data = channel.recvStr(); !data.equals(KernelCommunicationHandler.DELIMITER);
+          data = channel.recvStr()) {
+        identities.add(data);
+      }
+      signatureJSON = channel.recvStr();
+      headerJSON = channel.recvStr();
+      parentHeaderJSON = channel.recvStr();
+      metadataJSON = channel.recvStr();
+      contentJSON = channel.recvStr();
+    }
+    Header header = KernelJsonConverter.GSON.fromJson(headerJSON, Header.class);
+    Header parentHeader = KernelJsonConverter.GSON.fromJson(parentHeaderJSON, Header.class);
+    Map<String, String> metadata =
+        KernelJsonConverter.GSON.fromJson(metadataJSON, KernelJsonConverter.METADATA_TYPE);
+    Content.Reply content = null;
+    switch (header.msg_type) {
+      case execute_reply:
+        content = KernelJsonConverter.GSON.fromJson(contentJSON, ExecuteReply.class);
+        break;
+      case kernel_info_reply:
+        content = KernelJsonConverter.GSON.fromJson(contentJSON, KernelInfoReply.class);
+        break;
+      case connect_reply:
+        content = KernelJsonConverter.GSON.fromJson(contentJSON, ConnectReply.class);
+        break;
+      case shutdown_reply:
+        content = KernelJsonConverter.GSON.fromJson(contentJSON, ShutdownReply.class);
+        break;
+      default:
+        content = null;
+        break;
+    }
+    Message<Content.Reply> message =
+        new Message<Message.Content.Reply>(identities, header, parentHeader, metadata, content);
+    return message;
+  }
+}


### PR DESCRIPTION
 This CL includes the implementation of shutdown, connect and kernel info requests. I put them all under a aggregator class called MessageHandlers(Let me know if you think it's not good). I purposefully did not add execute request handlers in this CL, because it add more complexity(Will do it in the next CL).
