### PR TITLE
Adds a CodeMirror css rule and splits non-chrome css to separate file

### DIFF
--- a/sources/server/src/ui/styles/chrome.css
+++ b/sources/server/src/ui/styles/chrome.css
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+/**
+ * Styles that define the overall page chrome.
+ *
+ * Elements will be tagged with ID/CSS classnames of the form:
+ * "<project>-<module>-<name>" to avoid naming conflicts.
+ *
+ * For example: "datalab-editor-run-button" might be the id of a button
+ * within the "editor" module.
+ *
+ */
+
+/**
+ * Color palette
+ * - Thin (horz/vert) rules: #eee
+ * - Navigation/toolbar/menu background color: #f5f5f5
+ */
+
+body {
+  padding-top: 50px; /* Accounts for 50px (fixed) top navbar height */
+}
+
+/**
+ * Layout sidenav rules
+ */
+.datalab-layout-sidenav-sidebar {
+  /* Sticks the sidebar to the top-left corner of the viewport, just underneath the navbar */
+  position: fixed;
+  top: 51px; /* 50px navbar height + 1px border */
+  bottom: 0;
+  left: 0;
+
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  background-color: #f5f5f5;
+  border-right: 1px solid #eee;
+}

--- a/sources/server/src/ui/styles/editor.css
+++ b/sources/server/src/ui/styles/editor.css
@@ -14,45 +14,12 @@
 
 
 /**
- * Styles that define the overall page chrome.
- *
- * Elements will be tagged with ID/CSS classnames of the form:
- * "<project>-<module>-<name>" to avoid naming conflicts.
- *
- * For example: "datalab-editor-run-button" might be the id of a button
- * within the "editor" module.
- *
+ * Styles specific to notebook editing
  */
 
-/**
- * Color palette
- * - Thin (horz/vert) rules: #eee
- * - Navigation/toolbar/menu background color: #f5f5f5
- */
-
-body {
-  padding-top: 50px; /* Accounts for 50px (fixed) top navbar height */
-}
 
 /**
- * Layout sidenav rules
- */
-.datalab-layout-sidenav-sidebar {
-  /* Sticks the sidebar to the top-left corner of the viewport, just underneath the navbar */
-  position: fixed;
-  top: 51px; /* 50px navbar height + 1px border */
-  bottom: 0;
-  left: 0;
-
-  overflow-x: hidden;
-  overflow-y: auto;
-
-  background-color: #f5f5f5;
-  border-right: 1px solid #eee;
-}
-
-/**
- * Cell styling
+ * Code editor cell styling
  */
 .datalab-editor-cell-identifier {
   float: left;
@@ -71,4 +38,11 @@ body {
 .datalab-editor-cell-outputs {
   float: left;
   margin-left: 10px;
+}
+
+/**
+ * CodeMirror styling
+ */
+.CodeMirror {
+  height: auto;
 }


### PR DESCRIPTION
Note: There are style rules that are route/page specific being loaded up front (e.g., the code editor cell rules that were previously in the main chrome.css file). Will add an issue to track lazy-loading of css assets, which has two use cases:
- Route/page-specific css rules
- Plugin-specific css rules
