### PR TITLE
Feature/nbs e2e server comm

### DIFF
--- a/externs/ts/node/socket.io.d.ts
+++ b/externs/ts/node/socket.io.d.ts
@@ -1,0 +1,70 @@
+// Type definitions for socket.io
+// Project: http://socket.io/
+// Definitions by: William Orr <https://github.com/worr>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+
+///<reference path='../node/node.d.ts' />
+
+declare module "socket.io" {
+	import http = require('http');
+
+	export function listen(server: http.Server, options: any, fn: Function): SocketManager;
+	export function listen(server: http.Server, fn?: Function): SocketManager;
+	export function listen(port: Number): SocketManager;
+
+
+  interface Socket {
+    id: string;
+    json:any;
+    log: any;
+    volatile: any;
+    broadcast: any;
+    handshake: any;
+    in(room: string): Socket;
+    to(room: string): Socket;
+    join(name: string, fn: Function): Socket;
+    leave(name: string, fn: Function): Socket;
+    set(key: string, value: any, fn: Function): Socket;
+    get(key: string, fn: Function): Socket;
+    has(key: string, fn: Function): Socket;
+    del(key: string, fn: Function): Socket;
+    disconnect(): Socket;
+    send(data: any, fn: Function): Socket;
+    emit(ev: any, ...data:any[]): Socket;
+    on(ns: string, fn: Function): Socket;
+  }
+
+  interface SocketNamespace {
+    clients(room: string): Socket[];
+    log: any;
+    store: any;
+    json: any;
+    volatile: any;
+    in(room: string): SocketNamespace;
+    on(evt: string, fn: (socket: Socket) => void): SocketNamespace;
+    to(room: string): SocketNamespace;
+    except(id: any): SocketNamespace;
+    send(data: any): any;
+    emit(ev: any, ...data:any[]): Socket;
+    socket(sid: any, readable: boolean): Socket;
+    authorization(fn: Function): SocketNamespace;
+  }
+
+  interface SocketManager {
+    get(key: any): any;
+    set(key: any, value: any): SocketManager;
+    enable(key: any): SocketManager;
+    disable(key: any): SocketManager;
+    enabled(key: any): boolean;
+    disabled(key: any): boolean;
+    configure(env: string, fn: Function): SocketManager;
+    configure(fn: Function): SocketManager;
+    of(nsp: string): SocketNamespace;
+    on(ns: string, fn: Function): SocketManager;
+    sockets: SocketNamespace;
+  }
+
+
+}
+

--- a/sources/server/src/node/app/common/constants.ts
+++ b/sources/server/src/node/app/common/constants.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+

--- a/sources/server/src/node/app/common/interfaces.d.ts
+++ b/sources/server/src/node/app/common/interfaces.d.ts
@@ -26,22 +26,24 @@ declare module app {
     [index: string]: T;
   }
 
+  interface EventHandler<T> {
+    (event: T): void;
+  }
+
   interface KernelConfig {
     iopubPort: number;
     shellPort: number;
   }
 
-  interface KernelMessageHandler {
-    (message: any): void;
-  }
-
   interface IKernel {
     id: string;
     config: KernelConfig;
-    start (): void;
-    shutdown (): void;
-    onMessage (handler: KernelMessageHandler): void;
     execute (request: ExecuteRequest): void;
+    onExecuteReply (callback: EventHandler<ExecuteReply>): void;
+    onExecuteResult (callback: EventHandler<ExecuteResult>): void;
+    onKernelStatus (callback: EventHandler<KernelStatus>): void;
+    shutdown (): void;
+    start (): void;
   }
 
   interface IKernelManager {
@@ -50,6 +52,28 @@ declare module app {
     list (): IKernel[];
     shutdown (id: string): void;
     shutdownAll (): void;
+  }
+
+  interface ISession {
+    id: string;
+    getKernelId (): string;
+    getUserConnectionId (): string;
+    updateUserConnection (connection: IUserConnection): void;
+  }
+
+  interface IUserConnection {
+    id: string;
+    getSessionId (): string;
+    onDisconnect (callback: EventHandler<IUserConnection>): void;
+    onExecuteRequest (callback: EventHandler<ExecuteRequest>): void;
+    sendExecuteReply (reply: ExecuteReply): void;
+    sendExecuteResult (result: ExecuteResult): void;
+    sendKernelStatus (status: KernelStatus): void;
+  }
+
+  interface IUserConnectionManager {
+    onConnect (callback: EventHandler<IUserConnection>): void;
+    onDisconnect (callback: EventHandler<IUserConnection>): void;
   }
 
 }

--- a/sources/server/src/node/app/common/util.ts
+++ b/sources/server/src/node/app/common/util.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+/**
+ * Finds an open port available for binding.
+ *
+ * TODO(bryantd): this is a stop-gap implementation for port selection
+ * Find a robust/reliable way of getting available ports to replace this.
+ */
+var portOffset = 0;
+export function getAvailablePort (): number {
+  return 45100 + portOffset++;
+}
+
+/**
+ * Generic no-op function that takes a single arg
+ */
+export function noop (arg1: any): void {}

--- a/sources/server/src/node/app/config.ts
+++ b/sources/server/src/node/app/config.ts
@@ -21,9 +21,11 @@ import manager = require('./kernels/manager');
 
 /**
  * Default server configuration with support for environment variable overrides.
+ *
+ * TODO(bryantd): This should be configured from an external settings file eventually
  */
 var settings: app.Settings = {
-  httpPort: parseInt(process.env['SERVER_HTTP_PORT'] || 8080)
+  httpPort: parseInt(process.env['SERVER_HTTP_PORT'] || 9000)
 };
 
 export function getSettings (): app.Settings {
@@ -52,4 +54,19 @@ export function getApiRouter (): express.Router {
   // TODO(bryantd): register notebooks/datasets/other APIs here eventually
 
   return apiRouter;
+}
+
+/**
+ * Logs all messages to the console
+ */
+function logMessage (message: any, session: app.ISession): any {
+  console.log('Message: ', JSON.stringify(message));
+  return message;
+}
+
+/**
+ * Gets the ordered list of message processors
+ */
+export function getMessageProcessors (): app.MessageProcessor[] {
+  return [logMessage];
 }

--- a/sources/server/src/node/app/kernels/channels.ts
+++ b/sources/server/src/node/app/kernels/channels.ts
@@ -58,7 +58,7 @@ export class ChannelClient {
 
     this._socket = zmq.socket(this._socketType);
 
-    this._socket.on('message', this._receiveMessage.bind(this));
+    this._socket.on('message', this._receive.bind(this));
   }
 
   /**
@@ -66,14 +66,14 @@ export class ChannelClient {
    *
    * @param messageParts a multipart message
    */
-  _sendMessage (messageParts: string[]): void {
+  _send (messageParts: string[]): void {
     this._socket.send(messageParts);
   }
 
   /**
    * Handles a multipart message received from the zmq socket
    */
-  _receiveMessage () {
+  _receive () {
     throw new Error("Abstract. This method should be implemented by subclass");
   }
 

--- a/sources/server/src/node/app/kernels/iopub.ts
+++ b/sources/server/src/node/app/kernels/iopub.ts
@@ -36,21 +36,21 @@ export class IOPubChannelClient extends channels.ChannelClient {
   /**
    * Default no-op message delegation handlers
    */
-  _delegateKernelStatusMessage (status: app.KernelStatus): void {}
-  _delegateExecuteResultMessage (result: app.ExecuteResult): void {}
+  _delegateKernelStatusHandler (status: app.KernelStatus): void {}
+  _delegateExecuteResultHandler (result: app.ExecuteResult): void {}
 
   /**
    * Specifies a callback to handle kernel status messages
    */
-  onKernelStatusMessage (callback: app.KernelStatusHandler): void {
-    this._delegateKernelStatusMessage = callback;
+  onKernelStatus (callback: app.EventHandler<app.KernelStatus>): void {
+    this._delegateKernelStatusHandler = callback;
   }
 
   /**
    * Specifies a callback to handle execute result messages
    */
-  onExecuteResultMessage (callback: app.ExecuteResultHandler): void {
-    this._delegateExecuteResultMessage = callback;
+  onExecuteResult (callback: app.EventHandler<app.ExecuteResult>): void {
+    this._delegateExecuteResultHandler = callback;
   }
 
   /**
@@ -65,16 +65,16 @@ export class IOPubChannelClient extends channels.ChannelClient {
    * the pyerr and pyin messages are both swallowed here. The data contained within pyin and pyerr
    * are both fully captured by the execute_reply/execute_request combination of messages.
    */
-  _receiveMessage () {
+  _receive () {
     var message = ipy.parseIPyMessage(arguments);
 
     switch (message.header.msg_type) {
       case 'status':
-        this._handleKernelStatusMessage(message);
+        this._handleKernelStatus(message);
         break;
 
       case 'pyout':
-        this._handleExecuteResultMessage(message);
+        this._handleExecuteResult(message);
         break;
 
       case 'pyin':
@@ -95,27 +95,27 @@ export class IOPubChannelClient extends channels.ChannelClient {
   /**
    * Converts IPython message data for a kernel status msg to an internal message and delegates
    */
-  _handleKernelStatusMessage (message: app.ipy.Message) {
+  _handleKernelStatus (message: app.ipy.Message) {
 
     var status: app.KernelStatus = {
       status: message.content['execution_state'],
       requestId: message.parentHeader.msg_id
     };
 
-    this._delegateKernelStatusMessage (status);
+    this._delegateKernelStatusHandler (status);
   }
 
   /**
    * Converts IPython message data for a execute_result msg to an internal message and delegates
    */
-  _handleExecuteResultMessage (message: app.ipy.Message) {
+  _handleExecuteResult (message: app.ipy.Message) {
 
     var result: app.ExecuteResult = {
       result: message.content['data'],
       requestId: message.parentHeader.msg_id
     }
 
-    this._delegateExecuteResultMessage (result);
+    this._delegateExecuteResultHandler (result);
   }
 
 }

--- a/sources/server/src/node/app/kernels/manager.ts
+++ b/sources/server/src/node/app/kernels/manager.ts
@@ -53,7 +53,7 @@ export class KernelManager implements app.IKernelManager {
    * Gets the list of kernel instances managed by this instance
    */
   list (): app.IKernel[] {
-    return this._getIds().map((id: string): app.IKernel => {
+    return this._getIds().map((id) => {
       return this._idToKernel[id];
     });
   }
@@ -82,7 +82,7 @@ export class KernelManager implements app.IKernelManager {
   /**
    * Gets the list of kernel IDs
    */
-  _getIds (): string [] {
+  _getIds (): string[] {
     return Object.keys(this._idToKernel);
   }
 

--- a/sources/server/src/node/app/messages/messages.d.ts
+++ b/sources/server/src/node/app/messages/messages.d.ts
@@ -23,24 +23,22 @@
 
 declare module app {
 
-  interface KernelMessageHandler {
-    (message: any): void;
+  interface MessageProcessor {
+    /**
+     * @param message the message to process
+     * @param session session object from which the message originated
+     * @return the processed message or null to indicate message should be filtered
+     */
+    (message: any, session: app.ISession): any;
+  }
+
+  interface MessageHandler {
+    (message: any, session: app.ISession, callback: app.EventHandler<any>): void
   }
 
   interface KernelStatus {
     status: string;
     requestId: string;
-  }
-  interface KernelStatusHandler {
-    (status: KernelStatus): void;
-  }
-
-  interface ExecuteResult {
-    result: any;
-    requestId: string;
-  }
-  interface ExecuteResultHandler {
-    (result: ExecuteResult): void;
   }
 
   interface ExecuteReply {
@@ -53,14 +51,16 @@ declare module app {
     errorMessage?: string;
     traceback?: string[];
   }
-  interface ExecuteReplyHandler {
-    (reply: ExecuteReply): void;
-  }
 
   interface ExecuteRequest {
     code: string;
     // Note: user_variables and user_expressions are slated for removal/reworking in upcoming versions
     // https://github.com/ipython/ipython/wiki/IPEP-13:-Updating-the-Message-Spec
+    requestId: string;
+  }
+
+  interface ExecuteResult {
+    result: any;
     requestId: string;
   }
 

--- a/sources/server/src/node/app/sessions/messagepipeline.ts
+++ b/sources/server/src/node/app/sessions/messagepipeline.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+import utils = require('../common/util');
+import sessions = require('./session');
+
+
+/**
+ * Controls the flow of messages between users and kernels.
+ *
+ * Binds together kernel and user connections via session objects and provides support
+ * for passing some/all messages to a middleware stack for processing/interception/etc.
+ */
+export class MessagePipeline {
+
+  _userconnManager: app.IUserConnectionManager;
+  _kernelManager: app.IKernelManager;
+  _idToSession: app.Map<app.ISession>;
+  _messageProcessors: app.MessageProcessor[];
+
+  constructor (
+      userconnManager: app.IUserConnectionManager,
+      kernelManager: app.IKernelManager,
+      messageProcessors: app.MessageProcessor[]) {
+    this._userconnManager = userconnManager;
+    this._kernelManager = kernelManager;
+    this._messageProcessors = messageProcessors;
+    this._idToSession = {};
+    this._registerHandlers();
+  }
+
+  /**
+   * Binds the user connection to a new kernel instance via a newly created session object
+   */
+  _createSession (sessionId: string, connection: app.IUserConnection) {
+    var kernel = this._kernelManager.create({
+      iopubPort: utils.getAvailablePort(),
+      shellPort: utils.getAvailablePort()
+    });
+    return new sessions.Session(sessionId, connection, kernel, this._handleMessage.bind(this));
+  }
+
+  /**
+   * Receives and processes all messages flowing through all sessions owned by this instance
+   *
+   * Session objects that pass control to this method also supply a "next action" callback for
+   * returning control to the session after the middleware stack has had an opportunity
+   * to manipulate a given message.
+   */
+  _handleMessage (message: any, session: app.ISession, callback: app.EventHandler<any>) {
+    // Invoke each handler in the chain in order.
+    //
+    // If a handler returns null, the the message is considered "filtered" and processing
+    // of the message stops.
+    var processedMessage = message;
+    for (var i = 0; i < this._messageProcessors.length; ++i) {
+      processedMessage = this._messageProcessors[i](processedMessage, session);
+      if (processedMessage === null) {
+        // Then this message has been filtered, no further processing
+        console.log('Filtered: ', JSON.stringify(message));
+        break;
+      }
+    }
+
+    // Return control to the messaging stack via Session object that corresponds to this message
+    // if the message was not filtered by one of the message handlers
+    if (processedMessage !== null) {
+      callback(processedMessage);
+    }
+  }
+
+  /**
+   * Binds the new user connection to a session and configures session event handling
+   *
+   * If the session for the given connection already exists, the new connection reconnects to the
+   * existing session.
+   */
+  _handleUserConnect (connection: app.IUserConnection) {
+    var sessionId = connection.getSessionId();
+    var session = this._idToSession[sessionId];
+    if (!session) {
+      // Create a brand new session object
+      session = this._createSession(sessionId, connection);
+      this._idToSession[sessionId] = session;
+    } else {
+      // Update existing session object with new user connection
+      session.updateUserConnection(connection);
+    }
+  }
+
+  _handleUserDisconnect (connection: app.IUserConnection) {
+    // TODO(bryantd): implement procedure for tear down after user disconnect such that if the
+    // same user (as identified by session id) reconnects, the previous kernel instance is re-used,
+    // (i.e., implement disconnect such that reconnect is possible).
+  }
+
+  _registerHandlers () {
+    this._userconnManager.onConnect(this._handleUserConnect.bind(this));
+    this._userconnManager.onDisconnect(this._handleUserDisconnect.bind(this));
+  }
+}

--- a/sources/server/src/node/app/sessions/session.ts
+++ b/sources/server/src/node/app/sessions/session.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+/**
+ * Binds a user connection to a kernel and routes communication between them
+ *
+ * A session also provides hooks for routing messages through the message pipeline/middleware
+ * before sending the messages to their final destination (either kernel or user).
+ */
+export class Session implements app.ISession {
+
+  id: string;
+
+  _kernel: app.IKernel;
+  _userconn: app.IUserConnection;
+  /**
+   * All messages flowing in either direction between user<->kernel will pass through this handler
+   */
+  _messageHandler: app.MessageHandler;
+
+  constructor (
+      id: string,
+      userconn: app.IUserConnection,
+      kernel: app.IKernel,
+      messageHandler: app.MessageHandler) {
+    this.id = id;
+    this._kernel = kernel;
+    this._registerKernelEventHandlers();
+    this.updateUserConnection(userconn);
+    this._messageHandler = messageHandler;
+  }
+
+  getKernelId (): string {
+    return this._kernel.id;
+  }
+
+  getUserConnectionId (): string {
+    return this._userconn.id;
+  }
+
+  /**
+   * Updates the user connection associated with this session.
+   *
+   * A user connection update might occur when a user refreshes their browser, resulting in
+   * destruction of previously establishd user<->server connection.
+   *
+   * This method allows a user to reestablish connection with an existing/running kernel.
+   */
+  updateUserConnection (userconn: app.IUserConnection) {
+    this._userconn = userconn;
+    this._registerUserEventHandlers();
+  }
+
+  // Handlers for messages flowing in either direction between user<->kernel
+  //
+  // Each of the following methods delegates an incoming message to the middleware stack and
+  // sets up a (post-delegation) callback to forward the message to the appropriate entity
+  // (where "entity" is either a kernel or a user connection).
+
+  /**
+   * Delegates an incoming execute reply (from kernel) to the middleware stack
+   */
+  _handleExecuteReplyPreDelegate (reply: app.ExecuteReply) {
+    var nextAction = this._handleExecuteReplyPostDelegate.bind(this);
+    this._messageHandler(reply, this, nextAction);
+  }
+  /**
+   * Forwards the execute reply to the user, post-middleware stack processing
+   */
+  _handleExecuteReplyPostDelegate (message: any) {
+    this._userconn.sendExecuteReply(message);
+  }
+
+  /**
+   * Delegates an incoming execute result (from kernel) to the middleware stack
+   */
+  _handleExecuteResultPreDelegate (result: app.ExecuteResult) {
+    var nextAction = this._handleExecuteResultPostDelegate.bind(this);
+    this._messageHandler(result, this, nextAction);
+  }
+  /**
+   * Forwards the execute result to the user, post-middleware stack processing
+   */
+  _handleExecuteResultPostDelegate (message: any) {
+    this._userconn.sendExecuteResult(message);
+  }
+
+  /**
+   * Delegates in incoming kernel status (from kernel) to the middleware stack
+   */
+  _handleKernelStatusPreDelegate (status: app.KernelStatus) {
+    var nextAction = this._handleKernelStatusPostDelegate.bind(this);
+    this._messageHandler(status, this, nextAction);
+  }
+  /**
+   * Forwards the kernel status to the user, post-middleware stack processing
+   */
+  _handleKernelStatusPostDelegate (message: any) {
+    this._userconn.sendKernelStatus(message);
+  }
+
+  /**
+   * Delegates an incoming execute request (from user) to the middleware stack
+   */
+  _handleExecuteRequestPreDelegate (request: app.ExecuteRequest) {
+    var nextAction = this._handleExecuteRequestPostDelegate.bind(this);
+    this._messageHandler(request, this, nextAction);
+  }
+  /**
+   * Forwards execute request to the kernel, post-middleware stack processing
+   */
+  _handleExecuteRequestPostDelegate (message: any) {
+    this._kernel.execute(message);
+  }
+
+  _registerUserEventHandlers () {
+    this._userconn.onExecuteRequest(this._handleExecuteRequestPreDelegate.bind(this));
+  }
+
+  _registerKernelEventHandlers () {
+    this._kernel.onExecuteReply(this._handleExecuteReplyPreDelegate.bind(this));
+    this._kernel.onExecuteResult(this._handleExecuteResultPreDelegate.bind(this));
+    this._kernel.onKernelStatus(this._handleKernelStatusPreDelegate.bind(this));
+  }
+}

--- a/sources/server/src/node/app/users/connection.ts
+++ b/sources/server/src/node/app/users/connection.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+/// <reference path="../../../../../../externs/ts/node/socket.io.d.ts" />
+import socketio = require('socket.io');
+
+
+/**
+ * Implements server-side portion of client-server DataLab message protocol
+ *
+ * Instances of this class also own the socket.io socket instance for the user connection.
+ *
+ * Because type information is lost when messages are sent over socket.io connections
+ * the message protocol implemented here uses the socket.io *event* name to carry type information.
+ * This allows the messaging protocol be typed on both sides (without doing message introspection)
+ * at the cost of having one event per type.
+ */
+export class UserConnection implements app.IUserConnection {
+
+  id: string;
+
+  _socket: socketio.Socket;
+
+  constructor (id: string, socket: socketio.Socket) {
+    this.id = id;
+    this._socket = socket;
+    this._registerHandlers()
+  }
+
+  /**
+   * Gets an id for the session that corresponds to this user connection instance
+   */
+  getSessionId (): string {
+    // TODO(bryantd): just use the ip address for the session id as stop-gap solution.
+    // This approach works if you assume all users will have unique IP addresses (not necessarily
+    // true) and that a user is only working with a single notebook at a time (we want to support
+    // working with multiple notebook simultaneously).
+    //
+    // Notes/thoughts on how to actually implement this eventually follow:
+    // Needs to be a value unique to given user and persistent across refreshes.
+    // Not sufficient to just set a cookie because need to support multiple
+    // (different) notebooks open at the same time by a single user.
+    //
+    // Should be able to deterministically derive a session id from
+    // (notebookId, userId) tuple.  userId could be an actual userId or
+    // just some value that we set via cookie.
+    //
+    // Possible solution: (userId, notebookId) --> uuid.v5 (if opaque id is desirable)
+    // Another solution '%s+%s' % (userId, notebookId) (if non-opaque id is desirable)
+    //
+    // Currently prefer an opaque id so that code doesn't start relying upon the id's structure
+    // (and so it can be changed easily if we need to further qualify the session id in the future)
+    //
+    // See also the authorization hook in socket.io if we need to augment
+    // the connection handshake data to insert the session identifier and make it available here
+    // https://github.com/Automattic/socket.io/wiki/Authorizing
+    //
+    // Note: the url of the webpage that initiated the connection (which has the notebook id)
+    // is available via socket.handshake.headers.referer --> http://host:port/notebooks/<id>
+    return this._socket.handshake.address.address;
+  }
+
+  /**
+   * Registers a callback that is invoked whenever the user disconnects
+   */
+  onDisconnect (callback: app.EventHandler<app.IUserConnection>) {
+    this._delegateDisconnectHandler = callback;
+  }
+
+  /**
+   * Registers a callback to be invoked when a user sends a code execution request
+   */
+  onExecuteRequest (callback: app.EventHandler<app.ExecuteRequest>) {
+    this._delegateExecuteRequestHandler = callback;
+  }
+
+  /**
+   * Sends an execute reply message to the user
+   */
+  sendExecuteReply (reply: app.ExecuteReply) {
+    this._send('execute-reply', reply);
+  }
+
+  /**
+   * Sends an execute result message to the user
+   */
+  sendExecuteResult (result: app.ExecuteResult) {
+    this._send('execute-result', result);
+  }
+
+  /**
+   * Sends a kernel status message to the user
+   */
+  sendKernelStatus (status: app.KernelStatus) {
+    this._send('kernel-status', status);
+  }
+
+  _delegateExecuteRequestHandler (message: app.ExecuteRequest) {}
+
+  _delegateDisconnectHandler (connection: app.IUserConnection) {}
+
+  /**
+   * Handles connection cleanup and delegates to registered event handler
+   *
+   * Invoked whenever a user disconnects from the server (e.g., closes/refreshes browser)
+   */
+  _handleDisconnect () {
+    // Any connection-level cleanup/finalization goes here
+    this._delegateDisconnectHandler(this);
+  }
+
+  /**
+   * Validates that the received message is an ExecuteRequest and delegates
+   */
+  _handleExecuteRequest (message: any) {
+    // Validate that the message is an ExecuteRequest (structurally)
+    if (!message.requestId || !message.code) {
+      // TODO(bryantd): make this an error-level message once logger supporting levels is added
+      console.log('Malformed request for the execute request message: ', message);
+      // TODO(bryantd): eventually emit some sort of error response to the front-end
+    } else {
+      this._delegateExecuteRequestHandler (<app.ExecuteRequest>message);
+    }
+  }
+
+  /**
+   * Register callbacks to handle events/messages arriving via socket.io connection
+   */
+  _registerHandlers () {
+    this._socket.on('disconnect', this._handleDisconnect.bind(this));
+    this._socket.on('execute', this._handleExecuteRequest.bind(this));
+  }
+
+  _send (type: string, message: any) {
+    this._socket.emit(type, message);
+  }
+}

--- a/sources/server/src/node/app/users/manager.ts
+++ b/sources/server/src/node/app/users/manager.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+/// <reference path="../../../../../../externs/ts/node/socket.io.d.ts" />
+import http = require('http');
+import socketio = require('socket.io');
+import uuid = require('node-uuid');
+import conn = require('./connection');
+
+
+/**
+ * Manages the lifecycle of user connection resources
+ *
+ * Accepts incoming connections from socket.io and sets up event/message delegation
+ */
+export class UserConnectionManager implements app.IUserConnectionManager {
+
+  _socketioManager: socketio.SocketManager;
+  _idToConnection: app.Map<app.IUserConnection>;
+
+  constructor (socketioManager: socketio.SocketManager) {
+    this._socketioManager = socketioManager;
+    this._idToConnection = {};
+    this._registerHandlers();
+  }
+
+  /**
+   * Gets a single user connection via connection id
+   *
+   * Returns null if no connection matching the given id currently exists
+   */
+  get (id: string): app.IUserConnection {
+    return this._idToConnection[id] || null;
+  }
+
+  /**
+   * Enumerates the set of open user connections
+   */
+  list (): app.IUserConnection[] {
+    return Object.keys(this._idToConnection).map((id) => {
+      return this._idToConnection[id];
+    });
+  }
+
+  /**
+   * Registers a callback to be invoked whenever a new user connection is established
+   */
+  onConnect (callback: app.EventHandler<app.IUserConnection>) {
+    this._delegateConnectHandler = callback;
+  }
+
+  /**
+   * Registers a callback to be invoked whenever a user disconnects
+   */
+  onDisconnect (callback: app.EventHandler<app.IUserConnection>) {
+    this._delegateDisconnectHandler = callback;
+  }
+
+  _delegateConnectHandler (connection: app.IUserConnection) {}
+
+  _delegateDisconnectHandler (connection: app.IUserConnection) {}
+
+
+  _handleConnect (socket: socketio.Socket) {
+    var connection = new conn.UserConnection(uuid.v4(), socket);
+    console.log('User has connected: ' + connection.id);
+    this._idToConnection[connection.id] = connection;
+
+    // Register this manager instance to receive disconnect events for the new connection
+    connection.onDisconnect(this._handleDisconnect.bind(this));
+
+    this._delegateConnectHandler(connection);
+  }
+
+  /**
+   * Cleans up any resources related to the now disconnected user and delegates to event callback
+   */
+  _handleDisconnect (connection: app.IUserConnection) {
+    // Cleanup
+    delete this._idToConnection[connection.id];
+    // Invoke the registered event callback
+    this._delegateDisconnectHandler(connection);
+    console.log('User has disconnected: ' + connection.id);
+  }
+
+  _registerHandlers () {
+    this._socketioManager.on('connection', this._handleConnect.bind(this));
+    // Note: disconnect handlers are at the socket/connection level
+  }
+}

--- a/sources/server/src/node/package.json
+++ b/sources/server/src/node/package.json
@@ -8,8 +8,9 @@
   },
   "dependencies": {
     "express": "4.x",
-    "zmq": "2.8.x",
-    "node-uuid": "1.4.x"
+    "node-uuid": "1.4.x",
+    "socket.io": "1.1.x",
+    "zmq": "2.8.x"
   },
   "author": "Google DataLab Team",
   "license": "Apache 2.0"

--- a/sources/server/src/node/server.ts
+++ b/sources/server/src/node/server.ts
@@ -13,26 +13,39 @@
  */
 
 
+/// <reference path="../../../../externs/ts/node/node.d.ts" />
+/// <reference path="../../../../externs/ts/express/express.d.ts" />
+/// <reference path="../../../../externs/ts/node/socket.io.d.ts" />
+import http = require('http');
+import express = require('express');
+import socketio = require('socket.io');
+import config = require('./app/config');
+import wsServer = require('./app/users/manager');
+import msgs = require('./app/sessions/messagepipeline');
+
+
 /**
  * Main entry point for the server.
  *
  * Starts an HTTP server on port that can be overridden by environment variable defined in
  * app.Settings (see: app/config)
+ *
+ * Initializes the messaging system to listen for incoming user connections via socket.io
  */
-/// <reference path="../../../../externs/ts/node/node.d.ts" />
-/// <reference path="../../../../externs/ts/express/express.d.ts" />
-import http = require('http');
-import express = require('express');
-import config = require('./app/config');
-
-
 export function start (settings: app.Settings, apiRouter: express.Router) {
   var expressApp = express();
   expressApp.use('/api', apiRouter);
+  expressApp.use(express.static(__dirname + '/static'));
+
   var httpServer = http.createServer(expressApp);
 
   console.log("Starting HTTP server on port " + settings.httpPort);
   httpServer.listen(settings.httpPort);
+
+  var messagePipeline = new msgs.MessagePipeline(
+    new wsServer.UserConnectionManager(socketio.listen(httpServer)),
+    config.getKernelManager(),
+    config.getMessageProcessors());
 }
 
 start(config.getSettings(), config.getApiRouter());

--- a/sources/server/src/node/static/temp-e2e-test.html
+++ b/sources/server/src/node/static/temp-e2e-test.html
@@ -1,0 +1,55 @@
+<html>
+<!--
+    TODO(bryantd): This entire file can be removed once the client-side pieces exist to communicate
+    with the notebook server.  This is just a minimal bit of code to be able to drive the notebook
+    server from the browser's javascript console.
+
+    Open the browser console and run "execute(<code>)"; replies from the notebook server will
+    appear within the browser console (nothing fancy).
+-->
+<script src="/socket.io/socket.io.js"></script>
+<script>
+
+ function kernelIsBusy (isBusy) {
+   console.info('Kernel is ' + (isBusy ? 'busy' : 'idle'));
+ }
+ function notifyKernelDied () {
+   console.info('Your kernel has died!');
+ }
+
+var socket = io.connect('http://localhost:9000');
+
+socket.on('kernel-status', function (message) {
+  if (message.status == 'busy') {
+    kernelIsBusy(true);
+  } else if (message.status == 'idle') {
+    kernelIsBusy(false);
+  } else if (message.status == 'dead') {
+    notifyKernelDied();
+  } else {
+    // TODO: also handle kernel status = 'starting'
+    console.error('kernel state: ', message.status);
+  }
+});
+
+socket.on('execute-result', function (message) {
+  console.info('Result: ', message.result['text/plain']);
+});
+
+socket.on('execute-reply', function (message) {
+  if (message.success === false) {
+    console.error(message.errorName, message.errorMessage);
+  }
+  console.info('Execution Counter',  '[' + message.executionCount + ']');
+});
+
+var i = 0;
+function execute (code) {
+  socket.emit('execute', {
+    requestId: 'request-' + i++,
+    code: code
+  });
+}
+
+console.log('online');
+</script>


### PR DESCRIPTION
Implements the remaining server-side components for the first [functional milestone](https://github.com/GoogleCloudPlatform/datalab/wiki/DataLab-Server-functional-milestones).

Will follow-up this with a sequence diagram shortly to illustrate message flow within the notebook server.

Major additions
- User connection
  - Implements client-server messaging protocol (server-side part)
  - Manages socket.io connections for a single user connection
- User connection manager
  - Manages the set of active user connections
  - Handles connection lifecycle (wraps socket.io bits) and sets up connection event handling
- Session
  - Binds together a user connection and a kernel connection and routes messages through the message broker
- Message broker
  - Establishes new sessions and maintains the set of active sessions
  - Provides hooks for message middleware (e.g., for logging/tracing/etc.)

Minor changes
- Refactored method names in kernel/channel clients to be consistent with new code
- Added some more documentation to kernel client
