### PR TITLE
Move the name parts of a table to a named tuple.

### DIFF
--- a/sources/sdk/pygcp/gcp/bigquery/_query.py
+++ b/sources/sdk/pygcp/gcp/bigquery/_query.py
@@ -167,8 +167,7 @@ class Query(object):
     if isinstance(table, basestring):
       table = _Table(self._api, table)
     query_result = self._api.jobs_insert_query(self._sql,
-                                               dataset_id=table.dataset_id if table else None,
-                                               table_id=table.table_id if table else None,
+                                               name_parts=table.name if table else None,
                                                append=append,
                                                overwrite=overwrite,
                                                dry_run=False,

--- a/sources/sdk/pygcp/tests/bq_table_tests.py
+++ b/sources/sdk/pygcp/tests/bq_table_tests.py
@@ -112,8 +112,8 @@ class TestCases(unittest.TestCase):
     for table in ds:
       tables.append(table)
     self.assertEqual(2, len(tables))
-    self.assertEqual('test:testds.testTable1', tables[0].name)
-    self.assertEqual('test:testds.testTable2', tables[1].name)
+    self.assertEqual('test:testds.testTable1', tables[0].full_name)
+    self.assertEqual('test:testds.testTable2', tables[1].full_name)
 
   @mock.patch('gcp.bigquery._Api.tables_list')
   @mock.patch('gcp.bigquery._Api.datasets_get')
@@ -293,7 +293,7 @@ class TestCases(unittest.TestCase):
 
     result = table.insertAll(df)
     self.assertIsNotNone(result, "insertAll should return the table object")
-    mock_api_tabledata_insertAll.assert_called_with('testds', 'testTable0', [
+    mock_api_tabledata_insertAll.assert_called_with(('test', 'testds', 'testTable0'), [
       {'insertId': '#0', 'json': {u'column': 'r0', u'headers': 10.0, u'some': 0}},
       {'insertId': '#1', 'json': {u'column': 'r1', u'headers': 10.0, u'some': 1}},
       {'insertId': '#2', 'json': {u'column': 'r2', u'headers': 10.0, u'some': 2}},


### PR DESCRIPTION
Change the low-level APIs that take a table spec as a parameter to
consistently take a name_parts tuple.

Note: I decided to leave the full name out of the tuple for now so that we
can use ("%s:%s.%s" % tuple) to format a full name.
