### PR TITLE
Updates the build scripts to be goobuntu friendly. Updates a path or two...

### DIFF
--- a/deploy/ipython/local.sh
+++ b/deploy/ipython/local.sh
@@ -38,8 +38,9 @@ FROM $DOCKER_IMAGE
 
 EOF1
 
-# Copy a snapshot of gcloud configuration
-cp -r ~/.config/gcloud gcloud
+# Copy a snapshot of gcloud configuration.
+# -L in case user is using linked gcloud
+cp -Lr ~/.config/gcloud gcloud
 
 # Build and run the local docker image
 docker build -t gcp-ipython-local-instance .

--- a/sources/docker/ipythonlocal/build.sh
+++ b/sources/docker/ipythonlocal/build.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cp ../../../build/tools/metadata/server.js server.js
+cp ../../../build/metadata/server.js server.js
 
 docker build -t gcp-ipython-local .
 

--- a/sources/ipython/build.sh
+++ b/sources/ipython/build.sh
@@ -25,15 +25,15 @@ mv MANIFEST $PYLIB_DIR/IPython.manifest
 
 # Copy the IPython customized profile over
 cp ./profile/config.py $IPY_DIR/config.py
-cp -R ./profile/static $IPY_DIR
+cp -R ./profile/static/. $IPY_DIR
 
 # Compile the nodejs proxy server
 tsc --module commonjs --removeComments --noImplicitAny \
     --outDir $PROXY_DIR \
     ./proxy/*.ts
 
-cp -R ./proxy/config $PROXY_DIR/config
-cp -R ./proxy/static $PROXY_DIR/static
+cp -R ./proxy/config/. $PROXY_DIR/config
+cp -R ./proxy/static/. $PROXY_DIR/static
 
 # Package all of the IPython stuff into a tarball
 cd $BUILD_DIR

--- a/sources/server/build.sh
+++ b/sources/server/build.sh
@@ -10,7 +10,7 @@ mkdir -p "$ui_staging_path" "$node_staging_path" "$build_path" "$build_path/stat
 # NodeJS backend compilation in staging
 echo 'Building DataLab server backend...';
 # Copy node .ts files to the backend staging area.
-cp -r "$server_root/src/node/" "$node_staging_path";
+cp -r "$server_root/src/node/." "$node_staging_path";
 # Copy shared .ts files to the backend staging area.
 cp -r "$server_root/src/shared" "$node_staging_path/app";
 # Compile the typescript code in staging.
@@ -20,7 +20,7 @@ tsc $common_tsc_args --module commonjs $node_tsc_files;
 # UI compilation in staging
 echo 'Building DataLab server frontend...';
 # Copy UI .ts files to the frontend staging area.
-cp -r "$server_root/src/ui/" "$ui_staging_path";
+cp -r "$server_root/src/ui/." "$ui_staging_path";
 # Copy shared .ts files to the frontend staging area.
 cp -r "$server_root/src/shared" "$ui_staging_path/scripts/app";
 # Compile the typescript code in staging.

--- a/sources/tools/build.sh
+++ b/sources/tools/build.sh
@@ -13,4 +13,4 @@ fi
 BUILD_DIR="$REPO_DIR/build"
 
 # Copy the metadata service emulator tool used in the local ipython container
-cp -R ./metadata $BUILD_DIR/metadata
+cp -R ./metadata/. $BUILD_DIR/metadata


### PR DESCRIPTION
... to reflect the current build reality. Adds a cp follows symlink on gcloud auth copy. Needed since gcloud-dogfood creates ~/.config/gcloud-dogfood instead of gcloud
