### PR TITLE
Fix variable expansion in cell config blocks.

### DIFF
--- a/sources/lib/datalab/gcp/datalab/_utils.py
+++ b/sources/lib/datalab/gcp/datalab/_utils.py
@@ -214,7 +214,7 @@ def parse_config(config, env):
     # Using len() and v[0] instead of startswith makes this Unicode-safe.
     if v[0] == '$':
       v = v[1:]
-      if len(v) == 0 or v[0] == '$':
+      if len(v) and v[0] != '$':
         if v in env:
           v = env[v]
         else:


### PR DESCRIPTION
Logic was back to front. Seems hard to believe I didn't catch this.
I wonder if there was an else- at some point.

I added a --verbose option to dryrun to show the SQL as it is useful
to debug this kind of thing.

Issue #605
