### PR TITLE
Persistable queries

### DIFF
--- a/sources/sdk/pygcp/gcp/bigquery/_table.py
+++ b/sources/sdk/pygcp/gcp/bigquery/_table.py
@@ -174,6 +174,21 @@ class Table(object):
     """The name of the table, as used when it was constructed."""
     return self._name
 
+  @property
+  def project_id(self):
+    """The project ID for the table."""
+    return self._name_parts[0]
+
+  @property
+  def dataset_id(self):
+    """The dataset ID for the table."""
+    return self._name_parts[1]
+
+  @property
+  def table_id(self):
+    """The dataset ID for the table."""
+    return self._name_parts[2]
+
   def _load_info(self):
     """Loads metadata about this table."""
     if self._info is None:


### PR DESCRIPTION
- changed queries to use a job instead of query. The execution is still synchronous as we block on getting the result
- this enables use to be able to pass a Table in as the destination so we can persist the results
- the timeout mechanism in query has been modified; because we are in an interactive environment I expect that if the user says "timeout in 30 seconds", they want control returned to them within 30 seconds, they don't expect an indeterminate number of sequential calls to happen each with a 30 second timeout. So the timeout is decremented after each call by the elapsed time.
