### PR TITLE
Preparatory work for using crossfilter for table data

### DIFF
--- a/sources/ipython/profile/static/extensions/tableviewer.js
+++ b/sources/ipython/profile/static/extensions/tableviewer.js
@@ -2,29 +2,26 @@
 
 define(function() {
     return {
-        make_table_viewer: function (table_name, id, job_id) {
+        makeTableViewer: function (tableName, id, labels, totalRows, jobId) {
             var elt = document.getElementById("table_" + id);
             if (elt == undefined) {
                 console.log("NO DIV!");
                 return;
             }
-            elt.model = {
-                'page': 1,
-                'total_rows': 0,
-                'rows_per_page': 10,
-                'labels': [],
+            var model = {
+                "firstRow": 0,
+                "displayPage": 1,
+                "rowsPerPage": 10,
                 'data': []
             }
 
-            var page_id = "page_" + id;
-            var rows_per_page_id = "rpp_" + id;
-            var count_id = "count_" + id;
-            var head_id = "head_" + id;
-            var body_id = "body_" + id;
+            var pageId = "page_" + id;
+            var rowsPerPageId = "rpp_" + id;
+            var countId = "count_" + id;
+            var headId = "head_" + id;
+            var bodyId = "body_" + id;
 
-            var first = true;
-
-            var format = function () {
+            function format() {
                 var s = arguments[0];
                 for (var i = 1; i < arguments.length; i++) {
                     var re = new RegExp("\\{" + (i - 1) + "\\}", "gm");
@@ -33,122 +30,133 @@ define(function() {
                 return s;
             }
 
-            // Construct the skeleton HTML on first callback.
-            var construct = function (model) {
+            var html = format(
+                '<div>' +
+                '  <div style="display:inline;float:left">' + totalRows + ' rows</div>' +
+                '  <div style="display:inline;float:right">' +
+                (jobId ? ('Job: ' + jobId) : tableName) +
+                '  </div>' +
+                '</div>' +
+                '<br>' +
+                '<div>' +
+                '  <div style="display:inline;float:left">' +
+                '    <span style="vertical-align:super">Page </span>' +
+                '    <input type="number" min=1 id="{0}" style="width:120px">' +
+                '    <span style="vertical-align:super"> of </span>' +
+                '    <span style="vertical-align:super" id="{1}"></span>' +
+                '  </div>' +
+                '  <div style="display:inline;float:right">' +
+                '    <span style="vertical-align:super">Rows per Page </span>' +
+                '    <select id="{2}" style="width:80px">' +
+                '      <option value="10">10</option>' +
+                '      <option value="20">20</option>' +
+                '      <option value="50">50</option>' +
+                '      <option value="100">100</option>' +
+                '    </select>' +
+                '  </div>' +
+                '</div>' +
+                '<div style="overflow:auto;width:100%">' +
+                '  <table border="1" cellpadding="3" cellspacing="0" style="border:1px solid black;border-collapse:collapse">' +
+                '    <thead id="{3}" style="display:table-row-group;vertical-align:middle;border-collapse:collapse">' +
+                '      <tr>', pageId, countId, rowsPerPageId, headId);
 
-                var html = format(
-                    '<div>' +
-                    '  <div style="display:inline;float:left">' +
-                    model.total_rows + ' rows' +
-                    '  </div>' +
-                    '  <div style="display:inline;float:right">' +
-                    (job_id ? ('Job: ' + job_id) : table_name) +
-                    '  </div>' +
-                    '</div>' +
-                    '<br>' +
-                    '<div>' +
-                    '  <div style="display:inline;float:left">' +
-                    '    <span style="vertical-align:super">Page </span>' +
-                    '    <input type="number" min=1 id="{0}" style="width:120px">' +
-                    '    <span style="vertical-align:super"> of </span>' +
-                    '    <span style="vertical-align:super" id="{1}"></span>' +
-                    '  </div>' +
-                    '  <div style="display:inline;float:right">' +
-                    '    <span style="vertical-align:super">Rows per Page </span>' +
-                    '    <select id="{2}" style="width:80px">' +
-                    '      <option value="10">10</option>' +
-                    '      <option value="20">20</option>' +
-                    '      <option value="50">50</option>' +
-                    '      <option value="100">100</option>' +
-                    '    </select>' +
-                    '  </div>' +
-                    '</div>' +
-                    '<div style="overflow:auto;width:100%">' +
-                    '  <table border="1" cellpadding="3" cellspacing="0" style="border:1px solid black;border-collapse:collapse">' +
-                    '    <thead id="{3}" style="display:table-row-group;vertical-align:middle;border-collapse:collapse">' +
-                    '      <tr>', page_id, count_id, rows_per_page_id, head_id);
-
-                html += '<td style="background-color:LightGray"><b>Row</b></td>';
-                for (var c = 0; c < model.labels.length; c++) {
-                    html += '<td style="background-color:LightGray"><b>' + model.labels[c] + '</b></td>';
-                }
-
-                html += format(
-                    '      </tr>' +
-                    '    </thead>' +
-                    '    <tbody id="{0}" style="display:table-row-group;vertical-align:middle;border-collapse:collapse"/>' +
-                    '  </table>' +
-                    '</div>', body_id);
-
-                elt.innerHTML = html;
-
-                document.getElementById(page_id).addEventListener('input', function () {
-                    var model = elt.model;
-                    if (this.value >= 1 && this.value <= model.total_rows) {
-                        model.page = this.value;
-                        requestPageUpdate(model);
-                    }
-                });
-
-                document.getElementById(rows_per_page_id).addEventListener('change', function () {
-                    var model = elt.model;
-                    var offset = (model.page - 1) * model.rows_per_page;
-                    model.rows_per_page = parseInt(this.value);
-                    model.page = 1 + Math.floor(offset / model.rows_per_page);
-                    requestPageUpdate(model);
-                });
-                document.getElementById(rows_per_page_id).value = "10";
+            html += '<td style="background-color:LightGray"><b>Row</b></td>';
+            for (var c = 0; c < labels.length; c++) {
+                html += '<td style="background-color:LightGray"><b>' + labels[c] + '</b></td>';
             }
 
+            html += format(
+                '      </tr>' +
+                '    </thead>' +
+                '    <tbody id="{0}" style="display:table-row-group;vertical-align:middle;border-collapse:collapse"/>' +
+                '  </table>' +
+                '</div>', bodyId);
+
+            elt.innerHTML = html;
+
+            document.getElementById(pageId).addEventListener('input', function () {
+                if (this.value >= 1 && this.value <= totalRows) {
+                    model.displayPage = this.value;
+                    requestPageUpdate();
+                }
+            });
+
+            document.getElementById(rowsPerPageId).addEventListener('change', function () {
+                var offset = (model.displayPage - 1) * model.rowsPerPage;
+                model.rowsPerPage = parseInt(this.value);
+                model.displayPage = 1 + Math.floor(offset / model.rowsPerPage);
+                requestPageUpdate();
+            });
+            document.getElementById(rowsPerPageId).value = "10";
+
             // Update dynamic content.
-            var update = function (model) {
-                elt.model = model;
+            function update(data) {
+                model.data = data;
 
-                if (first) {
-                    first = false;
-                    construct(model);
+                var numRows = model.rowsPerPage;
+                var numPages = model.num_pages = Math.ceil(totalRows / numRows);
+                var startRow = (model.displayPage - 1) * model.rowsPerPage;
+                var rowsLeft = totalRows - startRow;
+                if (numRows > rowsLeft) {
+                    numRows = rowsLeft;
                 }
-
-                var num_rows = model.rows_per_page;
-                var num_pages = model.num_pages =
-                    Math.floor((model.total_rows + num_rows - 1) / num_rows);
-                var start_row = (model.page - 1) * model.rows_per_page;
-                var rows_left = model.total_rows - start_row;
-                if (num_rows > rows_left) {
-                    num_rows = rows_left;
-                }
+                var offset = (model.displayPage - 1) * model.rowsPerPage - model.firstRow;
 
                 var html = "";
-                for (var i = 0; i < num_rows; i++) {
+                for (var i = 0; i < numRows; i++) {
                     html += "<tr style='display:table-row'>";
-                    html += "<td style='background-color:WhiteSmoke'>" + (start_row + i) + "</td>";
-                    for (var c = 0; c < model.labels.length; c++) {
-                        html += "<td>" + model.data[i][c] + "</td>";
+                    html += "<td style='background-color:WhiteSmoke'>" + (startRow + i) + "</td>";
+                    for (var c = 0; c < labels.length; c++) {
+                        html += "<td>" + model.data[offset + i][labels[c]] + "</td>";
                     }
                     html += "</tr>";
                 }
 
-                document.getElementById(body_id).innerHTML = html;
-                document.getElementById(page_id).value = model.page;
-                document.getElementById(page_id).max = num_pages;
-                document.getElementById(count_id).textContent = num_pages;
+                document.getElementById(bodyId).innerHTML = html;
+                document.getElementById(pageId).value = model.displayPage;
+                document.getElementById(pageId).max = numPages;
+                document.getElementById(countId).textContent = numPages;
             }
 
-            var requestPageUpdate = function (model) {
-                var code = '%_get_table_page ' + id + ' ' + table_name + ' ' + model.page + ' '
-                    + model.rows_per_page;
-                IPython.notebook.kernel.get_data(code, function (data, error) {
-                    if (error) {
-                        elt.innerHTML = 'Unable to render the table. ' +
-                        'The data being displayed could not be retrieved: ' + error;
+            function requestPageUpdate() {
+                // See if we need to fetch more data
+                var first = (model.displayPage - 1) * model.rowsPerPage;
+                var last = first + model.rowsPerPage;
+                if (first >= model.firstRow && last < (model.firstRow + model.data.length)) {
+                    update(model.data);
+                } else {
+                    // Fetch more data. We try to fetch data surrounding the display page so the
+                    // user can go forward or back through locally cached data. However, if the
+                    // total amount of data is less than 1500 rows, ignore that and fetch it all
+                    // (this would be a first load).
+                    var count = 1000;
+                    if (totalRows <= 1500) { // We have less than 1500; fetch them all
+                        model.firstRow = 0;
+                        count = totalRows;
+                    } else if (totalRows - first < 500) { // We are near the end; fetch last 1000
+                        model.firstRow = totalRows - 1000;
                     } else {
-                        update(data);
+                        // fetch surrounding
+                        model.firstRow = first - 500 - model.rowsPerPage;
+                        if (model.firstRow < 0) {
+                            model.firstRow = 0;
+                        }
                     }
-                });
+                    var code = '%_get_table_rows ' + tableName + ' ' + model.firstRow +
+                        ' ' + count;
+                    IPython.notebook.kernel.get_data(code, function (data, error) {
+                        if (error) {
+                            elt.innerHTML = 'Unable to render the table. ' +
+                            'The data being displayed could not be retrieved: ' + error;
+                        } else {
+                            update(data['data']);
+                        }
+                    });
+                }
             }
 
             // Notify the Python object so we get the first page.
-            requestPageUpdate(elt.model);
+            requestPageUpdate();
         }
     };
 });


### PR DESCRIPTION
- the column labels for a table are supplied as arguments to make_table_viewer so
  they can be populated when the table viewer is created rather than on the first
  row update
- the cell magic to fetch table rows is now row-oriented rather than page oriented
- we fetch more than a page at a time, as needed. Typically we are aiming for the
  1000 rows surrounding the page being viewed. This means a lot of table viewer
  paging can happen locally in the browser. Furthermore we are no longer using the
  page cache in Table__getitem__ (we may be able to get rid of that at some point;
  I'm not going to do so yet though until we know the requirements of a DataFrame-
  like API for Table yet)
- the row data is now sent in the same form as range() returns; i.e. each row is a
  dictionary rather than a list. This is less efficient but it is what crossfilter
  expects, so we will easily be able to populate a crossfilter data set in future.
- Because we no longer need the **getitem** cache, we can share Table instances
  in the notebook, so the cache can be keyed off the table name rather than the
  DOM ID
