### PR TITLE
Handle parsing data for tables with nested RECORD fields.

### DIFF
--- a/sources/sdk/pygcp/gcp/bigquery/_table.py
+++ b/sources/sdk/pygcp/gcp/bigquery/_table.py
@@ -168,6 +168,7 @@ class Schema(list):
       data = definition
     else:
       raise Exception("Schema requires either data or json argument.")
+    self._bq_schema = data
     self._populate_fields(data)
 
   def __getitem__(self, key):
@@ -183,7 +184,6 @@ class Schema(list):
     self._map[name] = field
 
   def _populate_fields(self, data, prefix=''):
-    self._bq_schema = data
     for field_data in data:
       name = prefix + field_data['name']
       data_type = field_data['type']
@@ -671,7 +671,7 @@ class Table(object):
       else:
         raise Exception('Cannot use negative indices for table of unknown length')
 
-    schema = self.schema
+    schema = self.schema._bq_schema
     name_parts = self._name_parts
 
     def _retrieve_rows(page_token, count):


### PR DESCRIPTION
For now if the nested field is REPEATING we only handle the first
value in the underlying array of subfields. We could handle more and
add .0, .1, etc suffixes on the names, but this may have its own issues.

Note too that we only handle currently REPEATING in the case of RECORD
fields, not scalar fields.

In order to support this, we need to use the underlying _bq_schema in
Schema. This is happening in more and more of the code, leading me to
question how much value the flattened Schema object is providing, but
that is not something I want to address yet.
