### PR TITLE
Fixes session API routing to properly handle paths with :action suffix

### DIFF
--- a/sources/server/src/node/app/kernels/channels.ts
+++ b/sources/server/src/node/app/kernels/channels.ts
@@ -29,7 +29,7 @@ export class ChannelClient {
   _socketIdentity: string
   _socket: zmq.Socket;
 
-  constructor (connectionUrl: string, port: number, socketIdentity: string, socketType: string) {
+  constructor(connectionUrl: string, port: number, socketIdentity: string, socketType: string) {
     this._connectionUrl = connectionUrl;
     this._port = port;
     this._socketIdentity = socketIdentity;
@@ -37,21 +37,21 @@ export class ChannelClient {
     this._socket = null; // initialized on connect()
   }
 
-  connect (): void {
+  connect(): void {
     if (!this._socket) {
       this._createSocket();
     }
     this._socket.connect(this._connectionUrl + this._port);
   }
 
-  disconnect (): void {
+  disconnect(): void {
     this._socket.close();
   }
 
   /**
    * Creates a zmq socket and initializes it with appropriate event handlers.
    */
-  _createSocket () {
+  _createSocket() {
     if (!this._socketType) {
       throw new Error("Improperly initialized channel client. Define a socket type.");
     }
@@ -66,7 +66,7 @@ export class ChannelClient {
    *
    * @param messageParts a multipart message
    */
-  _send (messageParts: string[]): void {
+  _send(messageParts: string[]): void {
     this._socket.send(messageParts);
   }
 

--- a/sources/server/src/node/app/kernels/heartbeat.ts
+++ b/sources/server/src/node/app/kernels/heartbeat.ts
@@ -43,7 +43,16 @@ export class HeartbeatChannelClient extends channels.ChannelClient {
     super(connectionUrl, port, 'heartbeat-' + port, 'req');
 
     this._delegateHealthCheckHandler = onHealthCheck;
+  }
+
+  connect(): void {
+    super.connect();
     this._start();
+  }
+
+  disconnect(): void {
+    this._stop();
+    super.disconnect();
   }
 
   /**

--- a/sources/server/src/node/app/kernels/manager.ts
+++ b/sources/server/src/node/app/kernels/manager.ts
@@ -86,7 +86,8 @@ export class KernelManager implements app.IKernelManager {
   shutdown (id: string): void {
     var kernel = this.get(id);
     if (!kernel) {
-      throw new Error('No kernel exists with ID="' + id + '"');
+      // Kernel does not exist or has already been shutdown. Nothing to do.
+      return;
     }
     kernel.shutdown();
     delete this._idToKernel[id];


### PR DESCRIPTION
Action suffix used by sessions api for shutdown/reset.

Also includes a few other kernel lifecycle fixes:
- Allow for shutdown of kernel that may already be shutdown (e.g., kernel died, was cleaned up, session attempts kernel respawn)
- Stop listening for heartbeat upon kernel shutdown

Addresses #285 
