### PR TITLE
Fixed issue #480, gcp library installer now working

### DIFF
--- a/sources/lib/api/setup.py
+++ b/sources/lib/api/setup.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from distutils.core import setup
+from setuptools import setup
 
 # TODO(nikhilko):
 # Fill in various other bits that can/should be specified once we have them.
@@ -35,7 +35,7 @@ setup(
               'gcp.storage',
              ],
     description='Google Cloud APIs for data analysis scenarios.',
-    requires=['futures',
+    install_requires=['futures',
               'httplib2',
               'IPython',
               'oauth2client',


### PR DESCRIPTION
Changed distutils.core to setuptools, and adapted used keywords.

Adapted from: http://stackoverflow.com/questions/9810603/adding-install-requires-to-setup-py-when-making-a-python-package
