### PR TITLE
Changed table viewer metadata display to be one line.

### DIFF
--- a/sources/lib/datalab/gcp/datalab/_chart.py
+++ b/sources/lib/datalab/gcp/datalab/_chart.py
@@ -68,8 +68,9 @@ def _chart_cell(args, cell):
   chart_type = args['chart']
   count = 25 if chart_type == 'paged_table' else -1
   data, _ = _utils.get_data(source, fields, 0, count)
+
   return IPython.core.display.HTML(
-    _HTML_TEMPLATE % (div_id, div_id, chart_type, source, fields,
+    _HTML_TEMPLATE % (div_id, div_id, chart_type, _utils.get_data_source_index(source), fields,
                       json.dumps(chart_options, cls=gcp._util.JSONEncoder),
                       json.dumps(data, cls=gcp._util.JSONEncoder)))
 
@@ -78,7 +79,7 @@ def _chart_cell(args, cell):
 def _get_chart_data(line):
   try:
     args = line.strip().split()
-    source = args[0]
+    source = _utils._data_sources[int(args[0])]
     fields = args[1]
     first_row = int(args[2]) if len(args) > 2 else 0
     count = int(args[3]) if len(args) > 3 else -1

--- a/sources/lib/datalab/gcp/datalab/_utils.py
+++ b/sources/lib/datalab/gcp/datalab/_utils.py
@@ -247,3 +247,15 @@ def parse_config(config, env):
   replace_vars(config, env)
   return config
 
+
+# For chart and table HTML viewers, we use a list of table names and reference
+# instead the indices in the HTML, so as not to include things like projectID, etc,
+# in the HTML.
+
+_data_sources = []
+
+def get_data_source_index(name):
+  if name not in _data_sources:
+    _data_sources.append(name)
+  return _data_sources.index(name)
+

--- a/sources/lib/datalab/tests/chart_tests.py
+++ b/sources/lib/datalab/tests/chart_tests.py
@@ -51,15 +51,16 @@ class TestCases(unittest.TestCase):
       {'country': 'AU', 'quantity': 25}
     ]
     mock_get_item.return_value = t
-    data = gcp.datalab._chart._get_chart_data('t country 1 1')
+    ds = gcp.datalab._utils.get_data_source_index('t')
+    data = gcp.datalab._chart._get_chart_data('%d country 1 1' % ds)
     self.assertEquals('{"data": {"rows": [{"c": [{"v": "ZA"}]}], ' +
                       '"cols": [{"type": "string", "id": "country", "label": "country"}]}}', data)
 
-    data = gcp.datalab._chart._get_chart_data('t country 6 1')
+    data = gcp.datalab._chart._get_chart_data('%d country 6 1' % ds)
     self.assertEquals('{"data": {"rows": [], ' +
                       '"cols": [{"type": "string", "id": "country", "label": "country"}]}}', data)
 
-    data = gcp.datalab._chart._get_chart_data('t country 2 0')
+    data = gcp.datalab._chart._get_chart_data('%d country 2 0' % ds)
     self.assertEquals('{"data": {"rows": [], ' +
                       '"cols": [{"type": "string", "id": "country", "label": "country"}]}}', data)
 


### PR DESCRIPTION
Also, use a list for chart/table data sources so we have a level of indirection
that allows us to strip the table names out of the javascript.

And put each of our generated HTML blocks in a div rather than a div side-by-side with a script, just as it is a bit cleaner to wrap them like that.

Issue #558
