### PR TITLE
Execution of pipelines and YAML/JSON configs.

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -63,6 +63,7 @@ RUN pip install -U \
     pip install -U ggplot==0.6.5 && \
     pip install -U seaborn==0.6.0 && \
     pip install -U notebook==4.0.2 && \
+    pip install -U PyYAML==3.11 && \
     easy_install pip && \
     find /usr/local/lib/python2.7 -type d -name tests | xargs rm -rf
 

--- a/containers/datalab/content/license.txt
+++ b/containers/datalab/content/license.txt
@@ -4552,3 +4552,26 @@ Redistributions in binary form must reproduce the above copyright notice, this l
 Neither the name of the Jupyter Development Team nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+""""
+PyYAML
+""""
+Copyright (c) 2006 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/content/ipython/notebooks/BigQuery - Parameterized Queries.ipynb
+++ b/content/ipython/notebooks/BigQuery - Parameterized Queries.ipynb
@@ -51,10 +51,10 @@
      "data": {
       "text/html": [
        "\n",
-       "    <div class=\"bqtv\" id=\"bqtv_144226448516\"></div>\n",
-       "    <div><br />job_rBdcF3G97iFhEch8ObhdHrDtuDE<br />rows: 5</div>\n",
+       "    <div class=\"bqtv\" id=\"1_144246396381\"></div>\n",
+       "    <div><br />job_4lOBPP9v1p13KPQ3C3Lq14f9b1s (1.8s, cached)<br />rows: 5</div>\n",
        "    <script>\n",
-       "      require(['extensions/charting', 'element!bqtv_144226448516', 'style!/static/extensions/charting.css'],\n",
+       "      require(['extensions/charting', 'element!1_144246396381', 'style!/static/extensions/charting.css'],\n",
        "        function(charts, dom) {\n",
        "          charts.render(dom,\n",
        "            {\n",
@@ -92,10 +92,10 @@
      "data": {
       "text/html": [
        "\n",
-       "    <div class=\"bqtv\" id=\"bqtv_144226448517\"></div>\n",
-       "    <div><br />job_axuRyfx-iMEL4zHw5OTaOUvSc4I<br />rows: 3</div>\n",
+       "    <div class=\"bqtv\" id=\"2_144246396758\"></div>\n",
+       "    <div><br />job_Jew4AVhof1HRfQW9vN6EYKo17mI (1.6s, cached)<br />rows: 3</div>\n",
        "    <script>\n",
-       "      require(['extensions/charting', 'element!bqtv_144226448517'],\n",
+       "      require(['extensions/charting', 'element!2_144246396758'],\n",
        "        function(charts, dom) {\n",
        "          charts.render(dom,\n",
        "            {\n",
@@ -176,7 +176,7 @@
    "source": [
     "The queries above are just plain SQL queries. They are not bound to any particular SQL implementation. In order to use the SQL, we need to identify a SQL implementation as the executor. Let's use BigQuery as the executor since the data we are working with is in BigQuery.\n",
     "\n",
-    "As a first step, let's see the expanded query that would get executed - first with default and then with a non-default value. Note that single line syntax is %bigquery while multi-line cells use %%bigquery following the IPython syntax."
+    "As a first step, let's see the expanded query that would get executed - first with default and then with a non-default value. Note that single line syntax is %bigquery while multi-line cells use %%bigquery following the IPython syntax. When using non-default values we can use either JSON or YAML to specify the overridden values; in our example we are using JSON:"
    ]
   },
   {
@@ -202,11 +202,11 @@
      "data": {
       "text/html": [
        "\n",
-       "    <p>Dry run information: 10.5MB to process, results not cached</p>\n",
+       "    <p>Dry run information:    10MB to process, results not cached</p>\n",
        "    "
       ],
       "text/plain": [
-       "<gcp.bigquery._query_stats.QueryStats instance at 0x7fe51b6afb48>"
+       "<gcp.bigquery._query_stats.QueryStats instance at 0x7fa3e7303320>"
       ]
      },
      "execution_count": 5,
@@ -231,7 +231,7 @@
      "text": [
       "SELECT status, count(status) statcount\n",
       "FROM [cloud-datalab:sampledata.requestlogs_20140615]\n",
-      "WHERE endpoint = \"Admin\"\n",
+      "WHERE endpoint = \"Other\"\n",
       "AND status > 399\n",
       "GROUP BY status\n",
       "ORDER BY status\n"
@@ -241,11 +241,11 @@
      "data": {
       "text/html": [
        "\n",
-       "    <p>Dry run information: 10.5MB to process, results not cached</p>\n",
+       "    <p>Dry run information:    10MB to process, results cached</p>\n",
        "    "
       ],
       "text/plain": [
-       "<gcp.bigquery._query_stats.QueryStats instance at 0x7fe51b6a9ef0>"
+       "<gcp.bigquery._query_stats.QueryStats instance at 0x7fa3e77876c8>"
       ]
      },
      "execution_count": 6,
@@ -255,8 +255,9 @@
    ],
    "source": [
     "%%bigquery pipeline --sql StatusQueries.ErrorCountByEndpt \n",
-    "endpt = 'Other'\n",
-    "stat = 404"
+    "{\n",
+    "  \"endpt\": \"Other\"\n",
+    "}"
    ]
   },
   {
@@ -475,10 +476,10 @@
      "data": {
       "text/html": [
        "\n",
-       "    <div class=\"bqtv\" id=\"bqtv_144226448518\"></div>\n",
-       "    <div><br />job_s5lKum0dd2xUjh4TbgbAl3hPXhU<br />rows: 1</div>\n",
+       "    <div class=\"bqtv\" id=\"3_144246397618\"></div>\n",
+       "    <div><br />job_cfFFqqYRJRc7aHjwsLNSCCtNmUA (1.5s, cached)<br />rows: 1</div>\n",
        "    <script>\n",
-       "      require(['extensions/charting', 'element!bqtv_144226448518'],\n",
+       "      require(['extensions/charting', 'element!3_144246397618'],\n",
        "        function(charts, dom) {\n",
        "          charts.render(dom,\n",
        "            {\n",

--- a/sources/web/datalab/static/datalab.txt
+++ b/sources/web/datalab/static/datalab.txt
@@ -52,6 +52,7 @@ cat /datalab/license.txt
 - statsmodels [https://pypi.python.org/pypi/statsmodels]
 - sympy [https://pypi.python.org/pypi/sympy]
 - tornado [http://www.tornadoweb.org/en/stable/]
+- PyYAML [https://pypi.python.org/pypi/PyYAML]
 
 ## Node.js Modules
 - bunyan [https://www.npmjs.com/package/bunyan]


### PR DESCRIPTION
Add validate/execute/deploy actions to bigquery pipeline and change variable specs to be JSON/YAML.

Change config blocks for cell magics to be JSON or YAML rather than Python code.

For now I am not making variables for in an 'args' subsection of the config block.
It may be a good idea to do this to ensure they are namespaced separately from other
config values, but right now there are no other config values, and arguably it may be
cleaner to put other config values in a subsection rather than the other way around.
