### PR TITLE
Adds support for IPython configuration file when spawning kernels

### DIFF
--- a/sources/server/build.sh
+++ b/sources/server/build.sh
@@ -31,9 +31,9 @@ tsc $common_tsc_args --module amd $ui_tsc_files;
 # the static UI content directly.
 #
 # Copy the compiled backend .js from staging to the server build.
-rsync -avp $node_staging_path/ "$build_path";
+rsync -avp "$node_staging_path/" "$build_path";
 # Copy the built UI with static assets to the /static content path of the server build.
-rsync -avp $ui_staging_path/ "$build_path/static";
+rsync -avp "$ui_staging_path/" "$build_path/static";
 # Remove the unneeded .ts files from the build path (both ui and node).
 find "$build_path" -name '*.ts' | xargs rm;
 
@@ -43,6 +43,8 @@ rsync -avp "$profile_root/static/extensions/" "$build_path/static/profile/extens
 rsync -avp "$profile_root/static/require/" "$build_path/static/profile/require";
 # Copy over profile custom CSS that is not IPython-specific.
 rsync -avp "$profile_root/static/custom/gchart-table.css" "$build_path/static/profile/custom";
+# Copy the kernel profile configuration.
+rsync -avp "$server_root/profile" "$build_path";
 
 
 echo 'Build complete!'

--- a/sources/server/profile/kernel_config.py
+++ b/sources/server/profile/kernel_config.py
@@ -1,0 +1,22 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# DataLab configuration for IPython kernels.
+c = get_config()
+
+# Load these extensions at start-up.
+c.InteractiveShellApp.extensions = [
+  'gcp.interactive'
+]

--- a/sources/server/src/node/app/common/interfaces.d.ts
+++ b/sources/server/src/node/app/common/interfaces.d.ts
@@ -67,6 +67,11 @@ declare module app {
     heartbeatPort: number;
     iopubPort: number;
     shellPort: number;
+
+    /**
+     * Path to an IPython kernel config.py file to use.
+     */
+    configPath?: string;
   }
 
   /**

--- a/sources/server/src/node/app/config.ts
+++ b/sources/server/src/node/app/config.ts
@@ -68,7 +68,7 @@ export function getSettings(): app.Settings {
 /**
  * A single, server-wide kernel manager instance.
  */
-var _kernelManager: app.IKernelManager = new kernels.Manager();
+var _kernelManager: app.IKernelManager;
 
 /**
  * Gets the kernel manager singleton.
@@ -81,6 +81,15 @@ export function getKernelManager(): app.IKernelManager {
  * A single stateless server-wide notebook storage backend instance.
  */
 var _notebookStorage: app.INotebookStorage;
+
+export function initKernelManager(ipythonKernelConfigPath: string) {
+  if (_kernelManager) {
+    // Kernel manager already initialized.
+    return;
+  }
+
+  _kernelManager = new kernels.Manager(ipythonKernelConfigPath);
+}
 
 /**
  * Gets the configured notebook storage backend for persisting notebooks.

--- a/sources/server/src/node/app/kernels/client.ts
+++ b/sources/server/src/node/app/kernels/client.ts
@@ -126,6 +126,11 @@ export class KernelClient implements app.IKernel {
         '--matplotlib=inline'
         ];
 
+    // Add a flag for the IPython kernel configuration file path if one was provided.
+    if (this.config.configPath) {
+      args.push('--config=' + this.config.configPath);
+    }
+
     // Asynchronously spawns the kernel process, returning an event emitter for capturing
     // process events (e.g., failures).
     this._kernelProcess = childproc.spawn(cmd, args);

--- a/sources/server/src/node/app/kernels/manager.ts
+++ b/sources/server/src/node/app/kernels/manager.ts
@@ -24,9 +24,16 @@ import client = require('./client');
 export class KernelManager implements app.IKernelManager {
 
   _idToKernel: app.Map<app.IKernel>;
+  _kernelConfigPath: string;
 
-  constructor () {
+  /**
+   * Constructor.
+   *
+   * @param kernelConfigPath IPython kernel configuration file path.
+   */
+  constructor (kernelConfigPath: string) {
     this._idToKernel = {};
+    this._kernelConfigPath = kernelConfigPath;
   }
 
   /**
@@ -40,6 +47,11 @@ export class KernelManager implements app.IKernelManager {
       onKernelStatus: app.EventHandler<app.KernelStatus>,
       onOutputData: app.EventHandler<app.OutputData>
       ): app.IKernel {
+
+    // Set the kernel configuration file path if one was specified.
+    if (this._kernelConfigPath) {
+      config.configPath = this._kernelConfigPath;
+    }
 
     var kernel: app.IKernel = new client.KernelClient(
       id, config, onExecuteReply, onHealthCheck, onKernelStatus, onOutputData);

--- a/sources/server/src/node/server.ts
+++ b/sources/server/src/node/server.ts
@@ -32,18 +32,20 @@ import socketio = require('socket.io');
  * Configure and parse command line arguments with defaults.
  */
 var options = nomnom
-  .option(
-    'notebookPath', {
-      abbr: 'n',
-      full: 'notebook-path',
-      help: 'notebook loading root path',
-      default: './notebooks'
-    }
-  )
+  .option('notebookPath', {
+    abbr: 'n',
+    full: 'notebook-path',
+    help: 'notebook loading root path',
+    default: './notebooks'
+  })
   .option('gcsStorageBucket', {
     abbr: 'b',
     full: 'bucket',
     help: 'GCS storage bucket to use for server content'
+  })
+  .option('ipythonKernelConfigPath', {
+    full: 'ipy-config',
+    help: 'IPython kernel configuration file path'
   })
   .parse();
 
@@ -84,6 +86,8 @@ export function start (settings: app.Settings) {
 
 // Ensure that the notebook storage system is fully initialized
 config.initStorage(options.notebookPath, options.gcsStorageBucket);
+// Initialize the kernel manager with additional configuration.
+config.initKernelManager(options.ipythonKernelConfigPath);
 
 // Start the DataLab server running
 start(config.getSettings());


### PR DESCRIPTION
- Adds minimal IPython kernel configuration for auto-importing the gcp sdk library
- Adds kernel profile to build process
- Updates datalab-server launcher script to configure PYTHONPATH and specify kernel profile for loading gcp library
