### PR TITLE
Switch /profile/ to /static/ for serving static profile assets

### DIFF
--- a/sources/server/build.sh
+++ b/sources/server/build.sh
@@ -4,7 +4,7 @@ set -o errexit; # Fail build on first error, instead of carrying on by default
 # Load the common build config
 source config.sh;
 
-mkdir -p "$ui_staging_path" "$node_staging_path" "$build_path" "$build_path/static/profile/custom";
+mkdir -p "$ui_staging_path" "$node_staging_path" "$build_path" "$build_path/static/static/custom";
 
 ### BUILD
 # NodeJS backend compilation in staging
@@ -38,11 +38,12 @@ rsync -avp "$ui_staging_path/" "$build_path/static";
 find "$build_path" -name '*.ts' | xargs rm;
 
 # Copy over the extensions.
-rsync -avp "$profile_root/static/extensions/" "$build_path/static/profile/extensions";
+rsync -avp "$profile_root/static/extensions/" "$build_path/static/static/extensions";
 # Copy over the RequireJS plugins.
-rsync -avp "$profile_root/static/require/" "$build_path/static/profile/require";
+rsync -avp "$profile_root/static/require/" "$build_path/static/static/require";
 # Copy over profile custom CSS that is not IPython-specific.
-rsync -avp "$profile_root/static/custom/gchart-table.css" "$build_path/static/profile/custom";
+rsync -avp "$profile_root/static/custom/gchart-table.css" "$build_path/static/static/custom";
+
 # Copy the kernel profile configuration.
 rsync -avp "$server_root/profile" "$build_path";
 

--- a/sources/server/src/ui/index.html
+++ b/sources/server/src/ui/index.html
@@ -28,7 +28,7 @@
   <link rel="stylesheet" href="styles/ui.css">
 
   <!-- Profile -->
-  <link rel="stylesheet" href="profile/custom/gchart-table.css">
+  <link rel="stylesheet" href="static/custom/gchart-table.css">
 </head>
 <body>
   <header>

--- a/sources/server/src/ui/scripts/main.ts
+++ b/sources/server/src/ui/scripts/main.ts
@@ -35,11 +35,11 @@ require.config({
     app: './app',
 
     // Profile configuration paths
-    static: '/profile',
-    extensions: '/profile/extensions',
-    element: '/profile/require/element',
-    style: '/profile/require/style',
-    visualization: '/profile/require/visualization'
+    static: '/static',
+    extensions: '/static/extensions',
+    element: '/static/require/element',
+    style: '/static/require/style',
+    visualization: '/static/require/visualization'
   },
 
   shim: {


### PR DESCRIPTION
Allows for loading of CSS assets by the absolute paths used within the current IPython profile configuration.

Addresses #326 

Other require plugins tested with change and are still working (i.e., `extensions!`, `element!`)
