### PR TITLE
Notebook test framework.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ test
 *.pyc
 *.idea
 *.iml
+*.ipynb.yaml
 
 # For building the server incrementally from an IDE like Eclipse it can be useful to create
 # the two symlinks below to point to sources/server/src/shared, but we don't want them

--- a/containers/datalab/build-test.sh
+++ b/containers/datalab/build-test.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds the Google Cloud DataLab docker image with vcrpy and urllib
+# added. This allows for network layer mocking and much faster test
+# execution, but is not required for the test framework to work.
+
+# Create a versioned Dockerfile based on current date and git commit hash
+VERSION=`date +%Y%m%d`
+VERSION_SUBSTITUTION="s/_version_/0.5.$VERSION/"
+
+COMMIT=`git log --pretty=format:'%H' -n 1`
+COMMIT_SUBSTITUTION="s/_commit_/$COMMIT/"
+
+cat Dockerfile.in | sed $VERSION_SUBSTITUTION | sed $COMMIT_SUBSTITUTION > Dockerfile
+echo "RUN pip install -U requests==2.8.1 && pip install -U vcrpy==1.7.4" >> Dockerfile
+
+# Copy build outputs as a dependency of the Dockerfile
+rsync -avp ../../build/ build
+
+# Build the docker image
+docker build -t datalab-test .
+
+# Finally cleanup
+rm -rf build
+rm Dockerfile
+

--- a/tools/test.js
+++ b/tools/test.js
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+// This code is generic and can be factored out into a separate Jupyter testing project.
+
+function get_cell_contents() {
+  var cells = IPython.notebook.get_cells();
+  var outputs = []
+  for (var cellindex in cells) {
+    var cell = cells[cellindex];
+    if (cell.cell_type == 'code') {
+      var cell_outputs = cell.output_area.outputs;
+      var scrubbed = [];
+      for (var outputindex in cell_outputs) {
+        var output = cell_outputs[outputindex].data;
+        var scrubbed_data = {};
+        for (var mimetype in output) {
+          scrubbed_data[mimetype] = scrubber(mimetype, output[mimetype]);
+        }
+        scrubbed.push(scrubbed_data);
+      }
+      outputs.push({outputs: scrubbed, element: cell.output_area.element});
+    } else {
+      outputs.push({outputs: null});
+    }
+  }
+  return outputs;
+}
+
+function setStatus(status) {
+  e = document.createElement('div');
+  e.id = 'test_status'
+  e.textContent = status;
+  document.body.appendChild(e);
+}
+
+function validate(old_outputs, new_outputs) {
+  var failed = false;
+  console.log('Validating...');
+  var result = '';
+  if (old_outputs.length != new_outputs.length) {
+    var msg = 'Old output had ' + old_outputs.length + ' entries but new output has ' +
+        new_outputs.length + ' entries';
+    console.log('FAIL: ' + msg);
+    result += '#' + msg;
+    failed = true;
+  }
+  for (var i in new_outputs) {
+    var cellfailed = false;
+    var old_output = old_outputs[i];
+    var new_output = new_outputs[i];
+    var element = new_output.element;
+    if (old_output.outputs == null) {
+      if (new_output.outputs != null) {
+        var msg = 'Cell ' + i + ' had no outputs but now has ' + new_output.outputs.length;
+        console.log('FAIL: ' + msg);
+        result += '#' + msg;
+        cellfailed = true;
+      }
+    } else if (new_output.outputs == null) {
+      console.log('FAIL: Cell ' + i + ' now has no code output but did before');
+      cellfailed = true;
+    } else if (old_output.outputs.length != new_output.outputs.length) {
+      var msg = 'Cell ' + i + ' had ' + old_output.outputs.length + ' outputs but now has ' +
+          new_output.outputs.length;
+      console.log('FAIL: ' + msg);
+      result += '#' + msg;
+      cellfailed = true;
+    }
+    if (cellfailed) {
+      result += '#' + i + ':F';
+    } else {
+      for (var j in new_output.outputs) {
+        var old_set = old_output.outputs[j];
+        var new_set = new_output.outputs[j];
+        if (old_set.length != new_set.length) {
+          cellfailed = true;
+          result += '#' + i + ':F';
+          break;
+        }
+        for (var mt in new_set) {
+          if (new_set[mt] != old_set[mt]) {
+            console.log('FAIL: Failed at ' + i + ': ' + mt + '\nExpected: ' + old_set[mt] +
+                '\nbut got: ' + new_set[mt]);
+            cellfailed = true;
+            result += '#' + i + '/' + mt + ':F';
+            break;
+          }
+        }
+      }
+    }
+    if (cellfailed) {
+      failed = true;
+    }
+    if (new_output.element) {
+      if (cellfailed) {
+        new_output.element[0].style.backgroundColor="red";
+      } else {
+        new_output.element[0].style.backgroundColor="green";
+      }
+    }
+  }
+  if (failed) {
+    setStatus('FAIL' + result);
+  } else {
+    setStatus('PASS');
+  }
+}
+
+function getParameter(name) {
+  var match = RegExp('[?&]' + name + '=([^&]*)').exec(window.location.search);
+  return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
+}
+
+function checkIfDone(old_outputs) {
+  if (IPython.notebook.kernel_busy) {
+    console.log('Busy');
+    setTimeout(function() {
+      checkIfDone(old_outputs);
+    }, 1000);
+  } else {
+    console.log('Finished execution');
+    var new_outputs = get_cell_contents();
+    if (getParameter('vcr') == '1') {
+      IPython.notebook.kernel.execute("cassette.__exit__(None, None, None)\n")
+    }
+    validate(old_outputs, new_outputs);
+  }
+}
+
+function runNotebook() {
+  if (IPython.notebook.kernel && IPython.notebook.kernel.is_connected()) {
+    var old_outputs = get_cell_contents();
+    IPython.notebook.clear_all_output();
+    console.log('Starting execution');
+    if (getParameter('vcr') == '1') {
+      IPython.notebook.kernel.execute(
+          "import vcr\n" +
+          "import re\n" +
+          "\n" +
+          window.vcr_matchers +
+          "\n" +
+          "cassette_file = '" + IPython.notebook.notebook_path + ".yaml'\n" +
+          "myvcr = vcr.VCR()\n" +
+          "vcr_matcher_register(myvcr)\n" +
+          "cassette = myvcr.use_cassette(cassette_file)\n" +
+          "cassette.__enter__()\n")
+    }
+    
+    IPython.notebook.execute_all_cells();
+    setTimeout(function() {
+      checkIfDone(old_outputs);
+    }, 1000);
+  } else {
+    setTimeout(function() {
+      runNotebook();
+    }, 1000);
+  }
+}
+
+function testNotebook() {
+  var pageClass = document.body.className;
+  if (pageClass.indexOf('notebook_app') >= 0) {
+    runNotebook();
+  }
+}
+
+if (!('scrubber' in window)) {
+  window.scrubber = function(mimetype, data) {
+    return data;
+  }
+  window.vcr_matchers = "def vcr_matcher_register(v):\n  pass\n";
+}
+
+require(['base/js/namespace', 'base/js/events', 'base/js/dialog', 'base/js/utils', 'base/js/security'],
+        testNotebook);
+

--- a/tools/test.py
+++ b/tools/test.py
@@ -1,0 +1,146 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# PhantomJS won't install with brew on El Capitan yet.
+# Make sure vcrpy package is installed to use mocked HTTP request/responses,
+# and invoke with a 'vcr' argument. If .ipynb.yaml files exist they will be
+# used; if not they will be created.
+
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.firefox.webdriver import FirefoxProfile
+
+import argparse
+import os
+import re
+import sys
+from threading import Thread
+import time
+import yaml
+
+RED='\033[91m'
+GREEN='\033[92m'
+YELLOW='\033[93m'
+BLUE='\033[94m'
+END='\033[0m'
+
+
+def run_notebook_test(test, notebook, br, results, testscript):
+  if testscript:
+    br.execute_script(testscript)
+  result = []
+  try:
+    element = WebDriverWait(br, 240).until(
+        EC.presence_of_element_located((By.ID, "test_status"))
+    )
+    parts = []
+    ignore = test['ignore'] if 'ignore' in test else []
+    for part in element.text.split('#'):
+      if part == 'FAIL' or part == 'PASS':
+        continue
+      if len(ignore):
+        m = re.match(r'^([0-9]+)[/:].*', part)
+        if m and int(m.group(1)) in ignore:
+          continue
+        m = re.match(r'^Cell ([0-9]+) .*', part)
+        if m and int(m.group(1)) in ignore:
+          continue
+      parts.append(part)
+
+    actuals = '#'.join(sorted(parts))
+    expect = []
+    if 'expect' in test and len(test['expect']):
+      expect.extend(test['expect'])
+    expectations = '#'.join(sorted(expect))
+
+    if actuals == expectations:
+      result.append('%s%s: pass%s' % (GREEN, notebook, END))
+      br.quit()
+    else:
+      result.append('%s%s: fail%s' % (RED, notebook, END))
+      result.append('%sExpected: %s%s' % (BLUE, expectations, END))
+      result.append('%s  Actual: %s%s' % (YELLOW,  actuals, END))
+      # We leave this one open
+  except Exception as e:
+    result.append(e.message)
+    result.append('%s: timed out' % notebook)
+    br.quit()
+  results[notebook] = result
+
+
+def run_tests(url_base='http://localhost:8081', tests=[], vcr=False, profile=None, testscript=None):
+  threads = []
+  results = {}
+
+  for test in tests:
+    if 'disabled' in test and test['disabled']:
+      continue
+
+    # We create each browser sequentially as doing it in parallel can cause the 
+    # tests to be flaky
+    notebook = test['notebook']
+
+    # Load the notebook
+    ffprofile = None
+    if profile:
+      ffprofile = FirefoxProfile(profile)
+    br = webdriver.Firefox(ffprofile)
+    uri = url_base + '/notebooks/%s' % (notebook.replace(' ', '%20'))
+    if vcr:
+      uri += '?vcr=1'
+    br.get(uri)
+
+    # Kludge; we need a better way to know notebook is ready
+    br.find_element_by_tag_name('html')
+
+    t = Thread(target=run_notebook_test, args=[test, notebook, br, results, testscript])
+    threads.append(t)
+    t.start()
+
+  for t in threads:
+    t.join()
+
+  for result in results.values():
+    print '\n'.join(result)
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser('tests')
+  parser.add_argument('--base', default='http://localhost:8081', help='Base URL for Datalab instance')
+  parser.add_argument('--tests', default='test.yaml', help='YAML file containing test specifications')
+
+  # If testing a deployment we need an authorized account so don't want to use an anonymous profile.
+  # The profile must be specified here. On a Mac if you have a single profile, this should work:
+  #
+  #     --profile="`echo ~/Library/Application\ Support/Firefox/Profiles/*`"
+  #
+  parser.add_argument('--profile', help='profile to use; needed for non-local testing for authentication')
+
+  parser.add_argument('--vcr', action='store_true',
+      help='If set, record/replay network requests/responses.\n' + 
+          'Requires vcr and requests Python packages to be available in notebook environment.')
+
+  args = parser.parse_args()
+  with open(args.tests) as f:
+    tests = yaml.load(f)
+    testscrubber = ''
+    if os.path.exists('test_scrubber.js'):
+      with open('test_scrubber.js') as tf:
+        testscrubber = tf.read()
+    with open('test.js') as tf:
+      testscript = '{' + testscrubber + '\n' + tf.read() + '}'
+      
+    run_tests(args.base, tests, args.vcr, args.profile, testscript)
+

--- a/tools/test.yaml
+++ b/tools/test.yaml
@@ -1,0 +1,126 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Each entry should consist of a 'notebook' value with the relative
+# path to the notebook, and optional boolean 'disabled' to disable
+# the test completely, an optional 'ignore' list with the indices of
+# cells whose failure is expected and should not cause the overall
+# test to fail, and an optional 'expect' list of expected cell failures
+# for specific MIME types, useful for if the cell is expected to pass 
+# but one of the MIME output types is problematic.
+
+- notebook: datalab/intro/Introduction to Notebooks.ipynb
+
+- notebook: datalab/intro/Using Datalab - Accessing Cloud Data.ipynb
+  ignore:
+  - 4
+  - 7  # Because the cells are not executed in saved notebook
+
+- notebook: datalab/intro/Using Datalab - Managing Notebooks with Git.ipynb
+
+- notebook: datalab/samples/Anomaly Detection in HTTP Logs.ipynb
+  # These should not be needed but the notebook is out-of-date.
+  expect:
+  - 3/text/html:F
+  - 6/text/html:F
+  - 9/text/html:F
+
+- notebook: datalab/samples/Conversion Analysis with Google Analytics Data.ipynb
+  # These should not be needed but the notebook is out-of-date.
+  expect:
+  - 5/text/html:F
+  - 7/text/html:F
+  - 10/text/html:F
+
+- notebook: datalab/samples/Exploring Genomics Data.ipynb
+  # These should not be needed but the notebook is out-of-date.
+  expect:
+  - 8/text/html:F
+  - 14/text/html:F
+  - 17/text/html:F
+
+- notebook: datalab/samples/Programming Language Correlation.ipynb
+  # These should not be needed but the notebook is out-of-date.
+  expect:
+  - 8/text/html:F
+  - 13/text/html:F
+  # These are subject to changing data.
+  ignore:
+  - 14
+  - 19
+  - 22
+  - 25
+  - 27
+  - 31
+
+- notebook: datalab/tutorials/BigQuery/BigQuery APIs.ipynb
+  # These should not be needed but the notebook is out-of-date.
+  expect:
+  - 4/text/html:F
+  - 7/text/html:F
+  - 13/text/html:F
+  ignore:
+  - 24  # As it is scrubbed in saved notebook.
+
+- notebook: datalab/tutorials/BigQuery/BigQuery Commands.ipynb
+  # These should not be needed but the notebook is out-of-date.
+  expect:
+  - 6/text/html:F
+  - 7/text/html:F
+  - 14/text/html:F
+  - 15/text/html:F
+  - 17/text/html:F
+  - 19/text/html:F
+
+- notebook: datalab/tutorials/BigQuery/Hello BigQuery.ipynb
+  ignore:
+  - 2  # As it is scrubbed in saved notebook.
+
+- notebook: datalab/tutorials/BigQuery/Importing and Exporting Data.ipynb
+  ignore:
+  - 12  # Because output order can vary.
+  - 15  # Because we scrub it.
+  - 18  # Because it has a GCS timestamp that varies.
+
+# This one is currently broken as it defines a module 'requests' that conflicts with requests
+- notebook: datalab/tutorials/BigQuery/SQL and Pandas DataFrames.ipynb
+  disabled: true
+
+- notebook: datalab/tutorials/BigQuery/SQL Parameters.ipynb
+  # These should not be needed but the notebook is out-of-date.
+  expect:
+  - 2/text/html:F
+  - 3/text/html:F
+  - 7/text/html:F
+  - 10/text/html:F
+  - 13/text/html:F
+  - 18/text/html:F
+
+- notebook: datalab/tutorials/BigQuery/SQL Query Composition.ipynb
+  # These should not be needed but the notebook is out-of-date.
+  expect:
+  - 4/text/html:F
+  - 5/text/html:F
+  - 8/text/html:F
+  - 15/text/html:F
+
+- notebook: datalab/tutorials/Data/Interactive Charts with Google Charting APIs.ipynb
+
+- notebook: datalab/tutorials/Storage/Storage APIs.ipynb
+  ignore:
+  - 4  # As it is scrubbed
+
+- notebook: datalab/tutorials/Storage/Storage Commands.ipynb
+  disabled: true  # This notebook is very out-of-date
+

--- a/tools/test_scrubber.js
+++ b/tools/test_scrubber.js
@@ -1,0 +1,40 @@
+// Google Cloud Datalab-specific cell output scrubbing for test framework.
+
+window.scrubber = function(mimetype, data) {
+  if (data != undefined) {
+    data = data.
+      // Scrub job IDs.
+      replace(/job_[A-Za-z0-9_\-]+/g, "job_").
+      // Remove DOM element IDs in require.
+      replace(/\element\![0-9_]+/g, "element!").
+      // and other DOM ids.
+      replace(/\"[0-9][0-9]?_[0-9]+\"/g, "id").
+      // remove memory addresses.
+      replace(/ at 0x[0-9abcdef]+>/g, ">").
+      // Remove chart data source cache indices.
+      replace(/dataName:\"[0-9]+\"/g, "dataName").
+      // Remove query job metadata except # rows.
+      replace(/{"rows": \[.*\]}\);/gm, "ROWS);").
+      replace(/<br \/>\(rows: ([0-9]+),[^<]*</g, "<br />(rows: $1)<");
+    // We also want to scrub table cell contents inside tbody but not thead.
+    // That may be hard with regexp so split first.
+    var start = data.indexOf('<tbody>');
+    if (start >= 0) {
+        data = data.substring(0, start) +
+            data.substring(start).replace(/<th>[^<]*<\/th>/g, "<TH>").replace(/<td>[^<]*<\/td>/g, "<TD>");
+    }
+  }
+  return data;
+}
+
+window.vcr_matchers = 
+  "def scrub_project(uri):\n" +
+  "  return re.sub(r'/v2/projects/[^/]*/', '/v2/projects//', uri)\n" +
+  "\n" +
+  "def datalab_matcher(r1, r2):\n" +
+  "  return scrub_project(r1.uri) == scrub_project(r2.uri)\n" +
+  "\n" +
+  "def vcr_matcher_register(v):\n" +
+  "  print 'VCR register'\n" +
+  "  v.register_matcher('datalab', datalab_matcher)\n" +
+  "  v.match_on = ['datalab']\n";


### PR DESCRIPTION
This comprises an autotesting script, Selenium driver and framework for handling
exceptions (apparent failures that are expected).

Some notebooks are changed, to fix text/plain sections for query results and where
tables are now output as lists. A few other notebooks that are out-of-date have
the config file set up to accept them as-is for now.

The test.py script can be invoked with a 'vcr' argument in which case HTTP calls
will be recorded to YAML files or played back from those files if they already
exist, which speeds up test execution by an order of magnitude. To use this
feature a special test version of the container is required; it is recommended that
this be used locally only (so there are build and run scripts for this but no stage
or publish scripts).

To use against a cloud deployment a --profile argumemt must be given so that the
browser opens with the user's authenticated profile.

Tests are specified in a YAML file. Entire notebooks can be ignore, or individual
cells. For even finer control individual MIME-type outputs can be used on a
particular cell.
