### PR TITLE
Polish VM script (and get it to work on mac) + intro content copying

### DIFF
--- a/sources/ipython/IPythonExtensions/gcp/_notebooks.py
+++ b/sources/ipython/IPythonExtensions/gcp/_notebooks.py
@@ -295,7 +295,7 @@ class MemoryNotebookManager(SimpleNotebookManager):
     """Initializes an instance of a MemoryNotebookManager.
     """
     super(MemoryNotebookManager, self).__init__('in-memory', **kwargs)
-    self.add_notebook_list('', MemoryNotebookList())
+    self.add_notebook_list(MemoryNotebookList(), '')
 
 
 class StorageNotebookList(NotebookList):

--- a/sources/ipython/profile/config.py
+++ b/sources/ipython/profile/config.py
@@ -42,6 +42,3 @@ elif env == 'memory':
 
 if os.environ.get('IPYTHON_DEBUG', '') != '':
   c.NotebookApp.log_level = 'DEBUG'
-
-# Allow any origin to connect to sockets
-c.NotebookApp.allow_origin = '*'

--- a/sources/ipython/proxy/server.ts
+++ b/sources/ipython/proxy/server.ts
@@ -74,7 +74,13 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
   // /socket/* paths are completed handled in this server, and not forwarded on to
   // IPython as HTTP calls.
   if (path.indexOf('/socket') == 0) {
-    socketHandler(request, response);
+    if (!socketHandler) {
+      response.writeHead(404);
+      response.end();
+    }
+    else {
+      socketHandler(request, response);
+    }
     return;
   }
 
@@ -120,7 +126,10 @@ function upgradeHandler(request: http.ServerRequest, socket: net.Socket, head: B
 export function run(settings: common.Settings): void {
   ipythonServer = ipython.createProxyServer(settings);
 
-  socketHandler = sockets.createHandler(settings);
+  if (process.env['GAE_VM']) {
+    // Socket handler is only needed in managed VM scenarios.
+    socketHandler = sockets.createHandler(settings);
+  }
   healthHandler = health.createHandler(settings);
   infoHandler = info.createHandler(settings);
 


### PR DESCRIPTION
Changes to vm.sh:
- Switch from fuser to lsof
- Improve stdout spew
- Separate check/creation for firewall rule, as its possible to delete it, but not the network
- Create vm.yaml only if when creating a VM (avoid creating if script exits on failed network creation)
- Wait for IPython docker container to start before setting up an SSH tunnel to avoid errors
- Sync gcs buckets to copy intro notebooks from source folder to intro notebook target

Miscellaneous:
- Removed CORS setting from IPython config (left-over from previous managed VM investigation)
- Optionally respond to /socket requests (only when in managed VMs, since web sockets work fine in GCE)
- Fix in-memory notebook manager
