### PR TITLE
Pygcp jobs

### DIFF
--- a/sources/sdk/pygcp/gcp/bigquery/__init__.py
+++ b/sources/sdk/pygcp/gcp/bigquery/__init__.py
@@ -17,6 +17,8 @@
 import gcp as _gcp
 import gcp._util as _util
 from ._api import Api as _Api
+from ._job import Job as _Job
+from ._job import QueryJob as _QueryJob
 from ._query import Query as _Query
 from ._sampling import Sampling
 from ._table import Table as _Table
@@ -135,5 +137,30 @@ def schema(data):
     A TableSchema object.
   """
   return _TableSchema(data)
+
+
+def job(job_id, context=None):
+  """ Create a job reference for a specific job ID.
+
+  Args:
+    job_id: the job ID.
+  Returns:
+    A Job object.
+  """
+  api = _create_api(context)
+  return _Job(api, job_id)
+
+
+def query_job(job_id, table, context=None):
+  """ Create a job reference for a specific query job ID.
+
+  Args:
+    job_id: the job ID.
+    table: the Table that will be used for the query results.
+  Returns:
+    A QueryJob object.
+  """
+  api = _create_api(context)
+  return _QueryJob(api, job_id, table)
 
 # TODO(gram): Need an API to list the datasets in the project

--- a/sources/sdk/pygcp/gcp/bigquery/_job.py
+++ b/sources/sdk/pygcp/gcp/bigquery/_job.py
@@ -1,0 +1,374 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implements BigQuery Job functionality."""
+
+from datetime import datetime
+import codecs
+import collections
+import csv
+import os
+from ._parser import Parser as _Parser
+
+JobError = collections.namedtuple('JobError', ['location', 'message', 'reason'])
+
+
+class Job(object):
+  """Represents a BigQuery Job.
+  """
+
+  def __init__(self, api, job_id):
+    """Initializes an instance of a Job.
+
+    Args:
+      api: the BigQuery API object to use to issue requests. The project ID will be inferred from
+          this.
+      job_id: the BigQuery job ID corresponding to this job.
+    """
+    self._api = api
+    self._job_id = job_id
+    self._is_complete = False
+    self._errors = None
+    self._fatal_error = None
+
+  @property
+  def id(self):
+    """ Get the Job ID.
+
+    Returns:
+      The ID of the job.
+    """
+    return self._job_id
+
+  @property
+  def iscomplete(self):
+    """ Get the completion state of the job.
+
+    Returns:
+      True if the job is complete; False if it is still running.
+    """
+    self._refresh_state()
+    return self._is_complete
+
+  @property
+  def failed(self):
+    """ Get the success state of the job.
+
+    Returns:
+      True if the job failed; False if it is still running or succeeded (possibly with partial
+      failure).
+    """
+    self._refresh_state()
+    return self._is_complete and self._fatal_error
+
+  @property
+  def fatal_error(self):
+    """ Get the job error.
+
+    Returns:
+      None if the job succeeded or is still running, else the error tuple for the failure.
+    """
+    self._refresh_state()
+    return self._fatal_error
+
+  @property
+  def errors(self):
+    """ Get the errors in the job.
+
+    Returns:
+      None if the job is still running, else the list of errors that occurred.
+    """
+    self._refresh_state()
+    return self._errors
+
+  def _refresh_state(self):
+    """ Get the state of a job. If the job is complete this does nothing
+        otherwise it gets a refreshed copy of the job resource.
+    """
+    # TODO(gram): should we put a choke on refreshes? E.g. if the last call was less than
+    # a second ago should we return the cached value?
+    if self._is_complete:
+      return
+
+    response = self._api.jobs_get(self._job_id)
+
+    self._is_complete = \
+        response['state'] if 'state' in response and response['state'] == 'DONE' else False
+
+    if self._is_complete:
+      if 'status' in response:
+        status = response['status']
+        if 'errorResult' in status:
+          error_result = status['errorResult']
+          self._fatal_error = JobError(error_result['location'],
+                                       error_result['message'],
+                                       error_result['reason'])
+        if 'errors' in status:
+          self._errors = []
+          for error in status['errors']:
+            self._errors.append(JobError(error['location'], error['message'], error['reason']))
+
+  def __repr__(self):
+    """ Get the notebook representation for the job.
+    """
+    return 'Job %s' % str(self._job_id)
+
+
+class QueryJobResultProcessor(object):
+  """ Abstract base class for query job results processors.
+  """
+
+  @property
+  def result_count(self):
+    """ Get the number of results processed so far.
+
+    Returns:
+     Number of results.
+    """
+    pass
+
+  def set_schema(self, schema):
+    """ Process the schema of the results. This is called once before any calls to process().
+
+    Args:
+      schema: The schema of the results.
+    """
+    pass
+
+  def process(self, results):
+    """ Process a single result.
+
+    Args:
+      result: A row of results.
+    """
+    pass
+
+  def finish(self):
+    """ Called after all results have been processed. Can do any necessary housekeeping at this point.
+    """
+    pass
+
+  def on_fail(self):
+    """ Called if the query failed to clean up any associated resources.
+    """
+    pass
+
+
+class ResultCollector(QueryJobResultProcessor):
+  """ A query result processor that saves the results in an array.
+  """
+
+  def __init__(self):
+    super(ResultCollector, self).__init__()
+    self.rows = []
+    self.schema = None
+
+  @property
+  def result_count(self):
+    """ Get the number of results processed so far.
+
+    Returns:
+     Number of results.
+    """
+    return len(self.rows)
+
+  def set_schema(self, schema):
+    """ Process the schema of the results. This is called once before any calls to process().
+        Saves the schema for use by the results parser in process().
+
+    Args:
+      schema: The schema of the results.
+    """
+    self.schema = schema
+
+  def process(self, results):
+    """ Process a single result. Parses the result according to the schema and turns it into a
+        dictionary which is then appended to the list of result rows.
+
+      Args:
+        result: A row of results.
+    """
+    self.rows.append(_Parser.parse_row(self.schema, results))
+
+
+class ResultCSVFileSaver(QueryJobResultProcessor):
+  """ A query result processor that saves the results to a local file.
+  """
+
+  def __init__(self, path, write_header, dialect=csv.excel):
+    """
+    Args:
+      path: the local file path
+      write_header: if true (the default), write column name header row at start of file
+      dialect: the format to use for the output. By default, csv.excel. See
+          https://docs.python.org/2/library/csv.html#csv-fmt-params for how to customize this.
+    """
+    super(ResultCSVFileSaver, self).__init__()
+    self.path = path
+    self.schema = None
+    self.write_header = write_header
+    self.dialect = dialect
+    self.file = None
+    self.writer = None
+    self.count = 0
+
+  @property
+  def result_count(self):
+    """ Get the number of results processed so far.
+
+    Returns:
+     Number of results.
+    """
+    return self.count
+
+  def set_schema(self, schema):
+    """ Process the schema of the results. This is called once before any calls to process().
+        Saves the schema, and opens the output file and associated CSV dictionary writer.
+
+      Args:
+        schema: The schema of the results.
+    """
+    if not self.file:
+      self.schema = schema
+      self.file = codecs.open(self.path, 'w', 'utf-8')
+      fieldnames = []
+      for column in schema:
+        fieldnames.append(column['name'])
+      self.writer = csv.DictWriter(self.file, fieldnames=fieldnames, dialect=self.dialect)
+      if self.write_header:
+        self.writer.writeheader()
+
+  def process(self, results):
+    """ Process a single result. Parses the result according to the schema and turns it into a
+        dictionary which is then written to the CSV file with the DictionaryWriter.
+
+      Args:
+        result: A row of results.
+    """
+    self.writer.writerow(_Parser.parse_row(self.schema, results))
+    self.count += 1
+
+  def finish(self):
+    """ Closes the file after all results have been processed.
+    """
+    self.file.close()
+
+  def on_fail(self):
+    """ Clean up if the query failed. Closes the file stream and removes the CSV file if it exists.
+    """
+    if self.file:
+      self.file.close()
+      if os.exists(self.path):
+        os.remove(self.path)
+
+
+class QueryJob(Job):
+  """ Represents a BigQuery Query Job.
+  """
+
+  _DEFAULT_TIMEOUT = 60000
+
+  def __init__(self, api, job_id, table):
+    super(QueryJob, self).__init__(api, job_id)
+    self._table = table
+
+  @property
+  def table(self):
+    return self._table
+
+  def process_results(self, result_processor, page_size=0, timeout=None):
+    """ Process the results of a query job. Note that if the job is not complete,
+        this will block.
+
+    Args:
+      result_processor: object used to process the results.
+      page_size: limit to the number of rows to fetch per page.
+      timeout: duration (in milliseconds) to wait for the query to complete; default 60,000.
+      use_cache: whether to use cached results or not.
+    Returns:
+      The query result processor.
+    """
+
+    if not timeout:
+      timeout = self._DEFAULT_TIMEOUT
+
+    # Get the start time; we decrement the timeout each time by the elapsed time so the timeout
+    # applies to the overall operation, not individual page requests.
+    start_time = datetime.now()
+
+    try:
+      query_result = self._api.jobs_query_results(self._job_id,
+                                                  page_size=page_size,
+                                                  timeout=timeout,
+                                                  start_index=0)
+      if not query_result['jobComplete']:
+        return None
+
+      total_count = int(query_result['totalRows'])
+      if total_count != 0:
+        schema = query_result['schema']['fields']
+        result_processor.set_schema(schema)
+
+        while result_processor.result_count < total_count:
+          for r in query_result['rows']:
+            result_processor.process(r)
+
+          if result_processor.result_count < total_count:
+
+            # Set the timeout to be the remaining time
+            end_time = datetime.now()
+            elapsed = end_time - start_time
+            start_time = end_time
+            timeout -= int(elapsed.total_seconds() * 1000)
+            if timeout <= 0:  # TODO(gram): use a larger threshold; e.g. 1000?
+              break
+
+            query_result = self._api.jobs_query_results(self._job_id,
+                                                        page_size=page_size,
+                                                        timeout=timeout,
+                                                        start_index=result_processor.result_count)
+            if not query_result['jobComplete']:
+              break
+
+      result_processor.finish()
+    except KeyError:
+      result_processor.on_fail()
+
+    return result_processor
+
+  def collect_results(self, page_size=0, timeout=None):
+    """Retrieves results for the query.
+
+    Args:
+      page_size: limit to the number of rows to fetch per page.
+      timeout: duration (in milliseconds) to wait for the query to complete.
+    """
+    return self.process_results(ResultCollector(), page_size=page_size, timeout=timeout).rows
+
+  def save_results_as_csv(self, path, write_header=True, dialect=csv.excel, page_size=0,
+                          timeout=None):
+    """Save the results to a local file in CSV format.
+
+    Args:
+      path: path on the local filesystem for the saved results.
+      write_header: if true (the default), write column name header row at start of file.
+      dialect: the format to use for the output. By default, csv.excel. See
+          https://docs.python.org/2/library/csv.html#csv-fmt-params for how to customize this.
+      page_size: limit to the number of rows to fetch per page.
+      timeout: duration (in milliseconds) to wait for the query to complete.
+    Returns:
+      Nothing.
+    """
+    self.process_results(ResultCSVFileSaver(path, write_header, dialect), page_size=page_size,
+                         timeout=timeout)

--- a/sources/sdk/pygcp/gcp/bigquery/_query.py
+++ b/sources/sdk/pygcp/gcp/bigquery/_query.py
@@ -14,13 +14,12 @@
 
 """Implements Query and QueryResult BigQuery APIs."""
 
-import codecs
+
 import csv
-from datetime import datetime
-import os
 import pandas as pd
-from ._parser import Parser as _Parser
+from ._job import QueryJob as _QueryJob
 from ._sampling import Sampling as _Sampling
+from ._table import Table as _Table
 
 
 class QueryResults(list):
@@ -68,159 +67,11 @@ class QueryResults(list):
     return pd.DataFrame.from_dict(self)
 
 
-class ResultProcessor(object):
-  """ Abstract base class for query results processors.
-  """
-
-  @property
-  def result_count(self):
-    """ Get the number of results processed so far.
-
-    Returns:
-     Number of results.
-    """
-    pass
-
-  def set_schema(self, schema):
-    """ Process the schema of the results. This is called once before any calls to process().
-
-    Args:
-      schema: The schema of the results.
-    """
-    pass
-
-  def process(self, results):
-    """ Process a single result.
-
-    Args:
-      result: A row of results.
-    """
-    pass
-
-  def finish(self):
-    """ Called after all results have been processed. Can do any necessary housekeeping at this point.
-    """
-    pass
-
-  def on_fail(self):
-    """ Called if the query failed to clean up any associated resources.
-    """
-    pass
-
-
-class ResultCollector(ResultProcessor):
-  """ A query result processor that saves the results in an array.
-  """
-
-  def __init__(self):
-    self.rows = []
-    self.schema = None
-
-  @property
-  def result_count(self):
-    """ Get the number of results processed so far.
-
-    Returns:
-     Number of results.
-    """
-    return len(self.rows)
-
-  def set_schema(self, schema):
-    """ Process the schema of the results. This is called once before any calls to process(). Saves the schema
-        for use by the results parser in process().
-
-    Args:
-      schema: The schema of the results.
-    """
-    self.schema = schema
-
-  def process(self, results):
-    """ Process a single result. Parses the result according to the schema and turns it into a dictionary
-        which is then appended to the list of result rows.
-
-      Args:
-        result: A row of results.
-    """
-    self.rows.append(_Parser.parse_row(self.schema, results))
-
-
-class ResultCSVFileSaver(ResultProcessor):
-  """ A query result processor that saves the results to a local file.
-  """
-
-  def __init__(self, path, write_header, dialect=csv.excel):
-    """
-    Args:
-      path: the local file path
-      write_header: if true (the default), write column name header row at start of file
-      dialect: the format to use for the output. By default, csv.excel. See
-          https://docs.python.org/2/library/csv.html#csv-fmt-params for how to customize this.
-    """
-    self.path = path
-    self.schema = None
-    self.write_header = write_header
-    self.dialect = dialect
-    self.file = None
-    self.writer = None
-    self.count = 0
-
-  @property
-  def result_count(self):
-    """ Get the number of results processed so far.
-
-    Returns:
-     Number of results.
-    """
-    return self.count
-
-  def set_schema(self, schema):
-    """ Process the schema of the results. This is called once before any calls to process().
-        Saves the schema, and opens the output file and associated CSV dictionary writer.
-
-      Args:
-        schema: The schema of the results.
-    """
-    if not self.file:
-      self.schema = schema
-      self.file = codecs.open(self.path, 'w', 'utf-8')
-      fieldnames = []
-      for column in schema:
-        fieldnames.append(column['name'])
-      self.writer = csv.DictWriter(self.file, fieldnames=fieldnames, dialect=self.dialect)
-      if self.write_header:
-        self.writer.writeheader()
-
-  def process(self, results):
-    """ Process a single result. Parses the result according to the schema and turns it into a dictionary
-        which is then written to the CSV file with the DictionaryWriter.
-
-      Args:
-        result: A row of results.
-    """
-    self.writer.writerow(_Parser.parse_row(self.schema, results))
-    self.count += 1
-
-  def finish(self):
-    """ Closes the file after all results have been processed.
-    """
-    self.file.close()
-
-  def on_fail(self):
-    """ Clean up if the query failed. Closes the file stream and removes the CSV file if it exists.
-    """
-    if self.file:
-      self.file.close()
-      if os.exists(self.path):
-        os.remove(self.path)
-
-
 class Query(object):
   """Represents a Query object that encapsulates a BigQuery SQL query.
 
   This object can be used to execute SQL queries and retrieve results.
   """
-
-  _DEFAULT_TIMEOUT = 60000
 
   def __init__(self, api, sql):
     """Initializes an instance of a Query object.
@@ -251,10 +102,13 @@ class Query(object):
       malformed.
     """
     if not use_cache or (self._results is None):
-      self._results = self._execute(page_size, timeout, use_cache)
+      job = self.execute(table=None, use_cache=use_cache, batch=False)
+      rows = job.collect_results(page_size, timeout=timeout)
+      self._results = QueryResults(self._sql, job.id, rows)
     return self._results
 
-  def save(self, path, page_size=0, timeout=0, use_cache=True, write_header=True, dialect=csv.excel):
+  def save_to_file(self, path, page_size=0, timeout=0, use_cache=True, write_header=True,
+           dialect=csv.excel):
     """Save the results to a local file in CSV format.
 
     Args:
@@ -266,12 +120,9 @@ class Query(object):
       dialect: the format to use for the output. By default, csv.excel. See
           https://docs.python.org/2/library/csv.html#csv-fmt-params for how to customize this.
     """
-    try:
-      processor = ResultCSVFileSaver(path, write_header, dialect)
-      self._run_query(page_size, timeout, use_cache, processor)
-      return path
-    except KeyError:
-      raise Exception('Unexpected query response.')
+    job = self.execute(table=None, use_cache=use_cache, batch=False)
+    job.save_results_as_csv(path, write_header, dialect, page_size, timeout=timeout)
+    return path
 
   def sample(self, count=5, sampling=None, timeout=0, use_cache=True):
     """Retrieves a sampling of rows for the query.
@@ -285,8 +136,7 @@ class Query(object):
     Returns:
       A QueryResults objects representing a sampling of the result set.
     Raises:
-      Exception if the query could not be executed or query response was
-      malformed.
+      Exception if the query could not be executed or query response was malformed.
     """
     if sampling is None:
       sampling = _Sampling.default(count=count)
@@ -295,98 +145,44 @@ class Query(object):
     sampling_query = Query(self._api, sampling_sql)
     return sampling_query.results(page_size=0, timeout=timeout, use_cache=use_cache)
 
-  def _execute(self, page_size, timeout, use_cache):
-    """Executes a query and retrieve results after waiting for completion.
+  def execute(self, table=None, append=False, overwrite=False, use_cache=True, batch=True):
+    """ Initiate the query.
 
     Args:
-      page_size: limit to the number of rows to fetch per page.
-      timeout: duration (in milliseconds) to wait for the query to complete.
-      use_cache: whether to use cached results or not.
+      dataset_id: the datasetId for the result table.
+      table: the result table; either a string name or a Table.
+      append: if True, append to the table if it is non-empty; else the request will fail if table
+          is non-empty unless overwrite is True.
+      overwrite: if the table already exists, truncate it instead of appending or raising an
+          Exception.
+      use_cache: whether to use past query results or ignore cache. Has no effect if destination is
+          specified.
+      batch: whether to run this as a batch job (lower priority) or as an interactive job (high
+        priority, more expensive).
     Returns:
-      A QueryResults objects representing the result set.
+      A Job for the query
     Raises:
-      Exception if the query could not be executed or query response was
-      malformed.
+      Exception (KeyError) if query could not be executed.
     """
-    try:
-      collector = ResultCollector()
-      job_id = self._run_query(page_size, timeout, use_cache, collector)
-      return QueryResults(self._sql, job_id, collector.rows)
-    except KeyError:
+    if isinstance(table, basestring):
+      table = _Table(self._api, table)
+    query_result = self._api.jobs_insert_query(self._sql,
+                                               dataset_id=table.dataset_id if table else None,
+                                               table_id=table.table_id if table else None,
+                                               append=append,
+                                               overwrite=overwrite,
+                                               dry_run=False,
+                                               use_cache=use_cache,
+                                               batch=batch)
+    if 'jobReference' not in query_result:
       raise Exception('Unexpected query response.')
-
-  def _run_query(self, page_size, timeout, use_cache, result_processor):
-    """Executes a query and processes results after waiting for completion.
-
-    Args:
-      page_size: limit to the number of rows to fetch per page.
-      timeout: duration (in milliseconds) to wait for the query to complete; default 60,000.
-      use_cache: whether to use cached results or not.
-      result_processor: object used to process the results.
-    Returns:
-      The job ID for the query, or None if the job failed to complete with any results.
-    Raises:
-      Exception if the query could not be executed or query response was
-      malformed.
-    """
-
-    try:
-
-      # We don't use jobs_query as that only supports sync queries to anonymous tables and returns
-      # results in the body, but we are getting the results anyway with jobs_query_results. The latter
-      # blocks even if we created the query as an async query with jobs_insert. So we may as well handle
-      # both queries to a permanent table and an anon table in the same way, by inserting a query
-      # job then blocking with jobs_query_results.
-      query_result = self._api.jobs_insert_query(self._sql, use_cache=use_cache)
-
-      job_id = query_result['jobReference']['jobId']
-
-      if not timeout:
-        timeout = self._DEFAULT_TIMEOUT
-
-      # Get the start time; we decrement the timeout each time by the elapsed time so the timeout applies to
-      # the overall operation, not individual page requests.
-      start_time = datetime.now()
-      query_result = self._api.jobs_query_results(job_id,
-                                                  page_size=page_size,
-                                                  timeout=timeout,
-                                                  start_index=0)
-      if not query_result['jobComplete']:
-        return None
-
-      total_count = int(query_result['totalRows'])
-      if total_count != 0:
-        schema = query_result['schema']['fields']
-        result_processor.set_schema(schema)
-
-        while result_processor.result_count < total_count:
-          for r in query_result['rows']:
-            result_processor.process(r)
-
-          if result_processor.result_count < total_count:
-
-            # Set the timeout to be the remaining time
-            end_time = datetime.now()
-            elapsed = end_time - start_time
-            start_time = end_time
-            timeout -= int(elapsed.total_seconds() * 1000)
-            if timeout <= 0:  # TODO(gram): use a larger threshold; e.g. 1000?
-              break
-
-            query_result = self._api.jobs_query_results(job_id,
-                                                        page_size=page_size,
-                                                        timeout=timeout,
-                                                        start_index=result_processor.result_count)
-            if not query_result['jobComplete']:
-              break
-
-      result_processor.finish()
-      return job_id
-    except KeyError:
-      result_processor.on_fail()
-      raise Exception('Unexpected query response.')
-    # TODO(gram): change the _hhtp.py code to raise non-generic Exceptions so we can catch them here
-    # and surface more meaningful errors to the user.
+    job_id = query_result['jobReference']['jobId']
+    if not table:
+      destination = query_result['configuration']['query']['destinationTable']
+      table = _Table(self._api,
+                     (destination['projectId'], destination['datasetId'], destination['tableId']),
+                     is_temporary=True)
+    return _QueryJob(self._api, job_id, table)
 
   def _repr_sql_(self):
     """Creates a SQL representation of this object.

--- a/sources/sdk/pygcp/gcp/storage/_item.py
+++ b/sources/sdk/pygcp/gcp/storage/_item.py
@@ -136,7 +136,7 @@ class Item(object):
     """Writes text content to this item.
 
     Args:
-      content: the text content to be writtent.
+      content: the text content to be written.
       content_type: the type of text content.
     Raises:
       Exception if there was an error requesting the item's content.

--- a/sources/sdk/pygcp/tests/bq_jobs_tests.py
+++ b/sources/sdk/pygcp/tests/bq_jobs_tests.py
@@ -1,0 +1,90 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime as dt
+import unittest
+import gcp
+import gcp.bigquery
+import mock
+import numpy as np
+from oauth2client.client import AccessTokenCredentials
+import pandas
+
+class TestCases(unittest.TestCase):
+
+  @mock.patch('gcp.bigquery._Api.jobs_get')
+  def test_job_complete(self, mock_api_jobs_get):
+    mock_api_jobs_get.return_value = {}
+    j = gcp.bigquery.job('foo', self._create_context())
+    self.assertFalse(j.iscomplete)
+    self.assertFalse(j.failed)
+    mock_api_jobs_get.return_value = {'state': 'DONE'}
+    self.assertTrue(j.iscomplete)
+    self.assertFalse(j.failed)
+
+  @mock.patch('gcp.bigquery._Api.jobs_get')
+  def test_job_fatal_error(self, mock_api_jobs_get):
+    mock_api_jobs_get.return_value = {
+      'state': 'DONE',
+      'status': {
+        'errorResult': {
+          'location': 'A',
+          'message': 'B',
+          'reason': 'C'
+        }
+      }
+    }
+    j = gcp.bigquery.job('foo', self._create_context())
+    self.assertTrue(j.iscomplete)
+    self.assertTrue(j.failed)
+    e = j.fatal_error
+    self.assertIsNotNone(e)
+    self.assertEqual('A', e.location)
+    self.assertEqual('B', e.message)
+    self.assertEqual('C', e.reason)
+
+  @mock.patch('gcp.bigquery._Api.jobs_get')
+  def test_job_errors(self, mock_api_jobs_get):
+    mock_api_jobs_get.return_value = {
+      'state': 'DONE',
+      'status': {
+        'errors': [
+          {
+            'location': 'A',
+            'message': 'B',
+            'reason': 'C'
+          },
+          {
+            'location': 'D',
+            'message': 'E',
+            'reason': 'F'
+          }
+        ]
+      }
+    }
+    j = gcp.bigquery.job('foo', self._create_context())
+    self.assertTrue(j.iscomplete)
+    self.assertFalse(j.failed)
+    self.assertEqual(2, len(j.errors))
+    self.assertEqual('A', j.errors[0].location)
+    self.assertEqual('B', j.errors[0].message)
+    self.assertEqual('C', j.errors[0].reason)
+    self.assertEqual('D', j.errors[1].location)
+    self.assertEqual('E', j.errors[1].message)
+    self.assertEqual('F', j.errors[1].reason)
+
+  def _create_context(self):
+    project_id = 'test'
+    creds = AccessTokenCredentials('test_token', 'test_ua')
+    return gcp.Context(project_id, creds)

--- a/sources/sdk/pygcp/tests/bq_query_tests.py
+++ b/sources/sdk/pygcp/tests/bq_query_tests.py
@@ -30,9 +30,9 @@ class TestCases(unittest.TestCase):
     q = self._create_query(sql)
     results = q.results()
 
-    self.assertEqual(results.sql, sql)
-    self.assertEqual(len(results), 1)
-    self.assertEqual(results[0]['field1'], 'value1')
+    self.assertEqual(sql, results.sql)
+    self.assertEqual(1, len(results))
+    self.assertEqual('value1', results[0]['field1'])
 
   @mock.patch('gcp.bigquery._Api.jobs_query_results')
   @mock.patch('gcp.bigquery._Api.jobs_insert_query')
@@ -56,9 +56,9 @@ class TestCases(unittest.TestCase):
     q = self._create_query()
     results = q.results()
 
-    self.assertEqual(len(results), 1)
-    self.assertEqual(results.job_id, 'test_job')
-    self.assertEqual(mock_api_query_results.call_count, 1)
+    self.assertEqual(1, len(results))
+    self.assertEqual('test_job', results.job_id)
+    self.assertEqual(1, mock_api_query_results.call_count)
 
   @mock.patch('gcp.bigquery._Api.jobs_query_results')
   @mock.patch('gcp.bigquery._Api.jobs_insert_query')
@@ -71,9 +71,9 @@ class TestCases(unittest.TestCase):
     q = self._create_query()
     results = q.results()
 
-    self.assertEqual(len(results), 2)
-    self.assertEqual(mock_api_query_results.call_count, 2)
-    self.assertEqual(mock_api_query_results.call_args[0][0], 'test_job')
+    self.assertEqual(2, len(results))
+    self.assertEqual(2, mock_api_query_results.call_count)
+    self.assertEqual('test_job', mock_api_query_results.call_args[0][0])
 
   @mock.patch('gcp.bigquery._Api.jobs_insert_query')
   def test_malformed_response_raises_exception(self, mock_api_insert_query):
@@ -83,7 +83,7 @@ class TestCases(unittest.TestCase):
 
     with self.assertRaises(Exception) as error:
       _ = q.results()
-    self.assertEqual(error.exception[0], 'Unexpected query response.')
+    self.assertEqual('Unexpected query response.', error.exception[0])
 
   def _create_query(self, sql=None):
     if sql is None: sql = 'SELECT * ...'
@@ -99,6 +99,15 @@ class TestCases(unittest.TestCase):
     return {
       'jobReference': {
         'jobId': 'test_job'
+      },
+      'configuration': {
+        'query': {
+          'destinationTable': {
+            'projectId': 'project',
+            'datasetId': 'dataset',
+            'tableId': 'table'
+          }
+        }
       },
       'jobComplete': True,
     }
@@ -136,6 +145,15 @@ class TestCases(unittest.TestCase):
     return {
       'jobReference': {
         'jobId': 'test_job'
+      },
+      'configuration': {
+        'query': {
+          'destinationTable': {
+            'projectId': 'project',
+            'datasetId': 'dataset',
+            'tableId': 'table'
+          }
+        }
       },
       'jobComplete': False
     }


### PR DESCRIPTION
Added a Job class and QueryJob extension for async operations.
Add a to_dataframe method on Table to export to Pandas.
Add load and export methods on Table for moving data to/from GCS.
Fix some issues with insertAll.
Made the methods in Api more consistent; they now always return the result of Http.request
Moved the processing of query results to a QueryJob class. This makes it a more accessible way of accessing results from long-running query jobs.
Modified Query to use this, and added an insert method to query to create long-running queries with named tables for the results.
Fix the unit test assertions; they had expected and actual parameters inverted.
