### PR TITLE
Fix several issues found by samples:

### DIFF
--- a/sources/sdk/pygcp/gcp/bigquery/__init__.py
+++ b/sources/sdk/pygcp/gcp/bigquery/__init__.py
@@ -19,15 +19,15 @@ import gcp._util as _util
 from ._api import Api as _Api
 from ._dataset import DataSet as _DataSet
 from ._dataset import DataSetLister as _DataSetLister
-from ._dataset import DataSetName as _DataSetName
 from ._job import Job as _Job
 from ._query_job import QueryJob as _QueryJob
 from ._query import Query as _Query
 from ._sampling import Sampling
 from ._table import Schema as _Schema
 from ._table import Table as _Table
-from ._table import TableName as _TableName
 from ._udf import Function as _Function
+from ._utils import DataSetName as _DataSetName
+from ._utils import TableName as _TableName
 from ._view import View as _View
 
 

--- a/sources/sdk/pygcp/gcp/bigquery/_utils.py
+++ b/sources/sdk/pygcp/gcp/bigquery/_utils.py
@@ -1,0 +1,140 @@
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Useful common utility functions."""
+
+import collections
+import re
+
+
+DataSetName = collections.namedtuple('DataSetName', ['project_id', 'dataset_id'])
+TableName = collections.namedtuple('TableName', ['project_id', 'dataset_id', 'table_id'])
+
+# Absolute project-qualified name pattern: <project>:<dataset>
+_ABS_DATASET_NAME_PATTERN = r'^([a-z0-9\-_\.:]+)\:([a-zA-Z0-9_]+)$'
+
+# Relative name pattern: <dataset>
+_REL_DATASET_NAME_PATTERN = r'^([a-zA-Z0-9_]+)$'
+
+# Absolute project-qualified name pattern: <project>:<dataset>.<table>
+_ABS_TABLE_NAME_PATTERN = r'^([a-z0-9\-_\.:]+)\:([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]+)$'
+
+# Relative name pattern: <dataset>.<table>
+_REL_TABLE_NAME_PATTERN = r'^([a-zA-Z0-9_]+)\.([a-zA-Z0-9_]+)$'
+
+# Table-only name pattern: <table>
+_TABLE_NAME_PATTERN = r'^([a-zA-Z0-9_]+)$'
+
+
+def parse_dataset_name(name, project_id=None):
+  """Parses a dataset name into its individual parts.
+
+  Args:
+    name: the name to parse, or a tuple, dictionary or array containing the parts.
+    project_id: the expected project ID. If the name does not contain a project ID,
+        this will be used; if the name does contain a project ID and it does not match
+        this, an exception will be thrown.
+  Returns:
+    The DataSetName for the dataset.
+  Raises:
+    Exception: raised if the name doesn't match the expected formats.
+  """
+  _project_id = _dataset_id = None
+  if isinstance(name, basestring):
+    # Try to parse as absolute name first.
+    m = re.match(_ABS_DATASET_NAME_PATTERN, name, re.IGNORECASE)
+    if m is not None:
+      _project_id, _dataset_id = m.groups()
+    else:
+      # Next try to match as a relative name implicitly scoped within current project.
+      m = re.match(_REL_DATASET_NAME_PATTERN, name)
+      if m is not None:
+        groups = m.groups()
+        _dataset_id = groups[0]
+  elif isinstance(name, dict):
+    try:
+      _dataset_id = name['dataset_id']
+      _project_id = name['project_id']
+    except KeyError:
+      pass
+  else:
+    # Try treat as an array or tuple
+    if len(name) == 2:
+      # Treat as a tuple or array.
+      _project_id, _dataset_id = name
+    elif len(name) == 1:
+      _dataset_id = name[0]
+  if not _dataset_id:
+    raise Exception('Invalid dataset name: ' + str(name))
+  if not _project_id:
+    _project_id = project_id
+
+  return DataSetName(_project_id, _dataset_id)
+
+
+def parse_table_name(name, project_id=None, dataset_id=None):
+  """Parses a table name into its individual parts.
+
+  Args:
+    name: the name to parse, or a tuple, dictionary or array containing the parts.
+    project_id: the expected project ID. If the name does not contain a project ID,
+        this will be used; if the name does contain a project ID and it does not match
+        this, an exception will be thrown.
+    dataset_id: the expected dataset ID. If the name does not contain a dataset ID,
+        this will be used; if the name does contain a dataset ID and it does not match
+        this, an exception will be thrown.
+  Returns:
+    A tuple consisting of the full name and individual name parts.
+  Raises:
+    Exception: raised if the name doesn't match the expected formats.
+  """
+  _project_id = _dataset_id = _table_id = None
+  if isinstance(name, basestring):
+    # Try to parse as absolute name first.
+    m = re.match(_ABS_TABLE_NAME_PATTERN, name, re.IGNORECASE)
+    if m is not None:
+      _project_id, _dataset_id, _table_id = m.groups()
+    else:
+      # Next try to match as a relative name implicitly scoped within current project.
+      m = re.match(_REL_TABLE_NAME_PATTERN, name)
+      if m is not None:
+        groups = m.groups()
+        _project_id, _dataset_id, _table_id = project_id, groups[0], groups[1]
+      else:
+        # Finally try to match as a table name only.
+        m = re.match(_TABLE_NAME_PATTERN, name)
+        if m is not None:
+          groups = m.groups()
+          _project_id, _dataset_id, _table_id = project_id, dataset_id, groups[0]
+  elif isinstance(name, dict):
+    try:
+      _table_id = name['table_id']
+      _dataset_id = name['dataset_id']
+      _project_id = name['project_id']
+    except KeyError:
+      pass
+  else:
+    # Try treat as an array or tuple
+    if len(name) == 3:
+      _project_id, _dataset_id, _table_id = name
+    elif len(name) == 2:
+      _dataset_id, _table_id = name
+  if not _table_id:
+    raise Exception('Invalid table name: ' + str(name))
+  if not _project_id:
+    _project_id = project_id
+  if not _dataset_id:
+    _dataset_id = dataset_id
+
+  return TableName(_project_id, _dataset_id, _table_id)

--- a/sources/sdk/pygcp/tests/bq_jobs_tests.py
+++ b/sources/sdk/pygcp/tests/bq_jobs_tests.py
@@ -29,15 +29,15 @@ class TestCases(unittest.TestCase):
     j = gcp.bigquery.job('foo', self._create_context())
     self.assertFalse(j.iscomplete)
     self.assertFalse(j.failed)
-    mock_api_jobs_get.return_value = {'state': 'DONE'}
+    mock_api_jobs_get.return_value = {'status': {'state': 'DONE'}}
     self.assertTrue(j.iscomplete)
     self.assertFalse(j.failed)
 
   @mock.patch('gcp.bigquery._Api.jobs_get')
   def test_job_fatal_error(self, mock_api_jobs_get):
     mock_api_jobs_get.return_value = {
-      'state': 'DONE',
       'status': {
+        'state': 'DONE',
         'errorResult': {
           'location': 'A',
           'message': 'B',
@@ -57,8 +57,8 @@ class TestCases(unittest.TestCase):
   @mock.patch('gcp.bigquery._Api.jobs_get')
   def test_job_errors(self, mock_api_jobs_get):
     mock_api_jobs_get.return_value = {
-      'state': 'DONE',
       'status': {
+        'state': 'DONE',
         'errors': [
           {
             'location': 'A',

--- a/sources/sdk/pygcp/tests/bq_query_tests.py
+++ b/sources/sdk/pygcp/tests/bq_query_tests.py
@@ -27,7 +27,7 @@ class TestCases(unittest.TestCase):
   def test_single_result_query(self, mock_api_tables_get, mock_api_jobs_get, mock_api_insert_query,
                                mock_api_tabledata_list):
     mock_api_tables_get.return_value = self._create_tables_get_result()
-    mock_api_jobs_get.return_value = {'state': 'DONE'}
+    mock_api_jobs_get.return_value = {'status': {'state': 'DONE'}}
     mock_api_insert_query.return_value = self._create_insert_done_result()
     mock_api_tabledata_list.return_value = self._create_single_row_result()
 
@@ -45,7 +45,7 @@ class TestCases(unittest.TestCase):
   @mock.patch('gcp.bigquery._Api.tables_get')
   def test_empty_result_query(self, mock_api_tables_get, mock_api_jobs_get, mock_api_insert_query):
     mock_api_tables_get.return_value = self._create_tables_get_result(0)
-    mock_api_jobs_get.return_value = {'state': 'DONE'}
+    mock_api_jobs_get.return_value = {'status': {'state': 'DONE'}}
     mock_api_insert_query.return_value = self._create_insert_done_result()
 
     q = self._create_query()
@@ -61,7 +61,7 @@ class TestCases(unittest.TestCase):
                                    mock_api_jobs_get,
                                    mock_api_insert_query):
     mock_api_tables_get.return_value = self._create_tables_get_result()
-    mock_api_jobs_get.return_value = {'state': 'DONE'}
+    mock_api_jobs_get.return_value = {'status': {'state': 'DONE'}}
     mock_api_insert_query.return_value = self._create_incomplete_result()
 
     q = self._create_query()

--- a/sources/sdk/pygcp/tests/bq_table_tests.py
+++ b/sources/sdk/pygcp/tests/bq_table_tests.py
@@ -454,7 +454,9 @@ class TestCases(unittest.TestCase):
     self.assertEquals('bar', job.id)
 
   @mock.patch('gcp.bigquery._Api.table_extract')
-  def test_table_extract(self, mock_api_table_extract):
+  @mock.patch('gcp.bigquery._Api.jobs_get')
+  def test_table_extract(self, mock_api_jobs_get, mock_api_table_extract):
+    mock_api_jobs_get.return_value = {'status': {'state': 'DONE'}}
     mock_api_table_extract.return_value = None
     tbl = gcp.bigquery.table('testds.testTable0', context=self._create_context())
     job = tbl.extract('gs://foo')

--- a/sources/sdk/pygcp/tests/bq_view_tests.py
+++ b/sources/sdk/pygcp/tests/bq_view_tests.py
@@ -58,7 +58,7 @@ class TestCases(unittest.TestCase):
     mock_api_insert_query.return_value = self._create_insert_done_result()
     mock_api_tables_insert.return_value = self._create_tables_insert_success_result()
     mock_api_tables_get.return_value = self._create_tables_get_result()
-    mock_api_jobs_get.return_value = {'state': 'DONE'}
+    mock_api_jobs_get.return_value = {'status': {'state': 'DONE'}}
     mock_api_tabledata_list.return_value = self._create_single_row_result()
 
     name = 'test:testds.testView0'


### PR DESCRIPTION
- the parsing of job completion state was being done incorrectly
- job errors may not have a location field so now we are robust to any missing fields
- the Job class now has a helper function for blocking until completion
- extract() now uses that helper function to block by default
- Query.execute required a table name tuple but can now take a string
- to support the above, the TableName and DataSetName parser functions have been moved into
  a _utils.py file so they can be imported independently of Table and DataSet.
