### PR TITLE
Feature/nbs editor cell

### DIFF
--- a/sources/server/src/ui/chrome.css
+++ b/sources/server/src/ui/chrome.css
@@ -50,3 +50,25 @@ body {
   background-color: #f5f5f5;
   border-right: 1px solid #eee;
 }
+
+/**
+ * Cell styling
+ */
+.datalab-editor-cell-identifier {
+  float: left;
+  font-weight: bold;
+}
+.datalab-editor-cell-input-content {
+  float: left;
+  margin-left: 10px;
+}
+.datalab-editor-cell-output {
+  clear: both;
+}
+.datalab-editor-cell-output-indicator {
+  float: left;
+}
+.datalab-editor-cell-outputs {
+  float: left;
+  margin-left: 10px;
+}

--- a/sources/server/src/ui/scripts/app/common/Constants.ts
+++ b/sources/server/src/ui/scripts/app/common/Constants.ts
@@ -36,6 +36,9 @@ export var layouts = {
 export var codeEditor = {
   directiveName: 'datalabCodeEditor'
 };
+export var editorCell = {
+  directiveName: 'datalabEditorCell'
+}
 
 // Route-specific angular component names used for dependency injection
 export var notebooks = {
@@ -49,6 +52,7 @@ export var notebooks = {
 export var scopes = {
   // Generic components
   codeEditor: 'codeEditor',
+  editorCell: 'editorCell',
   layouts: 'layouts',
 
   // Route-specific components

--- a/sources/server/src/ui/scripts/app/components/codeeditor/CodeEditorDirective.ts
+++ b/sources/server/src/ui/scripts/app/components/codeeditor/CodeEditorDirective.ts
@@ -27,7 +27,7 @@ import codeMirror = require('codeMirror');
 var log = logging.getLogger(constants.scopes.codeEditor);
 
 var codeMirrorOptions: CodeMirror.EditorConfiguration = {
-  lineNumbers: true
+  lineNumbers: false
 };
 
 /**

--- a/sources/server/src/ui/scripts/app/components/editorcell/EditorCellDirective.ts
+++ b/sources/server/src/ui/scripts/app/components/editorcell/EditorCellDirective.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+/**
+ * Directive for creating a single editor cell
+ *
+ * The input region provides and editable text region. The output region appears if there is any
+ * output content, and disappears is the output content is falsey (undefined/null/empty).
+ */
+/// <reference path="../../../../../../../../externs/ts/angularjs/angular.d.ts" />
+/// <amd-dependency path="app/components/codeeditor/CodeEditorDirective" />
+import logging = require('app/common/Logging');
+import constants = require('app/common/Constants');
+import app = require('app/App');
+
+
+var log = logging.getLogger(constants.scopes.editorCell);
+
+/**
+ * Defines the shape of the controller/directive isolate scope.
+ */
+interface IEditorCellScope extends ng.IScope {
+  inputText: string;
+  outputHtml: string;
+  trustedOutputHtml: string;
+  cellIndex: number;
+}
+
+/**
+ * Creates a directive definition.
+ */
+function editorCellDirective (): ng.IDirective {
+  return {
+    restrict: 'E',
+    scope: {
+      inputText: '=',
+      outputs: '=',
+      executionCounter: '@'
+    },
+    templateUrl: constants.scriptPaths.app + '/components/editorcell/editorcell.html'
+  }
+}
+
+app.registrar.directive(constants.editorCell.directiveName, editorCellDirective);
+log.debug('Registered editor cell directive');

--- a/sources/server/src/ui/scripts/app/components/editorcell/editorcell.html
+++ b/sources/server/src/ui/scripts/app/components/editorcell/editorcell.html
@@ -1,0 +1,24 @@
+<div class="datalab-editor-cell">
+  <div class="datalab-editor-cell-controls">
+    <!-- Single-cell controls/buttons go here -->
+  </div>
+  <div class="datalab-editor-cell-input">
+    <div class="datalab-editor-cell-identifier">
+      <span class="datalab-editor-cell-index">[ {{ executionCounter }} ]<span>
+    </div>
+    <div class="datalab-editor-cell-input-content">
+      <datalab-code-editor contents="inputText"></datalab-code-editor>
+    </div>
+  </div>
+  <div class="datalab-editor-cell-output" ng-show="outputs">
+    <div class="datalab-editor-cell-output-indicator">
+      <span class="glyphicon glyphicon-log-out"></span>
+    </div>
+    <div class="datalab-editor-cell-outputs">
+      <div ng-repeat="output in outputs" ng-switch="output.mimetype">
+        <div ng-switch-when="text/html" ng-bind-html="output.content"></div>
+        <!-- Additional mime-types go here (css, js, etc.) -->
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Addresses issues #33 and #35 

The gray footer completely disappears when no html content for the output region is provided.  The header gray region will have some single-cell controls eventually (e.g., execute, "make-master", etc.)

![screen shot 2014-09-18 at 11 26 26 am](https://cloud.githubusercontent.com/assets/8355852/4325266/5b4758a4-3f63-11e4-9ee5-bd215345491f.png)
