### PR TITLE
Pygcp issue250

### DIFF
--- a/content/ipython/notebooks/BigQuery - Inserting Data.ipynb
+++ b/content/ipython/notebooks/BigQuery - Inserting Data.ipynb
@@ -439,7 +439,7 @@
      "source": [
       "Now we can create table with the schema that was just created.\n",
       "\n",
-      "For the purpose of this example, if the table exists we'll recreate it (with the `truncate=True` parameter). Additionally we'll do the same for creating a DataSet that will contain the table."
+      "For the purpose of this example, if the table exists we'll recreate it (with the `overwrite=True` parameter). Additionally we'll do the same for creating a DataSet that will contain the table."
      ]
     },
     {
@@ -464,7 +464,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "table = bq.table('samples.stock').create(schema, truncate=True)"
+      "table = bq.table('samples.stock').create(schema, overwrite=True)"
      ],
      "language": "python",
      "metadata": {},

--- a/sources/sdk/pygcp/gcp/bigquery/_table.py
+++ b/sources/sdk/pygcp/gcp/bigquery/_table.py
@@ -679,8 +679,8 @@ class Table(object):
 
     def _retrieve_rows(page_token, count):
 
+      page_rows = []
       if max_rows and count >= max_rows:
-        page_rows = []
         page_token = None
       else:
         if max_rows and page_size > (max_rows - count):
@@ -695,7 +695,8 @@ class Table(object):
           response = self._api.tabledata_list(name_parts, start_index=start_row,
                                               max_results=max_results)
         page_token = response['pageToken'] if 'pageToken' in response else None
-        page_rows = response['rows']
+        if 'rows' in response:
+          page_rows = response['rows']
 
       rows = []
       for row_dict in page_rows:


### PR DESCRIPTION
Fix the sample notebook to use the overwrite flag instead of truncate.
Fix an issue with displaying an empty table (in the notebook case, this could be because the inserted data is not available for querying yet). We would throw a KeyError exception before instead of returning no rows.
