### PR TITLE
Heading + markdown cell polish

### DIFF
--- a/sources/server/src/ui/scripts/app/components/codecell/codecell.html
+++ b/sources/server/src/ui/scripts/app/components/codecell/codecell.html
@@ -3,6 +3,7 @@
       cell="cell"
       worksheet-id="worksheetId"
       keymap="keymap"
+      language="python"
       enable-edit-region="ctrl.showEditRegion"
       enable-preview-region="ctrl.showPreviewRegion">
   </datalab-editor-cell>

--- a/sources/server/src/ui/scripts/app/components/codeeditor/CodeEditorDirective.ts
+++ b/sources/server/src/ui/scripts/app/components/codeeditor/CodeEditorDirective.ts
@@ -22,6 +22,7 @@
 /// <reference path="../../../../../../../../externs/ts/angularjs/angular.d.ts" />
 /// <reference path="../../../../../../../../externs/ts/codemirror/codemirror.d.ts" />
 /// <amd-dependency path="codeMirror/mode/python/python" />
+/// <amd-dependency path="codeMirror/mode/markdown/markdown" />
 /// <amd-dependency path="codeMirror/addon/edit/matchbrackets" />
 import codeMirror = require('codeMirror');
 import constants = require('app/common/Constants');
@@ -35,7 +36,9 @@ var log = logging.getLogger(constants.scopes.codeEditor);
 var codeMirrorOptions: CodeMirror.EditorConfiguration = {
   // TODO(bryantd): add hook to enable line numbers when containing cell becomes active.
   lineNumbers: false,
+
   indentUnit: 4,
+  lineWrapping: false,
 
   // Note: themes require additional css imports containing the CodeMirror syntax css rules.
   theme: 'quantum-light',
@@ -92,6 +95,9 @@ interface CodeEditorScope extends ng.IScope {
    * An example of a valid DOM event would be 'focus', 'mouseover', etc.
    */
   getActionHandlers: Function;
+
+  mode: string;
+  linewrap: boolean;
 }
 
 /**
@@ -107,6 +113,9 @@ function codeEditorDirectiveLink(
     : void {
 
   var cmContainer = element[0];
+
+  codeMirrorOptions.lineWrapping = scope.linewrap;
+  codeMirrorOptions.mode.name = scope.mode;
 
   var cmInstance: CodeMirror.Editor = codeMirror(cmContainer, codeMirrorOptions);
   cmInstance.addKeyMap(scope.getKeymap());
@@ -180,7 +189,9 @@ function codeEditorDirective(): ng.IDirective {
       source: '=',
       active: '=',
       getKeymap: '&keymap',
-      getActionHandlers: '&actions'
+      getActionHandlers: '&actions',
+      linewrap: '=',
+      mode: '='
     },
     link: codeEditorDirectiveLink,
   }

--- a/sources/server/src/ui/scripts/app/components/documentcell/DocumentCell.ts
+++ b/sources/server/src/ui/scripts/app/components/documentcell/DocumentCell.ts
@@ -65,6 +65,7 @@ export class DocumentCellController implements app.ICellController {
     var that = this;
     this._rootScope.$evalAsync(() => {
       that.showEditRegion = true;
+      that.showPreviewRegion = false;
     });
   }
 
@@ -75,6 +76,7 @@ export class DocumentCellController implements app.ICellController {
     var that = this;
     this._rootScope.$evalAsync(() => {
       that.showEditRegion = false;
+      that.showPreviewRegion = true;
     });
   }
 

--- a/sources/server/src/ui/scripts/app/components/editorcell/EditorCellDirective.ts
+++ b/sources/server/src/ui/scripts/app/components/editorcell/EditorCellDirective.ts
@@ -36,6 +36,7 @@ interface EditorCellScope extends ng.IScope {
   enableEditRegion: boolean;
   enablePreviewRegion: boolean;
   getKeymap: Function;
+  language: string;
   onPreviewRegionDoubleClick: Function;
   worksheetId: string;
 
@@ -153,6 +154,7 @@ function editorCellDirective(): ng.IDirective {
       getKeymap: '&keymap',
       enableEditRegion: '=',
       enablePreviewRegion: '=',
+      language: '@',
       onPreviewRegionDoubleClick: '&',
       worksheetId: '='
     },

--- a/sources/server/src/ui/scripts/app/components/editorcell/editorcell.html
+++ b/sources/server/src/ui/scripts/app/components/editorcell/editorcell.html
@@ -14,7 +14,9 @@
             source="cell.source"
             active="active"
             keymap='keymap'
-            actions='actions'>
+            actions='actions'
+            linewrap="cell.type == 'markdown' || cell.type=='heading'"
+            mode="language">
         </datalab-code-editor>
       </div>
 

--- a/sources/server/src/ui/scripts/app/components/markdowncell/markdowncell.html
+++ b/sources/server/src/ui/scripts/app/components/markdowncell/markdowncell.html
@@ -3,6 +3,7 @@
       cell="cell"
       worksheet-id="worksheetId"
       keymap="keymap"
+      language="markdown"
       enable-edit-region="ctrl.showEditRegion"
       enable-preview-region="ctrl.showPreviewRegion"
       on-preview-region-double-click="ctrl.switchToEditMode()">

--- a/sources/server/src/ui/styles/cm-quantum-light-theme.css
+++ b/sources/server/src/ui/styles/cm-quantum-light-theme.css
@@ -12,8 +12,8 @@ div.cm-s-quantum-light .CodeMirror-cursor { border-left: 2px solid #222; }
 .cm-s-quantum-light .cm-atom { color: #F90; }
 .cm-s-quantum-light .cm-number { color:  #DB4437; }
 .cm-s-quantum-light .cm-def { color: #8DA6CE; }
-.cm-s-quantum-light span.cm-variable-2, .cm-s-quantum-light span.cm-tag { color: #CDDC39; }
-.cm-s-quantum-light span.cm-variable-3, .cm-s-quantum-light span.cm-def { color: #03A9F4; }
+.cm-s-quantum-light span.cm-variable-2, .cm-s-quantum-light span.cm-tag { color: #616161; }
+.cm-s-quantum-light span.cm-variable-3, .cm-s-quantum-light span.cm-def { color: #616161; }
 
 .cm-s-quantum-light .cm-variable { color: #616161; }
 .cm-s-quantum-light .cm-property { color: #F4B400; }
@@ -27,7 +27,7 @@ div.cm-s-quantum-light .CodeMirror-cursor { border-left: 2px solid #222; }
 .cm-s-quantum-light .cm-builtin { color: #E91E63; }
 .cm-s-quantum-light .cm-tag { color: #A1887F; }
 .cm-s-quantum-light .cm-attribute { color: #FFCD40; }
-.cm-s-quantum-light .cm-header { color: #FF6400; }
+.cm-s-quantum-light .cm-header { color: #4285F4; }
 .cm-s-quantum-light .cm-hr { color: #AEAEAE; }
 .cm-s-quantum-light .cm-link {   color:#ad9361; font-style:italic; text-decoration:none; }
 .cm-s-quantum-light .cm-error { border-bottom: 1px solid red; }


### PR DESCRIPTION
- Changes edit and preview modes to be mutually exclusive (ala current IPython UX) instead of automatically rendered
- Makes editor cell configurable for
  - line wrapping
  - language mode
- Adds configuration to allow for markdown mode highlighting within markdown cells
- Removes syntax highlighting for header cells

Addresses: #248 and #261 
