### PR TITLE
pygcp changes

### DIFF
--- a/sources/sdk/pygcp/gcp/bigquery/__init__.py
+++ b/sources/sdk/pygcp/gcp/bigquery/__init__.py
@@ -23,6 +23,7 @@ from ._query import Query as _Query
 from ._sampling import Sampling
 from ._table import Table as _Table
 from ._table import DataSet as _DataSet
+from ._table import DataSetLister as _DataSetLister
 from ._table import TableSchema as _TableSchema
 from ._udf import Function as _Function
 
@@ -102,7 +103,7 @@ def table(name, context=None):
   <project]:<dataset>.<table> or <dataset>.<table>.
 
   Args:
-    name: the name of the table.
+    name: the name of the table, as a string or (project_id, dataset_id, table_id) tuple.
     context: an optional Context object providing project_id and credentials.
   Returns:
     A Table object that can be used to retrieve table metadata from BigQuery.
@@ -113,11 +114,18 @@ def table(name, context=None):
   return _Table(api, name)
 
 
-def dataset(dataset_id, context=None, create=False, friendly_name=None, description=None):
+def datasets(project_id=None, context=None):
+  api = _create_api(context)
+  if not project_id:
+    project_id = api.project_id
+  return _DataSetLister(api, project_id)
+
+
+def dataset(name, context=None):
   """Returns the Dataset with the specified dataset_id.
 
   Args:
-    dataset_id: the name of the dataset.
+    name: the name of the dataset, as a string or (project_id, dataset_id) tuple.
     context: an optional Context object providing project_id and credentials.
   Returns:
     A DataSet object.
@@ -125,7 +133,7 @@ def dataset(dataset_id, context=None, create=False, friendly_name=None, descript
   # TODO(gram): the creation part here is a stopgap until we have an API review and decide
   # what to do.
   api = _create_api(context)
-  return _DataSet(api, dataset_id)
+  return _DataSet(api, name)
 
 
 def schema(data):

--- a/sources/sdk/pygcp/gcp/bigquery/_api.py
+++ b/sources/sdk/pygcp/gcp/bigquery/_api.py
@@ -47,15 +47,14 @@ class Api(object):
     """The project_id associated with this API client."""
     return self._project_id
 
-  def jobs_insert_load(self, source, dataset_id, table_id, append=False, overwrite=False,
+  def jobs_insert_load(self, source, table_name, append=False, overwrite=False,
                        source_format='CSV'):
     """ Issues a request to load data from GCS to a BQ table
 
     Args:
       source: the URL of the source bucket(s). Can include wildcards, and can be a single
           string argument or a list.
-      dataset_id: the dataset id of the destination table.
-      table_id: the table id of the destination table.
+      table_name: a tuple representing the full name of the destination table.
       append: if True append onto existing table contents.
       overwrite: if True overwrite existing table contents.
       source_format: the format of the data; default 'CSV'. Other options are DATASTORE_BACKUP
@@ -65,7 +64,8 @@ class Api(object):
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._JOBS_PATH % self._project_id)
+    # TODO(gram): Should we be using table_name,project_id below?
+    url = Api._ENDPOINT + (Api._JOBS_PATH % table_name.project_id)
     if isinstance(source, basestring):
       source = [source]
     write_disposition = 'WRITE_EMPTY'
@@ -79,9 +79,9 @@ class Api(object):
         'load': {
           'sourceUris': source,
           'destinationTable': {
-            'projectId': self._project_id,
-            'datasetId': dataset_id,
-            'tableId': table_id
+            'projectId': table_name.project_id,
+            'datasetId': table_name.dataset_id,
+            'tableId': table_name.table_id
           },
           'createDisposition': 'CREATE_NEVER',
           'writeDisposition': write_disposition,
@@ -91,14 +91,13 @@ class Api(object):
     }
     return _util.Http.request(url, data=data, credentials=self._credentials)
 
-  def jobs_insert_query(self, sql, dataset_id=None, table_id=None, append=False, overwrite=False,
+  def jobs_insert_query(self, sql, table_name=None, append=False, overwrite=False,
                         dry_run=False, use_cache=True, batch=True):
     """Issues a request to insert a query job.
 
     Args:
       sql: the SQL string representing the query to execute.
-      dataset_id: None for an anonymous table, or the datasetId for a long-lived table.
-      table_id: None for an anonymous table, or the tableId for a long-lived table.
+      table_name: None for an anonymous table, or a name parts tuple for a long-lived table.
       append: if True, append to the table if it is non-empty; else the request will fail if table
           is non-empty unless overwrite is True.
       overwrite: if the table already exists, truncate it instead of appending or raising an
@@ -113,6 +112,7 @@ class Api(object):
     Raises:
       Exception if there is an error performing the operation.
     """
+    # TODO(gram): Should we be using table_name,project_id below?
     url = Api._ENDPOINT + (Api._JOBS_PATH % (self._project_id, ''))
     data = {
       'kind': 'bigquery#job',
@@ -126,12 +126,12 @@ class Api(object):
       },
     }
 
-    if dataset_id and table_id:
+    if table_name:
       query_config = data['configuration']['query']
       query_config['destinationTable'] = {
-        'projectId': self._project_id,
-        'datasetId': dataset_id,
-        'tableId': table_id
+        'projectId': table_name.project_id,
+        'datasetId': table_name.dataset_id,
+        'tableId': table_name.table_id
       }
       if append:
         query_config['writeDisposition'] = "WRITE_APPEND"
@@ -140,8 +140,7 @@ class Api(object):
 
     return _util.Http.request(url, data=data, credentials=self._credentials)
 
-  def jobs_query(self, sql, page_size=0, timeout=None, dry_run=False,
-                 use_cache=True):
+  def jobs_query(self, sql, page_size=0, timeout=None, dry_run=False, use_cache=True):
     """Issues a request to the jobs/query method.
 
     Args:
@@ -160,6 +159,7 @@ class Api(object):
     if timeout == None:  # Note: we use == to distinguish with timeout 0.
       timeout = Api._DEFAULT_TIMEOUT
 
+    # TODO(gram): Do we need to be able to handle other project_ids?
     url = Api._ENDPOINT + (Api._QUERIES_PATH % self._project_id, '')
     data = {
         'kind': 'bigquery#queryRequest',
@@ -172,7 +172,7 @@ class Api(object):
 
     return _util.Http.request(url, data=data, credentials=self._credentials)
 
-  def jobs_query_results(self, job_id, page_size=0, timeout=None, start_index=0):
+  def jobs_query_results(self, job_id, project_id=None, page_size=0, timeout=None, start_index=0):
     """Issues a request to the jobs/getQueryResults method.
 
     Args:
@@ -190,34 +190,36 @@ class Api(object):
       page_size = Api._DEFAULT_PAGE_SIZE
     if timeout == None:  # Note: we use == to distinguish with timeout 0.
       timeout = Api._DEFAULT_TIMEOUT
+    if not project_id:
+      project_id = self._project_id
 
     args = {
         'maxResults': page_size,
         'timeoutMs': timeout,
         'startIndex': start_index
       }
-
-    url = Api._ENDPOINT + (Api._QUERIES_PATH % (self._project_id, job_id))
+    url = Api._ENDPOINT + (Api._QUERIES_PATH % (project_id, job_id))
     return _util.Http.request(url, args=args, credentials=self._credentials)
 
   def jobs_get(self, job_id):
     """Issues a request to retrieve information about a job.
 
     Args:
-      dataset_id: the id of the dataset
+      job_id: the id of the job
     Returns:
       A parsed result object.
     Raises:
       Exception if there is an error performing the operation.
     """
+    # TODO(gram) Do we need to be able to handle other project_ids?
     url = Api._ENDPOINT + (Api._JOBS_PATH % self._project_id, job_id)
     return _util.Http.request(url, credentials=self._credentials)
 
-  def datasets_insert(self, dataset_id, friendly_name=None, description=None):
+  def datasets_insert(self, dataset_name, friendly_name=None, description=None):
     """Issues a request to create a dataset.
 
     Args:
-      dataset_id: the name of the dataset to create.
+      dataset_name: the name of the dataset to create.
       friendly_name: (optional) the friendly name for the dataset
       description: (optional) a description for the dataset
     Returns:
@@ -225,12 +227,12 @@ class Api(object):
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._DATASETS_PATH % (self._project_id, ''))
+    url = Api._ENDPOINT + (Api._DATASETS_PATH % (dataset_name.project_id, ''))
     data = {
       'kind': 'bigquery#dataset',
       'datasetReference': {
-        'projectId': self._project_id,
-        'datasetId': dataset_id,
+        'projectId': dataset_name.project_id,
+        'datasetId': dataset_name.dataset_id,
       },
     }
     if friendly_name:
@@ -239,11 +241,11 @@ class Api(object):
       data['description'] = description
     return _util.Http.request(url, data=data, credentials=self._credentials)
 
-  def datasets_delete(self, dataset_id, delete_contents=False):
+  def datasets_delete(self, dataset_name, delete_contents=False):
     """Issues a request to delete a dataset.
 
     Args:
-      dataset_id: the name of the dataset to delete.
+      dataset_name: the name of the dataset to delete.
       delete_contents: if True, any tables in the dataset will be deleted. If False and the
           dataset is non-empty an exception will be raised.
     Returns:
@@ -251,26 +253,26 @@ class Api(object):
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._DATASETS_PATH % (self._project_id, dataset_id))
+    url = Api._ENDPOINT + (Api._DATASETS_PATH % dataset_name)
     args = {}
     if delete_contents:
       args['deleteContents'] = True
     return _util.Http.request(url, method='DELETE', credentials=self._credentials)
 
-  def datasets_get(self, dataset_id):
+  def datasets_get(self, dataset_name):
     """Issues a request to retrieve information about a dataset.
 
     Args:
-      dataset_id: the id of the dataset
+      dataset_name: the name of the dataset
     Returns:
       A parsed result object.
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._DATASETS_PATH % (self._project_id, dataset_id))
+    url = Api._ENDPOINT + (Api._DATASETS_PATH % dataset_name)
     return _util.Http.request(url, credentials=self._credentials)
 
-  def datasets_list(self, max_results=0, page_token=None):
+  def datasets_list(self, project_id = None, max_results=0, page_token=None):
     """Issues a request to list the datasets in the project.
 
     Args:
@@ -281,7 +283,9 @@ class Api(object):
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._DATASETS_PATH % (self._project_id, ''))
+    if not project_id:
+      project_id = self._project_id
+    url = Api._ENDPOINT + (Api._DATASETS_PATH % (project_id, ''))
 
     args = {}
     if max_results != 0:
@@ -291,24 +295,24 @@ class Api(object):
 
     return _util.Http.request(url, args=args, credentials=self._credentials)
 
-  def tables_get(self, name_parts):
+  def tables_get(self, table_name):
     """Issues a request to retrieve information about a table.
 
     Args:
-      name_parts: a tuple representing the full name of the table.
+      table_name: a tuple representing the full name of the table.
     Returns:
       A parsed result object.
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._TABLES_PATH % name_parts)
+    url = Api._ENDPOINT + (Api._TABLES_PATH % table_name)
     return _util.Http.request(url, credentials=self._credentials)
 
-  def tables_list(self, dataset_id, max_results=0, page_token=None):
+  def tables_list(self, dataset_name, max_results=0, page_token=None):
     """Issues a request to retrieve a list of tables.
 
     Args:
-      dataset_id: the name of the dataset to enumerate.
+      dataset_name: the name of the dataset to enumerate.
       max_results: an optional maximum number of tables to retrieve.
       page_token: an optional token to continue the retrieval.
     Returns:
@@ -316,7 +320,8 @@ class Api(object):
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._TABLES_PATH % (self._project_id, dataset_id, ''))
+    url = Api._ENDPOINT +\
+          (Api._TABLES_PATH % (dataset_name.project_id, dataset_name.dataset_id, ''))
 
     args = {}
     if max_results != 0:
@@ -326,12 +331,11 @@ class Api(object):
 
     return _util.Http.request(url, args=args, credentials=self._credentials)
 
-  def tables_insert(self, dataset_id, table_id, schema, friendly_name=None, description=None):
+  def tables_insert(self, table_name, schema, friendly_name=None, description=None):
     """Issues a request to create a table in the specified dataset with the specified id and schema.
 
     Args:
-      dataset_id: the name of the dataset containing the table to create.
-      table_id: the id of the table to create.
+      table_name: the name of the table as a tuple of components.
       schema: the schema of the data.
       friendly_name: an optional friendly name.
       description: an optional description.
@@ -340,14 +344,14 @@ class Api(object):
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._TABLES_PATH % (self._project_id, dataset_id, ''))
+    url = Api._ENDPOINT + (Api._TABLES_PATH % (table_name.project_id, table_name.dataset_id, ''))
 
     data = {
       'kind': 'bigquery#table',
       'tableReference': {
-        'projectId': self._project_id,
-        'datasetId': dataset_id,
-        'tableId': table_id
+        'projectId': table_name.project_id,
+        'datasetId': table_name.dataset_id,
+        'tableId': table_name.table_id
       },
       'schema': {
         'fields': schema
@@ -361,20 +365,18 @@ class Api(object):
 
     return _util.Http.request(url, data=data, credentials=self._credentials)
 
-  def tabledata_insertAll(self, dataset_id, table_id, rows):
+  def tabledata_insertAll(self, table_name, rows):
     """Issues a request to insert data into a table.
 
     Args:
-      dataset_id: the name of the dataset containing the table to populate.
-      table_id: the id of the table to populate
+      table_name: the name of the table as a tuple of components.
       rows: the data to populate the table, as a list of dictionaries.
     Returns:
       A parsed result object.
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._TABLES_PATH % (self._project_id, dataset_id, table_id)) +\
-          "/insertAll"
+    url = Api._ENDPOINT + (Api._TABLES_PATH % table_name) + "/insertAll"
 
     data = {
       'kind': 'bigquery#tableDataInsertAllRequest',
@@ -383,13 +385,11 @@ class Api(object):
 
     return _util.Http.request(url, data=data, credentials=self._credentials)
 
-  def tabledata_list(self, dataset_id, table_id, start_index=None, max_results=None,
-                     page_token=None):
+  def tabledata_list(self, table_name, start_index=None, max_results=None, page_token=None):
     """ Retrieves the contents of a table.
 
     Args:
-      dataset_id: the name of the dataset containing the table.
-      table_id: the id of the table to list.
+      table_name: the name of the table as a tuple of components.
       start_index: the index of the row at which to start retrieval.
       max_results: an optional maximum number of rows to retrieve.
       page_token: an optional token to continue the retrieval.
@@ -398,7 +398,7 @@ class Api(object):
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._TABLEDATA_PATH % (self._project_id, dataset_id, table_id))
+    url = Api._ENDPOINT + (Api._TABLEDATA_PATH % table_name)
     args = {}
     if start_index:
       args['startIndex'] = start_index
@@ -408,25 +408,25 @@ class Api(object):
       args['pageToken'] = page_token
     return _util.Http.request(url, args=args, credentials=self._credentials)
 
-  def table_delete(self, dataset_id, table_id):
+  def table_delete(self, table_name):
     """Issues a request to delete a table.
 
     Args:
-      dataset_id: the name of the dataset containing the table to populate.
-      table_id: the id of the table to populate.
+      table_name: the name of the table as a tuple of components.
     Returns:
       A parsed result object.
     Raises:
       Exception if there is an error performing the operation.
     """
-    url = Api._ENDPOINT + (Api._TABLES_PATH % (self._project_id, dataset_id, table_id))
+    url = Api._ENDPOINT + (Api._TABLES_PATH % table_name)
     return _util.Http.request(url, method='DELETE', credentials=self._credentials)
 
-  def table_extract(self, dataset_id, table_id, destination, format='CSV', compressed=True,
+  def table_extract(self, table_name, destination, format='CSV', compressed=True,
                    field_delimiter=',', print_header=True):
     """Exports the table to GCS.
 
     Args:
+      table_name: the name of the table as a tuple of components.
       destination: the destination URI(s). Can be a single URI or a list.
       format: the format to use for the exported data; one of CSV, NEWLINE_DELIMITED_JSON or AVRO.
           Defaults to CSV.
@@ -439,21 +439,20 @@ class Api(object):
     Raises:
       Exception if there is an error performing the operation.
     """
-    # TODO(gram): Do we need to support the case where the project ID for the export is different
-    # to that of the table? This could happen but is not well-supported by our API.
-    url = Api._ENDPOINT + (Api._JOBS_PATH % self._project_id, '')
+    # TODO(gram) Do we need to be able to handle other project_ids?
+    url = Api._ENDPOINT + (Api._JOBS_PATH % table_name.project_id, '')
     if isinstance(destination, basestring):
       destination = [destination]
     data = {
-      #'projectId': self._project_id, # Code sample shows this but it is not in job reference spec
-      # Filed as b/19235843
+      #'projectId': table_name.project_id, # Code sample shows this but it is not in job
+      # reference spec. Filed as b/19235843
       'kind': 'bigquery#job',
       'configuration': {
         'extract': {
           'sourceTable': {
-            'projectId': self._project_id,
-            'datasetId': dataset_id,
-            'tableId': table_id
+            'projectId': table_name.project_id,
+            'datasetId': table_name.dataset_id,
+            'tableId': table_name.table_id,
           },
           'compression': 'GZIP' if compressed else 'NONE',
           'fieldDelimiter': field_delimiter,

--- a/sources/sdk/pygcp/gcp/bigquery/_job.py
+++ b/sources/sdk/pygcp/gcp/bigquery/_job.py
@@ -155,7 +155,7 @@ class QueryJobResultProcessor(object):
     pass
 
   def finish(self):
-    """ Called after all results have been processed. Can do any necessary housekeeping at this point.
+    """ Called after all results have been processed; do any necessary housekeeping here.
     """
     pass
 
@@ -285,11 +285,12 @@ class QueryJob(Job):
 
   @property
   def table(self):
+    """ Get the table used for the results of the query (note: the query may not be complete).
+    """
     return self._table
 
   def process_results(self, result_processor, page_size=0, timeout=None):
-    """ Process the results of a query job. Note that if the job is not complete,
-        this will block.
+    """ Process the results of a query job; this will block if the job is not complete.
 
     Args:
       result_processor: object used to process the results.
@@ -353,6 +354,8 @@ class QueryJob(Job):
     Args:
       page_size: limit to the number of rows to fetch per page.
       timeout: duration (in milliseconds) to wait for the query to complete.
+    Returns:
+      A list of rows of results.
     """
     return self.process_results(ResultCollector(), page_size=page_size, timeout=timeout).rows
 

--- a/sources/sdk/pygcp/tests/bq_table_tests.py
+++ b/sources/sdk/pygcp/tests/bq_table_tests.py
@@ -112,8 +112,8 @@ class TestCases(unittest.TestCase):
     for table in ds:
       tables.append(table)
     self.assertEqual(2, len(tables))
-    self.assertEqual('test:testds.testTable1', tables[0].name)
-    self.assertEqual('test:testds.testTable2', tables[1].name)
+    self.assertEqual('test:testds.testTable1', tables[0].full_name)
+    self.assertEqual('test:testds.testTable2', tables[1].full_name)
 
   @mock.patch('gcp.bigquery._Api.tables_list')
   @mock.patch('gcp.bigquery._Api.datasets_get')
@@ -293,7 +293,7 @@ class TestCases(unittest.TestCase):
 
     result = table.insertAll(df)
     self.assertIsNotNone(result, "insertAll should return the table object")
-    mock_api_tabledata_insertAll.assert_called_with('testds', 'testTable0', [
+    mock_api_tabledata_insertAll.assert_called_with(('test', 'testds', 'testTable0'), [
       {'insertId': '#0', 'json': {u'column': 'r0', u'headers': 10.0, u'some': 0}},
       {'insertId': '#1', 'json': {u'column': 'r1', u'headers': 10.0, u'some': 1}},
       {'insertId': '#2', 'json': {u'column': 'r2', u'headers': 10.0, u'some': 2}},


### PR DESCRIPTION
- added a DataSetName named tuple similar to TableName
- modified APIs that took project_id, dataset_id params to use DataSetNames
- modified the name parsers for Table and DataSet to be more flexible; can now also support TableName/DataSetNames, dictionaries and component arrays
- add the ability to iterate through the datasets in a project via top-level function datasets([project_id])
- refactored the sample methods in query and table to be sampler/sample pairs, where the former returns a sampling query and the latter executes and returns the results from a sampling query
- improved method comments in a number of places
- fixed a couple of bugs
- (from API review) changed DataSet.delete semantics to throw if no dataset
