### PR TITLE
Deployable UDFs.

### DIFF
--- a/content/ipython/notebooks/BigQuery - JavaScript UDFs.ipynb
+++ b/content/ipython/notebooks/BigQuery - JavaScript UDFs.ipynb
@@ -43,10 +43,10 @@
      "data": {
       "text/html": [
        "\n",
-       "    <div class=\"bqtv\" id=\"bqtv_144226439559\"></div>\n",
-       "    <div><br />job_71pgkONM5qcCddnOasQ5etX2-Ws<br />rows: 10</div>\n",
+       "    <div class=\"bqtv\" id=\"1_144235468450\"></div>\n",
+       "    <div><br />job_Zsn3Ey2Pi1BZ4GLLirfcck-c3tg (1.2s, cached)<br />rows: 10</div>\n",
        "    <script>\n",
-       "      require(['extensions/charting', 'element!bqtv_144226439559', 'style!/static/extensions/charting.css'],\n",
+       "      require(['extensions/charting', 'element!1_144235468450', 'style!/static/extensions/charting.css'],\n",
        "        function(charts, dom) {\n",
        "          charts.render(dom,\n",
        "            {\n",
@@ -136,9 +136,9 @@
      "data": {
       "text/html": [
        "\n",
-       "    <div class=\"bqtv\" id=\"udf_144226439560\"></div>\n",
+       "    <div class=\"bqtv\" id=\"2_144235468516\"></div>\n",
        "    <script>\n",
-       "      require(['extensions/bigquery', 'element!udf_144226439560'],\n",
+       "      require(['extensions/bigquery', 'element!2_144235468516'],\n",
        "          function(bq, dom) {\n",
        "              bq.evaluateUDF(dom, /**\n",
        " * @param {{word: string, corpus: string, word_count: integer}} r\n",
@@ -156,7 +156,7 @@
        "    "
       ],
       "text/plain": [
-       "<gcp.bigquery._udf.FunctionEvaluation at 0x7fc1712218d0>"
+       "<gcp.bigquery._udf.FunctionEvaluation at 0x7f55219d9b10>"
       ]
      },
      "execution_count": 3,
@@ -276,15 +276,15 @@
      "data": {
       "text/html": [
        "\n",
-       "    <div class=\"bqtv\" id=\"bqtv_144226439561\"></div>\n",
-       "    <div><br />job_3cILMfzUfgaIk4fcHQWU_L7nQYY<br />rows: 100</div>\n",
+       "    <div class=\"bqtv\" id=\"3_144235470307\"></div>\n",
+       "    <div><br />job_P1lOFq1TGjS-47CtH2mO-Bgb1pk (17.2s,     1MB processed)<br />rows: 100</div>\n",
        "    <script>\n",
-       "      require(['extensions/charting', 'element!bqtv_144226439561'],\n",
+       "      require(['extensions/charting', 'element!3_144235470307'],\n",
        "        function(charts, dom) {\n",
        "          charts.render(dom,\n",
        "            {\n",
        "              chartStyle:\"paged_table\",\n",
-       "              dataName:\"data-studio-team:_22cae82edc27e9be9a02c50fe9837efda6b0471d.anonev_tDE3REKvHrHQtG_62lMKKLVRzHI\",\n",
+       "              dataName:\"data-studio-team:_22cae82edc27e9be9a02c50fe9837efda6b0471d.anonev_ZPAm5dfZc4_tvx_pVXIRD327mYA\",\n",
        "              fields:\"word,count\",\n",
        "              totalRows:100,\n",
        "              rowsPerPage:25,\n",

--- a/sources/lib/datalab/tests/bigquery_tests.py
+++ b/sources/lib/datalab/tests/bigquery_tests.py
@@ -51,7 +51,7 @@ function(r, emitFn) {
 """
     mock_create_api.return_value = self._create_api()
     mock_notebook_environment.return_value = env
-    gcp.datalab._bigquery._udf_cell({'name': 'word_filter'}, cell_body)
+    gcp.datalab._bigquery._udf_cell({'module': 'word_filter'}, cell_body)
     udf = env['word_filter']
     self.assertIsNotNone(udf)
     self.assertEquals('word_filter', udf._name)


### PR DESCRIPTION
Different approach to other PR:

We now add any UDF function calls to the resolution environment when expanding
a deployable pipeline query.

This also fixes an issue with argument expansion that was missed when we changed
query() to use kwargs.

Change --name to --module but not actually creating modules; it's just syntax.
