### PR TITLE
Modifies build to output UI content to server's /static content dir

### DIFF
--- a/sources/buildSrc/TypeScriptCompileTask.groovy
+++ b/sources/buildSrc/TypeScriptCompileTask.groovy
@@ -24,7 +24,8 @@ import org.gradle.api.tasks.TaskAction
  */
 class TypeScriptCompileTask extends DefaultTask {
 
-    String pathToRootModule = ''
+    String relativePath = ''
+    String outputRelativePath = ''
     String srcDir = ''
     String outDir = project.buildDir.path
     String moduleType = 'commonjs'
@@ -34,15 +35,20 @@ class TypeScriptCompileTask extends DefaultTask {
     def compile() {
         // Enumerate the typescript files recursively within the given source path
         def tsFiles = []
-        new File("${ srcDir }${ pathToRootModule }").eachFileRecurse(FileType.FILES) {
+        new File("${ srcDir }${ relativePath }").eachFileRecurse(FileType.FILES) {
             if (it.name.endsWith('.ts')) {
                 tsFiles << it;
             }
         }
 
+        // If an output relative path was not defined, use the input relative path
+        if (outputRelativePath.isEmpty()) {
+            outputRelativePath = relativePath
+        }
+
         // Call out to the TypeScript compiler (tsc) to compile and emit to the build dir
         def proc = """tsc $compilerArgs --module $moduleType \
-           --outDir $outDir${ pathToRootModule } ${ tsFiles.join(' ') }""".execute()
+           --outDir $outDir${ outputRelativePath } ${ tsFiles.join(' ') }""".execute()
         if (proc.in.text?.trim()) {
             println "tsc stdout:\n${ proc.in.text }"
         }

--- a/sources/ipython/build.gradle
+++ b/sources/ipython/build.gradle
@@ -19,7 +19,7 @@ task copyIPythonProfile(type: Copy) {
 
 task compileProxyServer(type: TypeScriptCompileTask) {
   srcDir = 'ipython'
-  pathToRootModule = '/proxy'
+  relativePath = '/proxy'
 }
 
 task copyProxyServerConfig(type: Copy) {

--- a/sources/server/build.gradle
+++ b/sources/server/build.gradle
@@ -13,19 +13,20 @@
  */
 
 /**
- * Copy all UI files (except the TypeScript files) to the build dir
+ * Copy all UI files (except the TypeScript files) to the server's static content (build) directory
  */
 task copyStaticUi(type: Copy) {
     from './src/ui'
-    into  new File(project.buildDir, '/ui')
+    into  new File(project.buildDir, '/node/static')
     exclude '**/*.ts'
 }
 /**
- * Compile the main UI module and it's dependencies into a single main.js
+ * Compile the UI application code and output to the server's static content (build) directory
  */
 task tscUi(type: TypeScriptCompileTask) {
     srcDir = 'server/src'
-    pathToRootModule = '/ui/scripts/'
+    relativePath = '/ui/scripts/'
+    outputRelativePath = '/node/static/scripts'
     moduleType = 'amd'
 }
 
@@ -42,7 +43,7 @@ task copyStaticNode(type: Copy) {
  */
 task tscNode(type: TypeScriptCompileTask) {
     srcDir = 'server/src'
-    pathToRootModule = '/node/'
+    relativePath = '/node/'
     moduleType = 'commonjs'
 }
 
@@ -53,5 +54,5 @@ task tscNode(type: TypeScriptCompileTask) {
  * Execute all of the tasks necessary to build the DataLab server
  */
 task('build') {
-    dependsOn 'copyStaticUi', 'tscUi', 'copyStaticNode', 'tscNode'
+    dependsOn 'copyStaticNode', 'tscNode', 'copyStaticUi', 'tscUi'
 }


### PR DESCRIPTION
Previously the server- (src/node) and client-side (src/ui) builds for the server were being emitted to separate build output directories. Commit changes UI output to be emitted to the node /static content directory.

Before:

```
/server/src/node -> /build/server/node
/server/src/ui -> /build/server/ui
```

After

```
/server/src/node -> /build/server/node
/server/src/ui -> /build/server/node/static
```

Also added a property to TypeScriptCompileTask to accommodate the input and output directories being different paths, to support the above use case.
