### PR TITLE
Proxy server for Python

### DIFF
--- a/externs/ts/node-http-proxy/node-http-proxy.d.ts
+++ b/externs/ts/node-http-proxy/node-http-proxy.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for node-http-proxy node module v1.4.3
+//
+
+/// <reference path="../node/node.d.ts" />
+
+declare module 'http-proxy' {
+  import events = require('events');
+  import http = require('http');
+  import net = require('net');
+
+  export interface ProxyServerOptions {
+    target: string;
+  }
+
+  export interface ProxyServer extends events.EventEmitter {
+    web(request: http.ServerRequest, response: http.ServerResponse): void;
+    ws(request: http.ServerRequest, socket: net.Socket, head: Buffer): void;
+    listen(options: any): void;
+    close(): void;
+  }
+
+  export function createProxyServer(options: ProxyServerOptions): ProxyServer;
+}

--- a/sources/buildSrc/TypeScriptCompileTask.groovy
+++ b/sources/buildSrc/TypeScriptCompileTask.groovy
@@ -24,11 +24,9 @@ import org.gradle.api.tasks.TaskAction
  */
 class TypeScriptCompileTask extends DefaultTask {
 
-    String rootModule = ''
     String pathToRootModule = ''
-    String srcDir = 'server/src'
+    String srcDir = ''
     String outDir = project.buildDir.path
-    String outFile = ''
     String moduleType = 'commonjs'
     String compilerArgs = '--removeComments --noImplicitAny'
 

--- a/sources/ipython/build.gradle
+++ b/sources/ipython/build.gradle
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+task tscNode(type: TypeScriptCompileTask) {
+    srcDir = 'ipython'
+    pathToRootModule = '/proxy'
+}
+
+task copyPackageJson(type: Copy) {
+    from './proxy/package.json'
+    into new File(project.buildDir, '/proxy')
+}
+
+task('build') {
+    dependsOn 'tscNode', 'copyPackageJson'
+}

--- a/sources/ipython/proxy/package.json
+++ b/sources/ipython/proxy/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "http-proxy": "^1.4.3"
+  }
+}

--- a/sources/ipython/proxy/server.ts
+++ b/sources/ipython/proxy/server.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/// <reference path="../../../externs/ts/node/node.d.ts" />
+/// <reference path="../../../externs/ts/node-http-proxy/node-http-proxy.d.ts" />
+
+import http = require('http');
+import httpProxy = require('http-proxy');
+import net = require('net');
+
+var proxyOptions : httpProxy.ProxyServerOptions = {
+  target: 'http://localhost:8080'
+};
+var proxy = httpProxy.createProxyServer(proxyOptions);
+
+function requestHandler(request: http.ServerRequest, response: http.ServerResponse) {
+  proxy.web(request, response);
+}
+
+function upgradeHandler(request: http.ServerRequest, socket: net.Socket, head: Buffer) {
+  proxy.ws(request, socket, head);
+}
+
+var server = http.createServer(requestHandler);
+server.on('upgrade', upgradeHandler);
+server.listen(8000);

--- a/sources/server/build.gradle
+++ b/sources/server/build.gradle
@@ -25,7 +25,7 @@ task copyStaticUi(type: Copy) {
  * Compile the main UI module and it's dependencies into a single main.js
  */
 task tscUi(type: TypeScriptCompileTask) {
-    rootModule = 'main'
+    srcDir = 'server/src'
     pathToRootModule = '/ui/scripts/'
     moduleType = 'amd'
 }
@@ -34,7 +34,7 @@ task tscUi(type: TypeScriptCompileTask) {
  * Compile the NodeJS modules into a single server.js
  */
 task tscNode(type: TypeScriptCompileTask) {
-    rootModule = 'server'
+    srcDir = 'server/src'
     pathToRootModule = '/node/'
     moduleType = 'commonjs'
 }

--- a/sources/settings.gradle
+++ b/sources/settings.gradle
@@ -1,1 +1,1 @@
-include 'kernels:ijava:kernel', 'server'
+include 'kernels:ijava:kernel', 'server', 'ipython'

--- a/tools/ipy.sh
+++ b/tools/ipy.sh
@@ -1,32 +1,25 @@
 #!/bin/sh
 
-# Script to launch IPython customized to current user in context of repository.
+# Script to launch IPython with notebooks in a specified directory.
 
-USERNAME=$1
-if [ "$USERNAME" == "" ]; then
-  USERNAME=$USER
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ipy.sh <notebook_dir>"
+    exit
 fi
-
-USER_DIR=$REPO_DIR/dev/$USERNAME
-USER_PY_DIR=$USER_DIR/python
-USER_NB_DIR=$USER_DIR/notebooks
-
-# Create a notebooks directory
-mkdir -p $USER_NB_DIR
 
 # Setup python path to include modules being developed as well as any
 # developer specific modules.
 LIBS=$REPO_DIR/sources/sdk/pygcp:$REPO_DIR/sources/ipython
-export PYTHONPATH=$PYTHONPATH:$LIBS:$USER_PY_DIR
+export PYTHONPATH=$PYTHONPATH:$LIBS
 
 # Spew out some informative output.
-echo 'Notebooks:' $USER_NB_DIR
+echo 'Notebooks:' $1
 echo 'Lib Path :' $PYTHONPATH
 echo 'Local URL: http://localhost:9000'
 echo '----------'
 
 # Finally start IPython.
-ipython notebook --notebook-dir=$USER_NB_DIR \
-  --config=$REPO_DIR/sources/ipython/config.py \
+ipython notebook --notebook-dir=$1 \
+  --config=$REPO_DIR/sources/ipython/profile/config.py \
   --ip="*" --port=9000 \
-  --matplotlib=inline --no-mathjax --no-browser --no-script --quiet
+  --matplotlib=inline --no-mathjax --no-script --quiet

--- a/tools/ipyc.sh
+++ b/tools/ipyc.sh
@@ -16,6 +16,6 @@ echo 'Local URL: http://localhost:9001'
 echo '----------'
 
 # Finally start IPython.
-ipython notebook --config=$REPO_DIR/sources/ipython/config.py \
+ipython notebook --config=$REPO_DIR/sources/ipython/profile/config.py \
   --ip="*" --port=9001 \
   --matplotlib=inline --no-mathjax --no-script --quiet

--- a/tools/ipym.sh
+++ b/tools/ipym.sh
@@ -16,6 +16,6 @@ echo 'Local URL: http://localhost:9002'
 echo '----------'
 
 # Finally start IPython.
-ipython notebook --config=$REPO_DIR/sources/ipython/config.py \
+ipython notebook --config=$REPO_DIR/sources/ipython/profile/config.py \
   --ip="*" --port=9002 \
   --matplotlib=inline --no-mathjax --no-script --quiet


### PR DESCRIPTION
- Right now this is just a passthrough hardcoded proxy server, but it
  does do what its supposed to (for both HTTP and socket traffic).
- Setup to build via typescript/gradle.
- Added a typescript type definition for http-proxy module.

Some faciliating TypeScript build and misc tools changes.
