### PR TITLE
Adds tracking of execution state within notebook and executing cell UX

### DIFF
--- a/sources/server/src/node/app/kernels/shell.ts
+++ b/sources/server/src/node/app/kernels/shell.ts
@@ -46,8 +46,8 @@ export class ShellChannelClient extends channels.ChannelClient {
 
   /**
    * Sends a code execution request to the kernel.
-   * @param request an execution request
-   * @returns promise that will resolve to an execute reply message upon code execution completing
+   *
+   * @param request An execution request.
    */
   execute (request: app.ExecuteRequest): void {
     // Translate to execute request to the IPython message format and send to the kernel

--- a/sources/server/src/node/app/notebooks/session.ts
+++ b/sources/server/src/node/app/notebooks/session.ts
@@ -238,6 +238,10 @@ export class NotebookSession implements app.INotebookSession {
       cell.source = cellUpdate.source = action.source;
     }
 
+    if (action.state || action.state === '') {
+      cell.state = cellUpdate.state = action.state;
+    }
+
     if (action.outputs) {
       if (action.replaceOutputs) {
         // Simple case, replace the cell's outputs with the output list in the action message.

--- a/sources/server/src/shared/actions.d.ts
+++ b/sources/server/src/shared/actions.d.ts
@@ -137,6 +137,7 @@ declare module app {
         cellId: string;
         source?: string; // cell content string (e.g., code, markdown, etc.)
         prompt?: string;
+        state?: string;
 
         metadata?: app.Map<any>;
         // Flag to indicate whether the metadata dict should be merged with existing metadata

--- a/sources/server/src/shared/cells.ts
+++ b/sources/server/src/shared/cells.ts
@@ -14,9 +14,21 @@
 
 
 /**
- * Cell type string constants
+ * Cell type string constants.
  */
 export var code = 'code';
 export var heading = 'heading';
 export var markdown = 'markdown';
 export var raw = 'raw';
+
+
+/**
+ * Cell states.
+ */
+export var states = {
+  default: 'default',
+  error: 'error',
+  executing: 'executing',
+  pending: 'pending',
+  success: 'success'
+}

--- a/sources/server/src/shared/interfaces.d.ts
+++ b/sources/server/src/shared/interfaces.d.ts
@@ -66,6 +66,7 @@ declare module app {
       outputs?: CellOutput[];
 
       prompt?: string; // Prompt to display (e.g., execution counter value, busy symbol, etc.)
+      state?: string; // 'error' | 'success' | 'executing'
     }
 
 

--- a/sources/server/src/shared/updates.d.ts
+++ b/sources/server/src/shared/updates.d.ts
@@ -130,6 +130,8 @@ declare module app {
 
         source?: string; // The new source string value for the cell.
 
+        state?: string;
+
         outputs?: CellOutput[];
         // Flag determines whether the above list of outputs is appended or replaces existing
         // output list within the cell (false => append; true => replace).

--- a/sources/server/src/ui/scripts/app/common/Constants.ts
+++ b/sources/server/src/ui/scripts/app/common/Constants.ts
@@ -44,6 +44,9 @@ export var layouts = {
 // Note: When using these directive names within templates, the names are expected to be in
 // snake-case; e.g., directiveName:"fooBarBaz" is referred to as <foo-bar-baz /> within
 // an Angular template.
+export var busyIndicator = {
+  directiveName: 'datalabBusyIndicator'
+};
 export var cellOutputViewer = {
   directiveName: 'datalabCellOutputViewer'
 };
@@ -136,6 +139,7 @@ export var scopes = {
   markdownCell: 'markdownCell',
 
   // Generic directives.
+  busyIndicator: 'busyIndicator',
   cellOutputViewer: 'cellOutputViewer',
   cellToolbar: 'cellToolbar',
   codeEditor: 'codeEditor',

--- a/sources/server/src/ui/scripts/app/components/busyindicator/BusyIndicatorDirective.ts
+++ b/sources/server/src/ui/scripts/app/components/busyindicator/BusyIndicatorDirective.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2014 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+/**
+ * Renders a busy indicator.
+ */
+/// <reference path="../../../../../../../../externs/ts/angularjs/angular.d.ts" />
+import logging = require('app/common/Logging');
+import constants = require('app/common/Constants');
+import _app = require('app/App');
+
+var log = logging.getLogger(constants.scopes.busyIndicator);
+
+/**
+ * Busy indicator directive scope typedef.
+ */
+interface BusyIndicatorScope extends ng.IScope {
+  /**
+   * Is context currently busy?
+   */
+  busy: boolean;
+
+  /**
+   * Delay constant in milliseconds.
+   *
+   * Can only be passed as a string with current set of angular constant-binding hooks.
+   */
+  delay: string;
+
+  /**
+   * Enable the busy indicator?
+   */
+  enabled: boolean;
+
+  /**
+   * Should the busy indicator be shown?
+   *
+   * Equivalent to 'enabled' if the delay is zero, but otherwise only becomes true
+   * after the delay has passed and enabled is still true.
+   */
+  show: boolean;
+}
+
+/**
+ * Busy indicator directive controller.
+ */
+class BusyIndicatorController {
+
+  _pendingTimeout: ng.IPromise<any>;
+  _scope: BusyIndicatorScope;
+  _timeout: ng.ITimeoutService;
+
+  static $inject: string[] = ['$scope', '$timeout'];
+
+  /**
+   * Constructor.
+   *
+   * @param scope The directive scope.
+   */
+  constructor (scope: BusyIndicatorScope, timeout: ng.ITimeoutService) {
+    this._pendingTimeout = null;
+    this._scope = scope;
+    this._timeout = timeout;
+
+    this._scope.show = false;
+  }
+
+  /**
+   * Show the busy indicator after a delay.
+   *
+   * @param delay Milliseconds after which the busy indicator should become visible.
+   */
+  showAfter(delay: number) {
+    this._pendingTimeout = this._timeout(() => {
+      this._scope.show = true;
+    }, delay);
+  }
+
+  /**
+   * Hides the busy indicator.
+   */
+  hide() {
+    this._timeout.cancel(this._pendingTimeout);
+    this._scope.$evalAsync(() => {
+      this._scope.show = false;
+    });
+  }
+}
+
+function busyIndicatorDirectiveLink(
+    scope: BusyIndicatorScope,
+    element: ng.IAugmentedJQuery,
+    attrs: ng.IAttributes,
+    controller: BusyIndicatorController)
+    : void {
+
+  var delay = parseInt(attrs['delay']);
+
+  scope.$watch('enabled', (isBusy: any) => {
+    if (isBusy) {
+      controller.showAfter(delay);
+    } else {
+      controller.hide();
+    }
+  });
+};
+
+/**
+ * Creates a directive definition.
+ *
+ * @return An Angular directive definition.
+ */
+function busyIndicatorDirective (): ng.IDirective {
+  return {
+    restrict: 'E',
+    scope: {
+      busy: '=',
+      delay: '@',
+      enabled: '='
+    },
+    templateUrl: constants.scriptPaths.app + '/components/busyindicator/busyindicator.html',
+    replace: true,
+    controller: BusyIndicatorController,
+    link: busyIndicatorDirectiveLink
+  }
+}
+
+_app.registrar.directive(constants.busyIndicator.directiveName, busyIndicatorDirective);
+log.debug('Registered busy indicator directive');

--- a/sources/server/src/ui/scripts/app/components/busyindicator/busyindicator.html
+++ b/sources/server/src/ui/scripts/app/components/busyindicator/busyindicator.html
@@ -1,0 +1,6 @@
+<div class="datalab-busy-indicator row" ng-show="show">
+  <div class="progress">
+    <div class="progress-bar progress-bar-striped"
+      ng-class="{ 'active': busy, 'idle': !busy }"></div>
+  </div>
+</div>

--- a/sources/server/src/ui/scripts/app/components/editorcell/EditorCellDirective.ts
+++ b/sources/server/src/ui/scripts/app/components/editorcell/EditorCellDirective.ts
@@ -20,6 +20,7 @@
  * output content, and disappears if the output content is falsey (undefined/null/empty).
  */
 /// <reference path="../../../../../../../../externs/ts/angularjs/angular.d.ts" />
+/// <amd-dependency path="app/components/busyindicator/BusyIndicatorDirective" />
 /// <amd-dependency path="app/components/celloutputviewer/CellOutputViewerDirective" />
 /// <amd-dependency path="app/components/celltoolbar/CellToolbarDirective" />
 /// <amd-dependency path="app/components/codeeditor/CodeEditorDirective" />
@@ -44,6 +45,7 @@ interface EditorCellScope extends ng.IScope {
   // Internally assigned scope attributes.
   actions?: app.Map<Function>;
   active?: boolean;
+  executing?: boolean;
   keymap?: app.Map<Function>;
   notebook?: app.IClientNotebook;
 }

--- a/sources/server/src/ui/scripts/app/components/editorcell/editorcell.html
+++ b/sources/server/src/ui/scripts/app/components/editorcell/editorcell.html
@@ -31,8 +31,19 @@
     </div>
   </div>
 
+  <!-- Busy indicator shown during code cell execution -->
+  <datalab-busy-indicator
+      ng-if="cell.type == 'code'"
+      delay="5000"
+      busy="cell.state == 'executing'"
+      enabled="cell.state == 'executing' || cell.state == 'pending'">
+  </datalab-busy-indicator>
+
   <!-- Cell output region -->
-  <datalab-cell-output-viewer outputs="cell.outputs"></datalab-cell-output-viewer>
+  <datalab-cell-output-viewer
+      ng-if="cell.type == 'code'"
+      outputs="cell.outputs">
+  </datalab-cell-output-viewer>
 
   <!-- Cell preview region -->
   <div class="datalab-editor-cell-preview-region col-lg-12 col-md-12 col-sm-12 col-xs-12"

--- a/sources/server/src/ui/scripts/app/components/sessions/ClientNotebook.ts
+++ b/sources/server/src/ui/scripts/app/components/sessions/ClientNotebook.ts
@@ -81,19 +81,6 @@ class ClientNotebook implements app.IClientNotebook {
     this._registerEventHandlers();
   }
 
-  /**
-   * Sets the given cell to be active.
-   *
-   * There can only be a single active cell within a notebook at any time; equivalent to the
-   * notion of DOM element focus.
-   *
-   * @param cell The cell to select.
-   */
-  selectCell(cell: app.notebooks.Cell) {
-    this.activeCell = cell;
-  }
-
-
   // TODO(bryantd): decide if we want a local "predictive modification" for the various insert functions
   // to make the UI more responsive given the latency in getting back a server response for any of the
   // notebook modification operations (e.g., add/delete/move cell).
@@ -312,6 +299,18 @@ class ClientNotebook implements app.IClientNotebook {
   }
 
   /**
+   * Sets the given cell to be active.
+   *
+   * There can only be a single active cell within a notebook at any time; equivalent to the
+   * notion of DOM element focus.
+   *
+   * @param cell The cell to select.
+   */
+  selectCell(cell: app.notebooks.Cell) {
+    this.activeCell = cell;
+  }
+
+  /**
    * Selects the specified cell.
    *
    * @param worksheetId The id of the worksheet to select.
@@ -443,6 +442,11 @@ class ClientNotebook implements app.IClientNotebook {
     // Update the source content if it was provided in the update.
     if (update.source || update.source === '') {
       cell.source = update.source;
+    }
+
+    // Update the cell state if it was provided in the update.
+    if (update.state || update.state == '') {
+      cell.state = update.state;
     }
 
     // Add any outputs provided in the update.

--- a/sources/server/src/ui/styles/editor.css
+++ b/sources/server/src/ui/styles/editor.css
@@ -185,11 +185,25 @@
   position: fixed;
   width: 100%;
   /* Cause the toolbar to be on top of the other page content.
-  
+
     CodeMirror creates elements on z-index=2, so this value must be at least 3 in order to avoid
     notebook editor cell content superseding the editor toolbar.
   */
   z-index: 3;
+}
+
+.datalab-busy-indicator .progress {
+  height: 6px;
+  width: 250px;
+  margin-left: 35px;
+}
+
+.datalab-busy-indicator .progress-bar {
+  width: 100%;
+}
+
+.datalab-busy-indicator .progress-bar.idle {
+  background-color: #ccc;
 }
 
 .datalab-notebook-title {


### PR DESCRIPTION
- Adds kernel execution queue to session to track the state of individual execute requests
- Adds cell state updates (error/success/executing) that are published to clients
- Adds busy indicator directive that appears after 5s delay if cell is still executing
