### PR TITLE
Port to be both Py2 and Py3 compatible.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@
 .idea
 MANIFEST
 build
-dist
 .coverage
-
+dist

--- a/datalab/bigquery/__init__.py
+++ b/datalab/bigquery/__init__.py
@@ -11,21 +11,22 @@
 # the License.
 
 """Google Cloud Platform library - BigQuery Functionality."""
+from __future__ import absolute_import
 
-from _csv_options import CSVOptions
-from _dataset import Dataset, Datasets
-from _federated_table import FederatedTable
-from _job import Job
-from _query import Query
-from _query_job import QueryJob
-from _query_results_table import QueryResultsTable
-from _query_stats import QueryStats
-from _sampling import Sampling
-from _schema import Schema
-from _table import Table, TableMetadata
-from _udf import UDF
-from _utils import TableName, DatasetName
-from _view import View
+from ._csv_options import CSVOptions
+from ._dataset import Dataset, Datasets
+from ._federated_table import FederatedTable
+from ._job import Job
+from ._query import Query
+from ._query_job import QueryJob
+from ._query_results_table import QueryResultsTable
+from ._query_stats import QueryStats
+from ._sampling import Sampling
+from ._schema import Schema
+from ._table import Table, TableMetadata
+from ._udf import UDF
+from ._utils import TableName, DatasetName
+from ._view import View
 
 
 def wait_any(jobs, timeout=None):
@@ -43,7 +44,7 @@ def wait_any(jobs, timeout=None):
 
 
 def wait_all(jobs, timeout=None):
-  """ Return when at all of the specified jobs have completed or timeout expires.
+  """ Return when all of the specified jobs have completed or timeout expires.
 
   Args:
     jobs: a single Job or list of Jobs to wait on.

--- a/datalab/bigquery/_api.py
+++ b/datalab/bigquery/_api.py
@@ -11,6 +11,10 @@
 # the License.
 
 """Implements BigQuery HTTP API wrapper."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from past.builtins import basestring
+from builtins import object
 
 import datalab.utils
 
@@ -88,32 +92,32 @@ class Api(object):
     if append:
       write_disposition = 'WRITE_APPEND'
     data = {
-      'kind': 'bigquery#job',
-      'configuration': {
-        'load': {
-          'sourceUris': source,
-          'destinationTable': {
-            'projectId': table_name.project_id,
-            'datasetId': table_name.dataset_id,
-            'tableId': table_name.table_id
-          },
-          'createDisposition': 'CREATE_IF_NEEDED' if create else 'CREATE_NEVER',
-          'writeDisposition': write_disposition,
-          'sourceFormat': source_format,
-          'ignoreUnknownValues': ignore_unknown_values,
-          'maxBadRecords': max_bad_records,
+        'kind': 'bigquery#job',
+        'configuration': {
+            'load': {
+                'sourceUris': source,
+                'destinationTable': {
+                    'projectId': table_name.project_id,
+                    'datasetId': table_name.dataset_id,
+                    'tableId': table_name.table_id
+                },
+                'createDisposition': 'CREATE_IF_NEEDED' if create else 'CREATE_NEVER',
+                'writeDisposition': write_disposition,
+                'sourceFormat': source_format,
+                'ignoreUnknownValues': ignore_unknown_values,
+                'maxBadRecords': max_bad_records,
+            }
         }
-      }
     }
     if source_format == 'CSV':
       load_config = data['configuration']['load']
       load_config.update({
-        'fieldDelimiter': field_delimiter,
-        'allowJaggedRows': allow_jagged_rows,
-        'allowQuotedNewlines': allow_quoted_newlines,
-        'quote': quote,
-        'encoding': encoding,
-        'skipLeadingRows': skip_leading_rows
+          'fieldDelimiter': field_delimiter,
+          'allowJaggedRows': allow_jagged_rows,
+          'allowQuotedNewlines': allow_quoted_newlines,
+          'quote': quote,
+          'encoding': encoding,
+          'skipLeadingRows': skip_leading_rows
       })
 
     return datalab.utils.Http.request(url, data=data, credentials=self._credentials)
@@ -148,16 +152,16 @@ class Api(object):
     """
     url = Api._ENDPOINT + (Api._JOBS_PATH % (self._project_id, ''))
     data = {
-      'kind': 'bigquery#job',
-      'configuration': {
-        'query': {
-          'query': sql,
-          'useQueryCache': use_cache,
-          'allowLargeResults': allow_large_results
+        'kind': 'bigquery#job',
+        'configuration': {
+            'query': {
+                'query': sql,
+                'useQueryCache': use_cache,
+                'allowLargeResults': allow_large_results
+            },
+            'dryRun': dry_run,
+            'priority': 'BATCH' if batch else 'INTERACTIVE',
         },
-        'dryRun': dry_run,
-        'priority': 'BATCH' if batch else 'INTERACTIVE',
-      },
     }
 
     query_config = data['configuration']['query']
@@ -176,9 +180,9 @@ class Api(object):
 
     if table_name:
       query_config['destinationTable'] = {
-        'projectId': table_name.project_id,
-        'datasetId': table_name.dataset_id,
-        'tableId': table_name.table_id
+          'projectId': table_name.project_id,
+          'datasetId': table_name.dataset_id,
+          'tableId': table_name.table_id
       }
       if append:
         query_config['writeDisposition'] = "WRITE_APPEND"
@@ -211,7 +215,7 @@ class Api(object):
         'maxResults': page_size,
         'timeoutMs': timeout,
         'startIndex': start_index
-      }
+    }
     url = Api._ENDPOINT + (Api._QUERIES_PATH % (project_id, job_id))
     return datalab.utils.Http.request(url, args=args, credentials=self._credentials)
 
@@ -245,11 +249,11 @@ class Api(object):
     """
     url = Api._ENDPOINT + (Api._DATASETS_PATH % (dataset_name.project_id, ''))
     data = {
-      'kind': 'bigquery#dataset',
-      'datasetReference': {
-        'projectId': dataset_name.project_id,
-        'datasetId': dataset_name.dataset_id,
-      },
+        'kind': 'bigquery#dataset',
+        'datasetReference': {
+            'projectId': dataset_name.project_id,
+            'datasetId': dataset_name.dataset_id
+        },
     }
     if friendly_name:
       data['friendlyName'] = friendly_name
@@ -380,12 +384,12 @@ class Api(object):
         (Api._TABLES_PATH % (table_name.project_id, table_name.dataset_id, '', ''))
 
     data = {
-      'kind': 'bigquery#table',
-      'tableReference': {
-        'projectId': table_name.project_id,
-        'datasetId': table_name.dataset_id,
-        'tableId': table_name.table_id
-      }
+        'kind': 'bigquery#table',
+        'tableReference': {
+            'projectId': table_name.project_id,
+            'datasetId': table_name.dataset_id,
+            'tableId': table_name.table_id
+        }
     }
     if schema:
       data['schema'] = {'fields': schema}
@@ -479,21 +483,21 @@ class Api(object):
     data = {
       # 'projectId': table_name.project_id, # Code sample shows this but it is not in job
       # reference spec. Filed as b/19235843
-      'kind': 'bigquery#job',
-      'configuration': {
-        'extract': {
-          'sourceTable': {
-            'projectId': table_name.project_id,
-            'datasetId': table_name.dataset_id,
-            'tableId': table_name.table_id,
-          },
-          'compression': 'GZIP' if compress else 'NONE',
-          'fieldDelimiter': field_delimiter,
-          'printHeader': print_header,
-          'destinationUris': destination,
-          'destinationFormat': format,
+        'kind': 'bigquery#job',
+        'configuration': {
+            'extract': {
+                'sourceTable': {
+                    'projectId': table_name.project_id,
+                    'datasetId': table_name.dataset_id,
+                    'tableId': table_name.table_id,
+                },
+                'compression': 'GZIP' if compress else 'NONE',
+                'fieldDelimiter': field_delimiter,
+                'printHeader': print_header,
+                'destinationUris': destination,
+                'destinationFormat': format,
+            }
         }
-      }
     }
     return datalab.utils.Http.request(url, data=data, credentials=self._credentials)
 

--- a/datalab/bigquery/_csv_options.py
+++ b/datalab/bigquery/_csv_options.py
@@ -11,6 +11,9 @@
 # the License.
 
 """Implements CSV options for External Tables and Table loads from GCS."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 
 class CSVOptions(object):

--- a/datalab/bigquery/_dataset.py
+++ b/datalab/bigquery/_dataset.py
@@ -11,14 +11,17 @@
 # the License.
 
 """Implements Dataset, and related Dataset BigQuery APIs."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 import datalab.context
 import datalab.utils
 
-import _api
-import _table
-import _utils
-import _view
+from . import _api
+from . import _table
+from . import _utils
+from . import _view
 
 
 class Dataset(object):

--- a/datalab/bigquery/_federated_table.py
+++ b/datalab/bigquery/_federated_table.py
@@ -11,8 +11,11 @@
 # the License.
 
 """Implements External Table functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
-import _csv_options
+from . import _csv_options
 
 
 class FederatedTable(object):

--- a/datalab/bigquery/_job.py
+++ b/datalab/bigquery/_job.py
@@ -11,12 +11,15 @@
 # the License.
 
 """Implements BigQuery Job functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import division
 
 import datetime
 
 import datalab.utils
 
-import _api
+from . import _api
 
 
 class Job(datalab.utils.GCPJob):

--- a/datalab/bigquery/_parser.py
+++ b/datalab/bigquery/_parser.py
@@ -11,6 +11,12 @@
 # the License.
 
 """Implements BigQuery related data parsing helpers."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from builtins import zip
+from builtins import str
+from builtins import object
 
 import datetime
 
@@ -52,7 +58,7 @@ class Parser(object):
           value = datetime.datetime.utcfromtimestamp(float(value))
         elif data_type == 'BOOLEAN':
           value = value == 'true'
-        elif (type(value) != str) and (type(value) != unicode):
+        elif (type(value) != str):
           # TODO(gram): Handle nested JSON records
           value = str(value)
       return value

--- a/datalab/bigquery/_query.py
+++ b/datalab/bigquery/_query.py
@@ -11,16 +11,20 @@
 # the License.
 
 """Implements Query BigQuery API."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 import datalab.context
 import datalab.data
 import datalab.utils
 
-import _api
-import _federated_table
-import _sampling
-import _udf
-import _utils
+from . import _api
+from . import _federated_table
+from . import _query_job
+from . import _sampling
+from . import _udf
+from . import _utils
 
 
 class Query(object):
@@ -94,7 +98,7 @@ class Query(object):
 
     # We need to take care not to include the same UDF code twice so we use sets.
     udfs = set(udfs if udfs else [])
-    for value in values.values():
+    for value in list(values.values()):
       if isinstance(value, _udf.UDF):
         udfs.add(value)
     included_udfs = set([])
@@ -161,7 +165,7 @@ class Query(object):
     self._external_tables = None
     if len(data_sources):
       self._external_tables = {}
-      for name, table in data_sources.items():
+      for name, table in list(data_sources.items()):
         if table.schema is None:
           raise Exception('Referenced external table %s has no known schema' % name)
         self._external_tables[name] = table._to_query_json()
@@ -439,7 +443,7 @@ class Query(object):
     Returns:
       A View for the Query.
     """
+    # Do the import here to avoid circular dependencies at top-level.
+    from . import _view
     return _view.View(view_name, self._context).create(self._sql)
 
-import _query_job
-import _view

--- a/datalab/bigquery/_query_job.py
+++ b/datalab/bigquery/_query_job.py
@@ -11,8 +11,12 @@
 # the License.
 
 """Implements BigQuery query job functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
 
-import _job
+from . import _job
+from . import _query_results_table
 
 
 class QueryJob(_job.Job):
@@ -106,4 +110,3 @@ class QueryJob(_job.Job):
       raise Exception('Query failed: %s' % str(self.errors))
     return self._table
 
-import _query_results_table

--- a/datalab/bigquery/_query_results_table.py
+++ b/datalab/bigquery/_query_results_table.py
@@ -11,8 +11,10 @@
 # the License.
 
 """Implements BigQuery query job results table functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import _table
+from . import _table
 
 
 class QueryResultsTable(_table.Table):

--- a/datalab/bigquery/_query_stats.py
+++ b/datalab/bigquery/_query_stats.py
@@ -10,10 +10,14 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+
 """Implements representation of BigQuery query job dry run results."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 
-class QueryStats:
+class QueryStats(object):
   """A wrapper for statistics returned by a dry run query. Useful so we can get an HTML
   representation in a notebook.
   """

--- a/datalab/bigquery/_sampling.py
+++ b/datalab/bigquery/_sampling.py
@@ -11,6 +11,10 @@
 # the License.
 
 """Sampling for BigQuery."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from builtins import object
 
 
 class Sampling(object):
@@ -120,7 +124,7 @@ class Sampling(object):
     """
     def _random_sampling(sql):
       projection = Sampling._create_projection(fields)
-      sql = 'SELECT %s FROM (%s) WHERE rand() < %f' % (projection, sql, percent / 100.0)
+      sql = 'SELECT %s FROM (%s) WHERE rand() < %f' % (projection, sql, (float(percent) / 100.0))
       if count != 0:
         sql = '%s LIMIT %d' % (sql, count)
       return sql

--- a/datalab/bigquery/_schema.py
+++ b/datalab/bigquery/_schema.py
@@ -11,6 +11,12 @@
 # the License.
 
 """Implements Table and View Schema APIs."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from builtins import range
+from past.builtins import basestring
+from builtins import object
 
 import datetime
 import pandas
@@ -167,7 +173,7 @@ class Schema(list):
       A list of dictionaries containing field 'name' and 'type' entries, suitable for use in a
           BigQuery Tables resource schema.
     """
-    return [Schema._get_field_entry(name, value) for name, value in data.items()]
+    return [Schema._get_field_entry(name, value) for name, value in list(data.items())]
 
   @staticmethod
   def _from_list_record(data):
@@ -291,6 +297,7 @@ class Schema(list):
     """
     if isinstance(key, basestring):
       return self._map.get(key, None)
+    # noinspection PyCallByClass
     return list.__getitem__(self, key)
 
   def _add_field(self, name, data_type, mode='NULLABLE', description=''):
@@ -333,7 +340,7 @@ class Schema(list):
     other_map = other._map
     if len(self._map) != len(other_map):
       return False
-    for name in self._map.iterkeys():
+    for name in self._map.keys():
       if name not in other_map:
         return False
       if not self._map[name] == other_map[name]:

--- a/datalab/bigquery/_table.py
+++ b/datalab/bigquery/_table.py
@@ -11,6 +11,12 @@
 # the License.
 
 """Implements Table, and related Table BigQuery APIs."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from builtins import str
+from past.utils import old_div
+from builtins import object
 
 import calendar
 import codecs
@@ -25,12 +31,12 @@ import uuid
 import datalab.context
 import datalab.utils
 
-import _api
-import _csv_options
-import _job
-import _parser
-import _schema
-import _utils
+from . import _api
+from . import _csv_options
+from . import _job
+from . import _parser
+from . import _schema
+from . import _utils
 
 
 # import of Query is at end of module as we have a circular dependency of
@@ -263,7 +269,7 @@ class Table(object):
     Returns:
       The sanitized dictionary.
     """
-    for k in record.keys():
+    for k in list(record.keys()):
       v = record[k]
       # If the column is a date, convert to ISO string.
       if isinstance(v, pandas.Timestamp) or isinstance(v, datetime.datetime):
@@ -418,7 +424,7 @@ class Table(object):
                                          csv_delimiter, csv_header)
       return self._init_job_from_response(response)
     except Exception as e:
-      raise datalab.utils.JobError(location=traceback.format_exc(), message=e.message,
+      raise datalab.utils.JobError(location=traceback.format_exc(), message=str(e),
                                    reason=str(type(e)))
 
   def extract(self, destination, format='csv', csv_delimiter=',', csv_header=True, compress=False):
@@ -773,7 +779,7 @@ class Table(object):
             or self._cached_page_index + len(self._cached_page) <= item:
       # cache a new page. To get the start row we round to the nearest multiple of the page
       # size.
-      first = int(math.floor(item / self._DEFAULT_PAGE_SIZE)) * self._DEFAULT_PAGE_SIZE
+      first = old_div(item, self._DEFAULT_PAGE_SIZE) * self._DEFAULT_PAGE_SIZE
       count = self._DEFAULT_PAGE_SIZE
 
       if self.length >= 0:
@@ -891,10 +897,11 @@ class Table(object):
     Returns:
       A Query object that will return the specified fields from the records in the Table.
     """
+    # Do import here to avoid top-level circular dependencies.
+    from . import _query
     if fields is None:
       fields = '*'
     elif isinstance(fields, list):
       fields = ','.join(fields)
     return _query.Query('SELECT %s FROM %s' % (fields, self._repr_sql_()), context=self._context)
 
-import _query

--- a/datalab/bigquery/_udf.py
+++ b/datalab/bigquery/_udf.py
@@ -11,6 +11,10 @@
 # the License.
 
 """Google Cloud Platform library - BigQuery UDF Functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from builtins import object
 
 import json
 

--- a/datalab/bigquery/_utils.py
+++ b/datalab/bigquery/_utils.py
@@ -11,6 +11,10 @@
 # the License.
 
 """Useful common utility functions."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from past.builtins import basestring
 
 import collections
 import re
@@ -164,3 +168,5 @@ def parse_table_name(name, project_id=None, dataset_id=None):
 
 def format_query_errors(errors):
   return '\n'.join(['%s: %s' % (error['reason'], error['message']) for error in errors])
+
+

--- a/datalab/bigquery/_view.py
+++ b/datalab/bigquery/_view.py
@@ -11,11 +11,15 @@
 # the License.
 
 """Implements BigQuery Views."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from builtins import object
 
 import datalab.context
 
-import _query
-import _table
+from . import _query
+from . import _table
 
 # Query import is at end to avoid issues with circular dependencies.
 

--- a/datalab/bigquery/commands/__init__.py
+++ b/datalab/bigquery/commands/__init__.py
@@ -11,5 +11,7 @@
 # the License.
 
 
-import _bigquery
+from __future__ import absolute_import
+
+from . import _bigquery
 

--- a/datalab/bigquery/commands/_bigquery.py
+++ b/datalab/bigquery/commands/_bigquery.py
@@ -11,6 +11,12 @@
 # the License.
 
 """Google Cloud Platform library - BigQuery IPython Functionality."""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import zip
+from builtins import str
+from past.builtins import basestring
 
 try:
   import IPython
@@ -311,7 +317,7 @@ def _sample_cell(args, cell_body):
   else:
     results = table.sample(sampling=sampling)
   if args['verbose']:
-    print results.sql
+    print(results.sql)
   if args['profile']:
     return datalab.utils.commands.profile_df(results.to_dataframe())
   else:
@@ -339,17 +345,17 @@ def _create_cell(args, cell_body):
       datalab.bigquery.Dataset(args['name']).create(friendly_name=args['friendly'],
                                                     description=cell_body)
     except Exception as e:
-      print 'Failed to create dataset %s: %s' % (args['name'], e)
+      print('Failed to create dataset %s: %s' % (args['name'], e))
   else:
     if cell_body is None:
-      print 'Failed to create %s: no schema specified' % args['name']
+      print('Failed to create %s: no schema specified' % args['name'])
     else:
       try:
         record = datalab.utils.commands.parse_config(cell_body, datalab.utils.commands.notebook_environment(), as_dict=False)
         schema = datalab.bigquery.Schema(record)
         datalab.bigquery.Table(args['name']).create(schema=schema, overwrite=args['overwrite'])
       except Exception as e:
-        print 'Failed to create table %s: %s' % (args['name'], e)
+        print('Failed to create table %s: %s' % (args['name'], e))
 
 
 def _delete_cell(args, _):
@@ -372,12 +378,12 @@ def _delete_cell(args, _):
     try:
       datalab.bigquery.Dataset(args['name']).delete()
     except Exception as e:
-      print 'Failed to delete dataset %s: %s' % (args['name'], e)
+      print('Failed to delete dataset %s: %s' % (args['name'], e))
   else:
     try:
       datalab.bigquery.Table(args['name']).delete()
     except Exception as e:
-      print 'Failed to delete table %s: %s' % (args['name'], e)
+      print('Failed to delete table %s: %s' % (args['name'], e))
 
 
 def _dryrun_cell(args, cell_body):
@@ -396,7 +402,7 @@ def _dryrun_cell(args, cell_body):
   query = _get_query_argument(args, cell_body, datalab.utils.commands.notebook_environment())
 
   if args['verbose']:
-    print query.sql
+    print(query.sql)
   result = query.execute_dry_run()
   return datalab.bigquery._query_stats.QueryStats(total_bytes=result['totalBytesProcessed'],
                                               is_cached=result['cacheHit'])
@@ -484,7 +490,7 @@ def _execute_cell(args, cell_body):
   """
   query = _get_query_argument(args, cell_body, datalab.utils.commands.notebook_environment())
   if args['verbose']:
-    print query.sql
+    print(query.sql)
   return query.execute(args['target'], table_mode=args['mode'], use_cache=not args['nocache'],
                        allow_large_results=args['large']).results
 
@@ -506,13 +512,13 @@ def _pipeline_cell(args, cell_body):
     raise Exception('Deploying a pipeline is not yet supported')
 
   env = {}
-  for key, value in datalab.utils.commands.notebook_environment().iteritems():
+  for key, value in datalab.utils.commands.notebook_environment().items():
     if isinstance(value, datalab.bigquery._udf.UDF):
       env[key] = value
 
   query = _get_query_argument(args, cell_body, env)
   if args['verbose']:
-    print query.sql
+    print(query.sql)
   if args['action'] == 'dryrun':
     print(query.sql)
     result = query.execute_dry_run()

--- a/datalab/context/_api.py
+++ b/datalab/context/_api.py
@@ -11,6 +11,9 @@
 # the License.
 
 """Implements HTTP API wrapper."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 import datalab.utils
 

--- a/datalab/context/_context.py
+++ b/datalab/context/_context.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 """Implements Context functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
-import _project
-import _utils
+from . import _project
+from . import _utils
 
 
 class Context(object):

--- a/datalab/context/_project.py
+++ b/datalab/context/_project.py
@@ -11,13 +11,16 @@
 # the License.
 
 """Implements Projects functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 import os
 
 import datalab.utils
 
-import _api
-import _utils
+from . import _api
+from . import _utils
 
 
 # We could do this with the gcloud SDK. However, installing that while locked on oauth2.5

--- a/datalab/context/_utils.py
+++ b/datalab/context/_utils.py
@@ -14,6 +14,8 @@
 
 """ Support for getting gcloud credentials. """
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import oauth2client.client
 import json
 import os

--- a/datalab/context/commands/__init__.py
+++ b/datalab/context/commands/__init__.py
@@ -11,4 +11,6 @@
 # the License.
 
 
-import _projects
+from __future__ import absolute_import
+
+from . import _projects

--- a/datalab/context/commands/_projects.py
+++ b/datalab/context/commands/_projects.py
@@ -12,6 +12,8 @@
 
 """Implements listing projects and setting default project."""
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 try:
   import IPython
   import IPython.core.magic

--- a/datalab/data/__init__.py
+++ b/datalab/data/__init__.py
@@ -11,107 +11,11 @@
 # the License.
 
 """Google Cloud Platform library - Generic SQL Helpers."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-from _csv import Csv
-from _sql_module import SqlModule
-from _sql_statement import SqlStatement
-
-
-def _next_token(sql):
-  """ This is a basic tokenizer for our limited purposes.
-  It splits a SQL statement up into a series of segments, where a segment is one of:
-  - identifiers
-  - left or right parentheses
-  - multi-line comments
-  - single line comments
-  - white-space sequences
-  - string literals
-  - consecutive strings of characters that are not one of the items above
-
-  The aim is for us to be able to find function calls (identifiers followed by '('), and the
-  associated closing ')') so we can augment these if needed.
-
-  Args:
-    sql: a SQL statement as a (possibly multi-line) string.
-
-  Returns:
-    For each call, the next token in the initial input.
-  """
-  i = 0
-
-  # We use some lambda's to make the logic more clear. The start_* functions return
-  # true if i is the index of the start of that construct, while the end_* functions
-  # return true if i point to the first character beyond that construct or the end of the
-  # content.
-  #
-  # We don't currently need numbers so the tokenizer here just does sequences of
-  # digits as a convenience to shrink the total number of tokens. If we needed numbers
-  # later we would need a special handler for these much like strings.
-
-  start_multi_line_comment = lambda s, i: s[i] == '/' and i < len(s) - 1 and s[i + 1] == '*'
-  end_multi_line_comment = lambda s, i: s[i - 2] == '*' and s[i - 1] == '/'
-  start_single_line_comment = lambda s, i: s[i] == '-' and i < len(s) - 1 and s[i + 1] == '-'
-  end_single_line_comment = lambda s, i: s[i - 1] == '\n'
-  start_whitespace = lambda s, i: s[i].isspace()
-  end_whitespace = lambda s, i: not s[i].isspace()
-  start_number = lambda s, i: s[i].isdigit()
-  end_number = lambda s, i: not s[i].isdigit()
-  start_identifier = lambda s, i: s[i].isalpha() or s[i] == '_' or s[i] == '$'
-  end_identifier = lambda s, i: not(s[i].isalnum() or s[i] == '_')
-  start_string = lambda s, i: s[i] == '"' or s[i] == "'"
-  always_true = lambda s, i: True
-
-  while i < len(sql):
-    start = i
-    if start_multi_line_comment(sql, i):
-      i += 1
-      end_checker = end_multi_line_comment
-    elif start_single_line_comment(sql, i):
-      i += 1
-      end_checker = end_single_line_comment
-    elif start_whitespace(sql, i):
-      end_checker = end_whitespace
-    elif start_identifier(sql, i):
-      end_checker = end_identifier
-    elif start_number(sql, i):
-      end_checker = end_number
-    elif start_string(sql, i):
-      # Special handling here as we need to check for escaped closing quotes.
-      quote = sql[i]
-      end_checker = always_true
-      i += 1
-      while i < len(sql) and sql[i] != quote:
-        i += 2 if sql[i] == '\\' else 1
-    else:
-      # We return single characters for everything else
-      end_checker = always_true
-
-    i += 1
-    while i < len(sql) and not end_checker(sql, i):
-      i += 1
-
-    (yield sql[start:i])
-
-
-def tokenize(sql):
-  """ This is a basic tokenizer for our limited purposes.
-  It splits a SQL statement up into a series of segments, where a segment is one of:
-  - identifiers
-  - left or right parentheses
-  - multi-line comments
-  - single line comments
-  - white-space sequences
-  - string literals
-  - consecutive strings of characters that are not one of the items above
-
-  The aim is for us to be able to find function calls (identifiers followed by '('), and the
-  associated closing ')') so we can augment these if needed.
-
-  Args:
-    sql: a SQL statement as a (possibly multi-line) string.
-
-  Returns:
-    A list of strings corresponding to the groups above.
-  """
-  return list(_next_token(sql))
+from ._csv import Csv
+from ._sql_module import SqlModule
+from ._sql_statement import SqlStatement
+from ._utils import tokenize
 

--- a/datalab/data/_csv.py
+++ b/datalab/data/_csv.py
@@ -11,12 +11,17 @@
 # the License.
 
 """Implements usefule CSV utilities."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import next
+from builtins import str
+from builtins import range
+from builtins import object
 
 
 import csv
 import pandas as pd
 from sklearn.feature_extraction.text import CountVectorizer
-import yaml
 
 import datalab.storage
 
@@ -47,7 +52,7 @@ class Csv(object):
   @staticmethod
   def _read_local_lines(path, max_lines=None):
     lines = []
-    for line in open(path).xreadlines():
+    for line in open(path):
       if max_lines is not None and len(lines) >= max_lines:
         break
       lines.append(line)
@@ -93,7 +98,7 @@ class Csv(object):
 
     if len(lines) == 0:
       return []
-    columns_size = len(csv.reader([lines[0]]).next())
+    columns_size = len(next(csv.reader([lines[0]])))
     if headers is None:
       headers = ['col' + str(e) for e in range(columns_size)]
     if len(headers) != columns_size:

--- a/datalab/data/_sql_module.py
+++ b/datalab/data/_sql_module.py
@@ -11,9 +11,17 @@
 # the License.
 
 """Helper functions for %%sql modules."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from past.builtins import basestring
+from builtins import object
 
 import shlex
 import types
+
+from . import _sql_statement
+from . import _utils
 
 
 # It would be nice to be able to inherit from Python module but AFAICT that is not possible.
@@ -21,13 +29,6 @@ import types
 
 class SqlModule(object):
   """ A container for SqlStatements defined together and able to reference each other. """
-
-  # Names used for the arg parser, unnamed (main) query and last query in the module.
-  # Note that every module has a last query, but not every module has a main query.
-
-  _SQL_MODULE_ARGPARSE = '_sql_module_arg_parser'
-  _SQL_MODULE_MAIN = '_sql_module_main'
-  _SQL_MODULE_LAST = '_sql_module_last'
 
   @staticmethod
   def _get_sql_args(parser, args=None):
@@ -59,7 +60,7 @@ class SqlModule(object):
       args.update(overrides)
 
     # Don't return any args that are None as we don't want to expand to 'None'
-    return {arg: value for arg, value in args.iteritems() if value is not None}
+    return {arg: value for arg, value in args.items() if value is not None}
 
   @staticmethod
   def get_default_query_from_module(module):
@@ -71,9 +72,7 @@ class SqlModule(object):
     Returns:
       The default query associated with this module.
     """
-    if isinstance(module, types.ModuleType):
-      return module.__dict__.get(SqlModule._SQL_MODULE_LAST, None)
-    return None
+    return _utils.get_default_query_from_module(module)
 
   @staticmethod
   def get_sql_statement_with_environment(item, args=None):
@@ -97,7 +96,7 @@ class SqlModule(object):
     env = {}
     if item.module:
       env.update(item.module.__dict__)
-      parser = env.get(SqlModule._SQL_MODULE_ARGPARSE, None)
+      parser = env.get(_utils._SQL_MODULE_ARGPARSE, None)
       if parser:
         args = SqlModule._get_sql_args(parser, args=args)
       else:
@@ -126,4 +125,3 @@ class SqlModule(object):
     return _sql_statement.SqlStatement.format(sql._sql, args)
 
 
-import _sql_statement

--- a/datalab/data/_sql_statement.py
+++ b/datalab/data/_sql_statement.py
@@ -11,10 +11,18 @@
 # the License.
 
 """Implements SQL statement helper functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from builtins import object
+from past.builtins import basestring
 
 import re
 import types
+
 import datalab.utils
+
+from . import _utils
 
 
 class SqlStatement(object):
@@ -90,7 +98,7 @@ class SqlStatement(object):
       # If it is a SQL module, get the main/last query from the module, so users can refer
       # to $module. Useful especially if final query in module has no DEFINE QUERY <name> part.
       if isinstance(dep, types.ModuleType):
-        dep = _sql_module.SqlModule.get_default_query_from_module(dep)
+        dep = _utils.get_default_query_from_module(dep)
       # If we can't resolve the $name, give up.
       if dep is None:
         raise Exception("Unsatisfied dependency $%s" % dependency)
@@ -152,7 +160,7 @@ class SqlStatement(object):
           raise Exception('Invalid sql. Unable to substitute $%s.' % e.args[0])
 
         if isinstance(value, types.ModuleType):
-          value = _sql_module.SqlModule.get_default_query_from_module(value)
+          value = _utils.get_default_query_from_module(value)
 
         if isinstance(value, SqlStatement):
           sql = value.format(value._sql, resolved_vars)
@@ -160,7 +168,7 @@ class SqlStatement(object):
         elif '_repr_sql_' in dir(value):
           # pylint: disable=protected-access
           value = value._repr_sql_()
-        elif type(value) == str or type(value) == unicode:
+        elif isinstance(value, basestring):
           value = SqlStatement._escape_string(value)
         elif isinstance(value, list) or isinstance(value, tuple):
           if isinstance(value, tuple):
@@ -169,7 +177,7 @@ class SqlStatement(object):
           for v in value:
             if len(expansion) > 1:
               expansion += ', '
-            if type(v) == str or type(v) == unicode:
+            if isinstance(v, basestring):
               expansion += SqlStatement._escape_string(v)
             else:
               expansion += str(v)
@@ -203,4 +211,3 @@ class SqlStatement(object):
         raise Exception('Invalid sql; $ with no following $ or identifier: %s.' % sql)
     return dependencies
 
-import _sql_module

--- a/datalab/data/_utils.py
+++ b/datalab/data/_utils.py
@@ -1,0 +1,138 @@
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Google Cloud Platform library - Generic SQL Helpers."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+import types
+
+
+# Names used for the arg parser, unnamed (main) query and last query in the module.
+# Note that every module has a last query, but not every module has a main query.
+
+_SQL_MODULE_ARGPARSE = '_sql_module_arg_parser'
+_SQL_MODULE_MAIN = '_sql_module_main'
+_SQL_MODULE_LAST = '_sql_module_last'
+
+
+def get_default_query_from_module(module):
+  """ Given a %%sql module return the default (last) query for the module.
+
+  Args:
+    module: the %%sql module.
+
+  Returns:
+    The default query associated with this module.
+  """
+  if isinstance(module, types.ModuleType):
+    return module.__dict__.get(_SQL_MODULE_LAST, None)
+  return None
+
+
+def _next_token(sql):
+  """ This is a basic tokenizer for our limited purposes.
+  It splits a SQL statement up into a series of segments, where a segment is one of:
+  - identifiers
+  - left or right parentheses
+  - multi-line comments
+  - single line comments
+  - white-space sequences
+  - string literals
+  - consecutive strings of characters that are not one of the items above
+
+  The aim is for us to be able to find function calls (identifiers followed by '('), and the
+  associated closing ')') so we can augment these if needed.
+
+  Args:
+    sql: a SQL statement as a (possibly multi-line) string.
+
+  Returns:
+    For each call, the next token in the initial input.
+  """
+  i = 0
+
+  # We use some lambda's to make the logic more clear. The start_* functions return
+  # true if i is the index of the start of that construct, while the end_* functions
+  # return true if i point to the first character beyond that construct or the end of the
+  # content.
+  #
+  # We don't currently need numbers so the tokenizer here just does sequences of
+  # digits as a convenience to shrink the total number of tokens. If we needed numbers
+  # later we would need a special handler for these much like strings.
+
+  start_multi_line_comment = lambda s, i: s[i] == '/' and i < len(s) - 1 and s[i + 1] == '*'
+  end_multi_line_comment = lambda s, i: s[i - 2] == '*' and s[i - 1] == '/'
+  start_single_line_comment = lambda s, i: s[i] == '-' and i < len(s) - 1 and s[i + 1] == '-'
+  end_single_line_comment = lambda s, i: s[i - 1] == '\n'
+  start_whitespace = lambda s, i: s[i].isspace()
+  end_whitespace = lambda s, i: not s[i].isspace()
+  start_number = lambda s, i: s[i].isdigit()
+  end_number = lambda s, i: not s[i].isdigit()
+  start_identifier = lambda s, i: s[i].isalpha() or s[i] == '_' or s[i] == '$'
+  end_identifier = lambda s, i: not(s[i].isalnum() or s[i] == '_')
+  start_string = lambda s, i: s[i] == '"' or s[i] == "'"
+  always_true = lambda s, i: True
+
+  while i < len(sql):
+    start = i
+    if start_multi_line_comment(sql, i):
+      i += 1
+      end_checker = end_multi_line_comment
+    elif start_single_line_comment(sql, i):
+      i += 1
+      end_checker = end_single_line_comment
+    elif start_whitespace(sql, i):
+      end_checker = end_whitespace
+    elif start_identifier(sql, i):
+      end_checker = end_identifier
+    elif start_number(sql, i):
+      end_checker = end_number
+    elif start_string(sql, i):
+      # Special handling here as we need to check for escaped closing quotes.
+      quote = sql[i]
+      end_checker = always_true
+      i += 1
+      while i < len(sql) and sql[i] != quote:
+        i += 2 if sql[i] == '\\' else 1
+    else:
+      # We return single characters for everything else
+      end_checker = always_true
+
+    i += 1
+    while i < len(sql) and not end_checker(sql, i):
+      i += 1
+
+    (yield sql[start:i])
+
+
+def tokenize(sql):
+  """ This is a basic tokenizer for our limited purposes.
+  It splits a SQL statement up into a series of segments, where a segment is one of:
+  - identifiers
+  - left or right parentheses
+  - multi-line comments
+  - single line comments
+  - white-space sequences
+  - string literals
+  - consecutive strings of characters that are not one of the items above
+
+  The aim is for us to be able to find function calls (identifiers followed by '('), and the
+  associated closing ')') so we can augment these if needed.
+
+  Args:
+    sql: a SQL statement as a (possibly multi-line) string.
+
+  Returns:
+    A list of strings corresponding to the groups above.
+  """
+  return list(_next_token(sql))
+

--- a/datalab/data/commands/__init__.py
+++ b/datalab/data/commands/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
@@ -11,4 +12,4 @@
 # the License.
 
 
-import _sql
+from . import _sql

--- a/datalab/data/commands/_sql.py
+++ b/datalab/data/commands/_sql.py
@@ -11,6 +11,11 @@
 # the License.
 
 """Google Cloud Platform library - %%arguments IPython Cell Magic Functionality."""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import str
+from past.builtins import basestring
 
 try:
   import IPython
@@ -219,7 +224,7 @@ def _arguments(code, module):
     env.update(builtins)
 
     # Execute the cell which should be one or more calls to arg().
-    exec code in env
+    exec(code, env)
 
     # Iterate through the module dictionary. For any newly defined objects,
     # add args to the parser.
@@ -243,7 +248,7 @@ def _arguments(code, module):
         else:
           arg_parser.add_argument(key, default=val, action='store_false')
       elif isinstance(val, basestring) or isinstance(val, int) or isinstance(val, float) \
-          or isinstance(val, long):
+          or isinstance(val, int):
         arg_parser.add_argument(key, default=val)
       elif isinstance(val, list):
         arg_parser.add_argument(key, default=val, nargs='+')
@@ -269,7 +274,7 @@ def _arguments(code, module):
         raise Exception('Cannot generate argument for %s of type %s' % (key, type(val)))
 
   except Exception as e:
-    print "%%sql arguments: %s from code '%s'" % (str(e), str(code))
+    print("%%sql arguments: %s from code '%s'" % (str(e), str(code)))
   return arg_parser
 
 
@@ -315,7 +320,7 @@ def _split_cell(cell, module):
 
         # This is not the first query, so gather the previous query text.
         query = '\n'.join([line for line in lines[last_def:i] if len(line)]).strip()
-        if select_match and name != datalab.data.SqlModule._SQL_MODULE_MAIN and len(query) == 0:
+        if select_match and name != datalab.data._utils._SQL_MODULE_MAIN and len(query) == 0:
           # Avoid DEFINE query name\nSELECT ... being seen as an empty DEFINE followed by SELECT
           continue
 
@@ -323,14 +328,14 @@ def _split_cell(cell, module):
         statement = datalab.data.SqlStatement(query, module)
         module.__dict__[name] = statement
         # And set the 'last' query to be this too
-        module.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST] = statement
+        module.__dict__[datalab.data._utils._SQL_MODULE_LAST] = statement
 
       # Get the query name and strip off our syntactic sugar if appropriate.
       if define_match:
         name = define_match.group(1)
         lines[i] = define_match.group(2)
       else:
-        name = datalab.data.SqlModule._SQL_MODULE_MAIN
+        name = datalab.data._utils._SQL_MODULE_MAIN
 
       # Save the starting line index of the new query
       last_def = i
@@ -344,12 +349,12 @@ def _split_cell(cell, module):
     query = '\n'.join([line for line in lines[last_def:] if len(line)]).strip()
     statement = datalab.data.SqlStatement(query, module)
     module.__dict__[name] = statement
-    module.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST] = statement
+    module.__dict__[datalab.data._utils._SQL_MODULE_LAST] = statement
 
   if code is None:
     code = ''
-  module.__dict__[datalab.data.SqlModule._SQL_MODULE_ARGPARSE] = _arguments(code, module)
-  return module.__dict__.get(datalab.data.SqlModule._SQL_MODULE_LAST, None)
+  module.__dict__[datalab.data._utils._SQL_MODULE_ARGPARSE] = _arguments(code, module)
+  return module.__dict__.get(datalab.data._utils._SQL_MODULE_LAST, None)
 
 
 def sql_cell(args, cell):
@@ -383,4 +388,4 @@ def sql_cell(args, cell):
   else:
     # Add it as a module
     sys.modules[name] = module
-    exec 'import %s' % name in ipy.user_ns
+    exec('import %s' % name, ipy.user_ns)

--- a/datalab/storage/__init__.py
+++ b/datalab/storage/__init__.py
@@ -11,6 +11,7 @@
 # the License.
 
 """Google Cloud Platform library - Cloud Storage Functionality."""
+from __future__ import absolute_import
 
-from _bucket import Bucket, Buckets
-from _item import Item, Items
+from ._bucket import Bucket, Buckets
+from ._item import Item, Items

--- a/datalab/storage/_api.py
+++ b/datalab/storage/_api.py
@@ -11,8 +11,13 @@
 # the License.
 
 """Implements Storage HTTP API wrapper."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import datalab.utils
 
 
@@ -256,4 +261,4 @@ class Api(object):
   @staticmethod
   def _escape_key(key):
     # Disable the behavior to leave '/' alone by explicitly specifying the safe parameter.
-    return urllib.quote(key, safe='')
+    return urllib.parse.quote(key, safe='')

--- a/datalab/storage/_bucket.py
+++ b/datalab/storage/_bucket.py
@@ -11,6 +11,9 @@
 # the License.
 
 """Implements Bucket-related Cloud Storage APIs."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 import dateutil.parser
 import re
@@ -18,8 +21,8 @@ import re
 import datalab.context
 import datalab.utils
 
-import _api
-import _item
+from . import _api
+from . import _item
 
 
 # REs to match bucket names and optionally object names

--- a/datalab/storage/_item.py
+++ b/datalab/storage/_item.py
@@ -11,13 +11,16 @@
 # the License.
 
 """Implements Object-related Cloud Storage APIs."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 import dateutil.parser
 
 import datalab.utils
 import datalab.context
 
-import _api
+from . import _api
 
 # TODO(nikhilko): Read/write operations don't account for larger files, or non-textual content.
 #                 Use streaming reads into a buffer or StringIO or into a file handle.
@@ -287,5 +290,3 @@ class Items(object):
   def __iter__(self):
     return iter(datalab.utils.Iterator(self._retrieve_items))
 
-
-import _bucket

--- a/datalab/storage/commands/__init__.py
+++ b/datalab/storage/commands/__init__.py
@@ -11,5 +11,7 @@
 # the License.
 
 
-import _storage
+from __future__ import absolute_import
+
+from . import _storage
 

--- a/datalab/storage/commands/_storage.py
+++ b/datalab/storage/commands/_storage.py
@@ -11,6 +11,10 @@
 # the License.
 
 """Google Cloud Platform library - BigQuery IPython Functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from past.builtins import basestring
 
 try:
   import IPython
@@ -162,7 +166,7 @@ def _expand_list(names):
         # Expand possible key values.
         if bucket not in items and key[:1] == '*':
           # We need the full list; cache a copy for efficiency.
-          items[bucket] = [item.metadata.name for item in datalab.storage.Bucket(bucket).items()]
+          items[bucket] = [item.metadata.name for item in list(datalab.storage.Bucket(bucket).items())]
         # If we have a cached copy use it
         if bucket in items:
           candidates = items[bucket]
@@ -214,7 +218,7 @@ def _storage_copy(args, _):
                                                           bucket=destination_bucket)
     except Exception as e:
       errs.append("Couldn't copy %s to %s: %s" %
-                  (source, target, _extract_storage_api_response_error(e.message)))
+                  (source, target, _extract_storage_api_response_error(str(e))))
   if errs:
     raise Exception('\n'.join(errs))
 
@@ -232,7 +236,7 @@ def _storage_create(args, _):
         raise Exception("Invalid bucket name %s" % name)
     except Exception as e:
       errs.append("Couldn't create %s: %s" %
-                  (name, _extract_storage_api_response_error(e.message)))
+                  (name, _extract_storage_api_response_error(str(e))))
   if errs:
     raise Exception('\n'.join(errs))
 
@@ -261,7 +265,7 @@ def _storage_delete(args, _):
         raise Exception("Can't delete item with invalid name %s" % item)
     except Exception as e:
       errs.append("Couldn't delete %s: %s" %
-                  (item, _extract_storage_api_response_error(e.message)))
+                  (item, _extract_storage_api_response_error(str(e))))
   if errs:
     raise Exception('\n'.join(errs))
 
@@ -276,7 +280,7 @@ def _storage_list_buckets(project, pattern):
 
 def _storage_get_keys(bucket, pattern):
   """ Get names of all storage keys in a specified bucket that match a pattern. """
-  return [item for item in bucket.items() if fnmatch.fnmatch(item.metadata.name, pattern)]
+  return [item for item in list(bucket.items()) if fnmatch.fnmatch(item.metadata.name, pattern)]
 
 
 def _storage_get_key_names(bucket, pattern):

--- a/datalab/utils/_async.py
+++ b/datalab/utils/_async.py
@@ -11,21 +11,23 @@
 # the License.
 
 """Decorators for async methods and functions to dispatch on threads and support chained calls."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 import abc
 import concurrent.futures
 import functools
 
-import _job
+from . import _job
+from future.utils import with_metaclass
 
 
-class async(object):
+class async(with_metaclass(abc.ABCMeta, object)):
   """ Base class for async_function/async_method. Creates a wrapped function/method that will
       run the original function/method on a thread pool worker thread and return a Job instance
       for monitoring the status of the thread.
   """
-
-  __metaclass__ = abc.ABCMeta
   executor = concurrent.futures.ThreadPoolExecutor(max_workers=50)  # Pool for doing the work.
 
   def __init__(self, function):
@@ -42,7 +44,7 @@ class async(object):
   def _preprocess_kwargs(**kwargs):
     # Pre-process keyword arguments - if any are Futures block until they can be resolved.
     return {kw: (arg.result() if isinstance(arg, concurrent.futures.Future) else arg)
-            for kw, arg in kwargs.items()}
+            for kw, arg in list(kwargs.items())}
 
   @abc.abstractmethod
   def _call(self, *args, **kwargs):

--- a/datalab/utils/_gcp_job.py
+++ b/datalab/utils/_gcp_job.py
@@ -11,9 +11,11 @@
 # the License.
 
 """Implements GCP Job functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import datalab.context
-import _job
+from . import _job
 
 
 class GCPJob(_job.Job):

--- a/datalab/utils/_http.py
+++ b/datalab/utils/_http.py
@@ -11,10 +11,17 @@
 # the License.
 
 """Implements HTTP client helper functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from past.builtins import basestring
+from builtins import object
 
 import datetime
 import json
-import urllib
+import urllib.request, urllib.parse, urllib.error
 import httplib2
 
 
@@ -77,7 +84,7 @@ class Http(object):
     headers['user-agent'] = 'GoogleCloudDataLab/1.0'
     # Add querystring to the URL if there are any arguments.
     if args is not None:
-      qs = urllib.urlencode(args)
+      qs = urllib.parse.urlencode(args)
       url = url + '?' + qs
 
     # Setup method to POST if unspecified, and appropriate request headers
@@ -125,7 +132,7 @@ class Http(object):
       if 200 <= response.status < 300:
         if raw_response:
           return content
-        return json.loads(content)
+        return json.loads(str(content, encoding='UTF-8'))
       else:
         raise RequestException(response.status, content)
     except ValueError:

--- a/datalab/utils/_iterator.py
+++ b/datalab/utils/_iterator.py
@@ -11,6 +11,9 @@
 # the License.
 
 """Iterator class for iterable cloud lists."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import object
 
 
 class Iterator(object):

--- a/datalab/utils/_job.py
+++ b/datalab/utils/_job.py
@@ -11,6 +11,10 @@
 # the License.
 
 """Implements Job functionality for async tasks."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from builtins import object
 
 import concurrent.futures
 import datetime
@@ -160,7 +164,7 @@ class Job(object):
       try:
         self._result = self._future.result()
       except Exception as e:
-        message = e.message if e.message else str(e)
+        message = str(e)
         self._fatal_error = JobError(location=traceback.format_exc(), message=message,
                                      reason=str(type(e)))
 

--- a/datalab/utils/_json_encoder.py
+++ b/datalab/utils/_json_encoder.py
@@ -12,6 +12,8 @@
 
 """ JSON encoder that can handle Python datetime objects. """
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import datetime
 import json
 

--- a/datalab/utils/_lambda_job.py
+++ b/datalab/utils/_lambda_job.py
@@ -11,9 +11,11 @@
 # the License.
 
 """Implements OS shell Job functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
-import _async
-import _job
+from . import _async
+from . import _job
 
 
 class LambdaJob(_job.Job):

--- a/datalab/utils/_lru_cache.py
+++ b/datalab/utils/_lru_cache.py
@@ -11,6 +11,11 @@
 # the License.
 
 """A simple LRU cache."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from past.builtins import basestring
+from builtins import object
 
 import datetime
 
@@ -80,7 +85,7 @@ class LRUCache(object):
       self._cache[key] = entry = {}
     else:
       # Cache is full; displace an entry
-      entry = min(self._cache.values(), key=lambda x: x['last_used'])
+      entry = min(list(self._cache.values()), key=lambda x: x['last_used'])
       self._cache.pop(entry['key'])
       self._cache[key] = entry
 

--- a/datalab/utils/_utils.py
+++ b/datalab/utils/_utils.py
@@ -11,6 +11,10 @@
 # the License.
 
 """Miscellaneous simple utility functions."""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import str
 
 import pytz
 import traceback
@@ -24,7 +28,7 @@ def print_exception_with_last_stack(e):
     e: the exception to print.
   """
   traceback.print_exc()
-  print str(e)
+  print(str(e))
 
 
 def get_item(env, name, default=None):

--- a/datalab/utils/commands/__init__.py
+++ b/datalab/utils/commands/__init__.py
@@ -10,15 +10,18 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
 # Support functions for magics and display help.
-from _commands import CommandParser
-from _html import Html, HtmlBuilder
-from _utils import *
+from ._commands import CommandParser
+from ._html import Html, HtmlBuilder
+from ._utils import *
 
 # Magics
-import _chart
-import _chart_data
-import _csv
-import _extension
-import _job
-import _modules
+from . import _chart
+from . import _chart_data
+from . import _csv
+from . import _extension
+from . import _job
+from . import _modules

--- a/datalab/utils/commands/_chart.py
+++ b/datalab/utils/commands/_chart.py
@@ -11,6 +11,8 @@
 # the License.
 
 """Google Cloud Platform library - Chart cell magic."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 try:
   import IPython
@@ -19,8 +21,8 @@ try:
 except ImportError:
   raise Exception('This module can only be loaded in ipython.')
 
-import _commands
-import _utils
+from . import _commands
+from . import _utils
 
 
 @IPython.core.magic.register_line_cell_magic

--- a/datalab/utils/commands/_chart_data.py
+++ b/datalab/utils/commands/_chart_data.py
@@ -11,6 +11,9 @@
 # the License.
 
 """Google Cloud Platform library - chart_data cell magic."""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 try:
   import IPython
@@ -24,7 +27,7 @@ import json
 import datalab.data
 import datalab.utils
 
-import _utils
+from . import _utils
 
 
 @IPython.core.magic.register_cell_magic
@@ -42,16 +45,16 @@ def _get_chart_data(line, cell_body=''):
     source_index = int(source_index)
     if source_index >= len(_utils._data_sources):  # Can happen after e.g. kernel restart
       # TODO(gram): get kernel restart events in charting.js and disable any refresh timers.
-      print 'No source %d' % source_index
+      print('No source %d' % source_index)
       return IPython.core.display.JSON({'data': {}})
     source = _utils._data_sources[source_index]
     schema = None
 
     controls = metadata['controls'] if 'controls' in metadata else {}
     data, _ = _utils.get_data(source, fields, controls, first_row, count, schema)
-  except Exception, e:
+  except Exception as e:
     datalab.utils.print_exception_with_last_stack(e)
-    print 'Failed with exception %s' % e
+    print('Failed with exception %s' % e)
     data = {}
 
   # TODO(gram): The old way - commented out below - has the advantage that it worked

--- a/datalab/utils/commands/_commands.py
+++ b/datalab/utils/commands/_commands.py
@@ -11,6 +11,9 @@
 # the License.
 
 """Implementation of command parsing and handling within magics."""
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
 try:
   import IPython
@@ -69,8 +72,7 @@ class CommandParser(argparse.ArgumentParser):
       args = CommandParser.create_args(line, namespace)
       return self.parse_args(args)
     except Exception as e:
-      if e.message:
-        print e.message
+      print(str(e))
       return None
 
   def subcommand(self, name, help):

--- a/datalab/utils/commands/_csv.py
+++ b/datalab/utils/commands/_csv.py
@@ -11,6 +11,8 @@
 # the License.
 
 """Implements CSV file exploration"""
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 
 try:
@@ -24,8 +26,8 @@ import pandas as pd
 
 import datalab.data
 
-import _commands
-import _utils
+from . import _commands
+from . import _utils
 
 
 @IPython.core.magic.register_line_cell_magic

--- a/datalab/utils/commands/_extension.py
+++ b/datalab/utils/commands/_extension.py
@@ -11,6 +11,8 @@
 # the License.
 
 """Google Cloud Platform library - Extension cell magic."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 try:
   import IPython
@@ -19,8 +21,8 @@ try:
 except ImportError:
   raise Exception('This module can only be loaded in ipython.')
 
-import _commands
-import _utils
+from . import _commands
+from . import _utils
 
 
 @IPython.core.magic.register_line_magic

--- a/datalab/utils/commands/_html.py
+++ b/datalab/utils/commands/_html.py
@@ -11,6 +11,12 @@
 # the License.
 
 """Google Cloud Platform library - IPython HTML display Functionality."""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from builtins import range
+from past.builtins import basestring
+from builtins import object
 
 import time
 
@@ -67,9 +73,9 @@ class Html(object):
     if len(self._script) != 0:
       parts.append('<script>')
       parts.append('require([')
-      parts.append(','.join(map(lambda d: '"%s"' % d[0], self._dependencies)))
+      parts.append(','.join(['"%s"' % d[0] for d in self._dependencies]))
       parts.append('], function(')
-      parts.append(','.join(map(lambda d: d[1], self._dependencies)))
+      parts.append(','.join([d[1] for d in self._dependencies]))
       parts.append(') {')
       parts.append(self._script)
       parts.append('});')
@@ -118,7 +124,7 @@ class HtmlBuilder(object):
       if first:
         first = False
         if datatype == 'dict' and not attributes:
-          attributes = o.keys()
+          attributes = list(o.keys())
 
         if attributes is not None:
           self._segments.append('<tr>')

--- a/datalab/utils/commands/_job.py
+++ b/datalab/utils/commands/_job.py
@@ -11,6 +11,9 @@
 # the License.
 
 """Implements job view"""
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
 
 
 try:
@@ -22,8 +25,8 @@ except ImportError:
 
 import datalab.utils
 
-import _commands
-import _html
+from . import _commands
+from . import _html
 
 
 _local_jobs = {}

--- a/datalab/utils/commands/_modules.py
+++ b/datalab/utils/commands/_modules.py
@@ -11,6 +11,8 @@
 # the License.
 
 """Implementation of various module magics"""
+from __future__ import absolute_import
+from __future__ import unicode_literals
 
 try:
   import IPython
@@ -21,8 +23,8 @@ except ImportError:
 import sys
 import types
 
-import _commands
-import _utils
+from . import _commands
+from . import _utils
 
 
 @IPython.core.magic.register_line_cell_magic
@@ -51,11 +53,11 @@ def _pymodule_cell(args, cell):
 
 def _create_python_module(name, code):
   # By convention the module is associated with a file name matching the module name
-  module = types.ModuleType(name)
+  module = types.ModuleType(str(name))
   module.__file__ = name
   module.__name__ = name
 
-  exec code in module.__dict__
+  exec(code, module.__dict__)
 
   # Hold on to the module if the code executed successfully
   sys.modules[name] = module

--- a/datalab/utils/commands/_utils.py
+++ b/datalab/utils/commands/_utils.py
@@ -11,6 +11,11 @@
 # the License.
 
 """Utility functions."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+from builtins import str
+from past.builtins import basestring
 
 try:
   import IPython
@@ -34,7 +39,7 @@ import datalab.bigquery
 import datalab.storage
 import datalab.utils
 
-import _html
+from . import _html
 
 
 def notebook_environment():
@@ -149,7 +154,7 @@ def _get_data_from_dataframe(source, fields='*', first_row=0, count=-1, schema=N
   df_slice = source.reset_index(drop=True)[first_row:first_row + count]
   for index, data_frame_row in df_slice.iterrows():
     row = data_frame_row.to_dict()
-    for key in row.keys():
+    for key in list(row.keys()):
       val = row[key]
       if isinstance(val, pandas.Timestamp):
         row[key] = val.to_pydatetime()
@@ -273,7 +278,7 @@ def replace_vars(config, env):
     Exception if any variable references are not found in env.
   """
   if isinstance(config, dict):
-    for k, v in config.items():
+    for k, v in list(config.items()):
       if isinstance(v, dict) or isinstance(v, list) or isinstance(v, tuple):
         replace_vars(v, env)
       elif isinstance(v, basestring):
@@ -439,7 +444,7 @@ def parse_control_options(controls, variable_defaults=None):
   div_id = _html.Html.next_id()
   if variable_defaults is None:
     variable_defaults = {}
-  for varname, control in controls.items():
+  for varname, control in list(controls.items()):
     label = control.get('label', varname)
     control_id = div_id + '__' + varname
     control_ids.append(control_id)
@@ -506,7 +511,7 @@ def parse_control_options(controls, variable_defaults=None):
       if max_ <= min_:
         raise Exception('slider control must specify a min value less than max value')
       step = control.get('step', 1 if isinstance(min_, int) and isinstance(max_, int)
-                         else (max_ - min_) / 10.0)
+                         else (float(max_ - min_) / 10.0))
       if value is None:
         value = min_
       control_html = """

--- a/install-virtualenv.sh
+++ b/install-virtualenv.sh
@@ -1,9 +1,7 @@
-+#!/bin/sh
+#!/bin/sh
 
 # Build a distribution package
 tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts
 pip install .
 jupyter nbextension install --py datalab.notebook --sys-prefix
 rm datalab/notebook/static/*.js
-
-

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ Support package for Google Cloud Datalab. This provides cell magics and Python A
 for accessing Google's Cloud Platform services such as Google BigQuery.
   """,
   install_requires=[
+    'future==0.15.2',
     'futures==3.0.5',
     'httplib2==0.9.2',
     'oauth2client==2.0.2',
@@ -71,6 +72,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
     'python-dateutil==2.5.0',
     'pytz>=2015.4',
     'pyyaml==3.11',
+    'requests==2.9.1',
     'scikit-learn==0.17.1'
   ],
   package_data={

--- a/tests/_util/http_tests.py
+++ b/tests/_util/http_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import mock
 import unittest
 
@@ -52,8 +54,10 @@ class TestCases(unittest.TestCase):
     TestCases._setup_mocks(mock_request, mock_response, '{}')
 
     Http.request('http://www.example.org', args={'a': 1, 'b': 'a b c'})
-    self.assertEqual(mock_request.call_args[0][0],
-                     'http://www.example.org?a=1&b=a+b+c')
+    parts = mock_request.call_args[0][0].replace('?', '&').split('&')
+    self.assertEqual(parts[0], 'http://www.example.org')
+    self.assertTrue('a=1' in parts[1:])
+    self.assertTrue('b=a+b+c' in parts[1:])
 
   @mock.patch('httplib2.Response')
   @mock.patch('httplib2.Http.request')

--- a/tests/_util/lru_cache_tests.py
+++ b/tests/_util/lru_cache_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import unittest
 
 from datalab.utils._lru_cache import LRUCache

--- a/tests/_util/util_tests.py
+++ b/tests/_util/util_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import imp
 import unittest
 
@@ -21,7 +23,7 @@ class TestCases(unittest.TestCase):
   @staticmethod
   def _get_data():
     m = imp.new_module('baz')
-    exec 'x = 99' in m.__dict__
+    exec('x = 99', m.__dict__)
     data = {
       'foo': {
         'bar': {

--- a/tests/bigquery/api_tests.py
+++ b/tests/bigquery/api_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import unittest
 import mock
 from oauth2client.client import AccessTokenCredentials

--- a/tests/bigquery/dataset_tests.py
+++ b/tests/bigquery/dataset_tests.py
@@ -10,6 +10,9 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
 import mock
 from oauth2client.client import AccessTokenCredentials
 import unittest

--- a/tests/bigquery/federated_table_tests.py
+++ b/tests/bigquery/federated_table_tests.py
@@ -10,6 +10,9 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+import collections
 import mock
 from oauth2client.client import AccessTokenCredentials
 import unittest
@@ -44,13 +47,15 @@ class TestCases(unittest.TestCase):
 
   @staticmethod
   def _get_data():
-    return [
-      {'day': 1, 'weight': 220},
-      {'day': 2, 'weight': 221},
-      {'day': 3, 'weight': 220},
-      {'day': 4, 'weight': 219},
-      {'day': 5, 'weight': 218},
-    ]
+    data = []
+    day = 1
+    for weight in [220, 221, 220, 219, 218]:
+      d = collections.OrderedDict()
+      data.append(d)
+      d['day'] = day
+      day += 1
+      d['weight'] = weight
+    return data
 
   @staticmethod
   def _get_table_definition(uris, skip_rows=0):

--- a/tests/bigquery/jobs_tests.py
+++ b/tests/bigquery/jobs_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import mock
 from oauth2client.client import AccessTokenCredentials
 import unittest

--- a/tests/bigquery/parser_tests.py
+++ b/tests/bigquery/parser_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import unittest
 import datalab.bigquery as bq
 

--- a/tests/bigquery/query_tests.py
+++ b/tests/bigquery/query_tests.py
@@ -10,6 +10,9 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
 import mock
 from oauth2client.client import AccessTokenCredentials
 import unittest
@@ -89,7 +92,7 @@ class TestCases(unittest.TestCase):
 
     with self.assertRaises(Exception) as error:
       _ = q.results()
-    self.assertEqual('Unexpected response from server', error.exception[0])
+    self.assertEqual('Unexpected response from server', str(error.exception))
 
   def test_udf_expansion(self):
     sql = 'SELECT * FROM udf(source)'

--- a/tests/bigquery/sampling_tests.py
+++ b/tests/bigquery/sampling_tests.py
@@ -10,8 +10,10 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import unittest
-from datalab.bigquery._sampling import Sampling
+from datalab.bigquery import Sampling
 
 
 class TestCases(unittest.TestCase):

--- a/tests/bigquery/schema_tests.py
+++ b/tests/bigquery/schema_tests.py
@@ -10,8 +10,11 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import collections
 import pandas
+import sys
 import unittest
 
 import datalab.bigquery
@@ -61,17 +64,30 @@ class TestCases(unittest.TestCase):
 
     with self.assertRaises(Exception) as error1:
       _ = datalab.bigquery.Schema.from_data(variant1)
-    self.assertEquals('Cannot create a schema from heterogeneous list [3, 2.0, True, ' +
-                      '[\'cow\', \'horse\', [0, []]]]; perhaps you meant to use ' +
-                      'Schema.from_record?', error1.exception[0])
+    if sys.version_info[0] == 3:
+      self.assertEquals('Cannot create a schema from heterogeneous list [3, 2.0, True, ' +
+                        '[\'cow\', \'horse\', [0, []]]]; perhaps you meant to use ' +
+                        'Schema.from_record?', str(error1.exception))
+    else:
+      self.assertEquals('Cannot create a schema from heterogeneous list [3, 2.0, True, ' +
+                        '[u\'cow\', u\'horse\', [0, []]]]; perhaps you meant to use ' +
+                        'Schema.from_record?', str(error1.exception))
     with self.assertRaises(Exception) as error2:
       _ = datalab.bigquery.Schema.from_data(variant2)
-    self.assertEquals('Cannot create a schema from dict OrderedDict([(\'Column1\', 3), ' +
-                      '(\'Column2\', 2.0), (\'Column3\', True), (\'Column4\', ' +
-                      'OrderedDict([(\'Column1\', \'cow\'), (\'Column2\', \'horse\'), ' +
-                      '(\'Column3\', OrderedDict([(\'Column1\', 0), (\'Column2\', ' +
-                      'OrderedDict())]))]))]); perhaps you meant to use Schema.from_record?',
-                      error2.exception[0])
+    if sys.version_info[0] == 3:
+      self.assertEquals('Cannot create a schema from dict OrderedDict([(\'Column1\', 3), ' +
+                        '(\'Column2\', 2.0), (\'Column3\', True), (\'Column4\', ' +
+                        'OrderedDict([(\'Column1\', \'cow\'), (\'Column2\', \'horse\'), ' +
+                        '(\'Column3\', OrderedDict([(\'Column1\', 0), (\'Column2\', ' +
+                        'OrderedDict())]))]))]); perhaps you meant to use Schema.from_record?',
+                        str(error2.exception))
+    else:
+      self.assertEquals('Cannot create a schema from dict OrderedDict([(u\'Column1\', 3), ' +
+                        '(u\'Column2\', 2.0), (u\'Column3\', True), (u\'Column4\', ' +
+                        'OrderedDict([(u\'Column1\', u\'cow\'), (u\'Column2\', u\'horse\'), ' +
+                        '(u\'Column3\', OrderedDict([(u\'Column1\', 0), (u\'Column2\', ' +
+                        'OrderedDict())]))]))]); perhaps you meant to use Schema.from_record?',
+                        str(error2.exception))
     schema3 = datalab.bigquery.Schema.from_data([variant1])
     schema4 = datalab.bigquery.Schema.from_data([variant2])
     schema5 = datalab.bigquery.Schema.from_data(master)

--- a/tests/bigquery/table_tests.py
+++ b/tests/bigquery/table_tests.py
@@ -10,6 +10,10 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
+from builtins import object
 import calendar
 import datetime as dt
 import mock
@@ -35,7 +39,8 @@ class TestCases(unittest.TestCase):
 
   def test_api_paths(self):
     name = datalab.bigquery._utils.TableName('a', 'b', 'c', 'd')
-    self.assertEqual('/projects/a/datasets/b/tables/cd', datalab.bigquery._api.Api._TABLES_PATH % name)
+    self.assertEqual('/projects/a/datasets/b/tables/cd',
+                     datalab.bigquery._api.Api._TABLES_PATH % name)
     self.assertEqual('/projects/a/datasets/b/tables/cd/data',
                      datalab.bigquery._api.Api._TABLEDATA_PATH % name)
     name = datalab.bigquery._utils.DatasetName('a', 'b')
@@ -133,7 +138,7 @@ class TestCases(unittest.TestCase):
 
     with self.assertRaises(Exception) as error:
       _ = t.schema
-    self.assertEqual(error.exception[0], 'Unexpected table response: missing schema')
+    self.assertEqual('Unexpected table response: missing schema', str(error.exception))
 
   @mock.patch('datalab.bigquery._api.Api.tables_list')
   @mock.patch('datalab.bigquery._api.Api.datasets_get')
@@ -217,7 +222,7 @@ class TestCases(unittest.TestCase):
     with self.assertRaises(Exception) as error:
       _ = TestCases._create_table_with_schema(schema)
     self.assertEqual('Table test:testds.testTable0 could not be created as it already exists',
-                     error.exception[0])
+                     str(error.exception))
 
     mock_api_tables_insert.return_value = {'selfLink': 'http://foo'}
     self.assertIsNotNone(TestCases._create_table_with_schema(schema), 'Expected a table')
@@ -250,7 +255,7 @@ class TestCases(unittest.TestCase):
 
     with self.assertRaises(Exception) as error:
       table.insert_data(df)
-    self.assertEqual('Table %s does not exist.' % str(table), error.exception[0])
+    self.assertEqual('Table %s does not exist.' % str(table), str(error.exception))
 
   @mock.patch('uuid.uuid4')
   @mock.patch('time.sleep')
@@ -283,7 +288,7 @@ class TestCases(unittest.TestCase):
 
     with self.assertRaises(Exception) as error:
       table.insert_data(df)
-    self.assertEqual('Table does not contain field headers', error.exception[0])
+    self.assertEqual('Table does not contain field headers', str(error.exception))
 
   @mock.patch('uuid.uuid4')
   @mock.patch('time.sleep')
@@ -318,7 +323,7 @@ class TestCases(unittest.TestCase):
     with self.assertRaises(Exception) as error:
       table.insert_data(df)
     self.assertEqual('Field headers in data has type FLOAT but in table has type STRING',
-                     error.exception[0])
+                     str(error.exception))
 
   @mock.patch('uuid.uuid4')
   @mock.patch('time.sleep')
@@ -539,24 +544,24 @@ class TestCases(unittest.TestCase):
     with self.assertRaises(Exception) as error:
       tbl2 = tbl2.snapshot(dt.timedelta(hours=-2))
     self.assertEqual('Cannot use snapshot() on an already decorated table',
-                     error.exception[0])
+                     str(error.exception))
 
     with self.assertRaises(Exception) as error:
       _ = tbl2.window(dt.timedelta(hours=-2), 0)
     self.assertEqual('Cannot use window() on an already decorated table',
-                     error.exception[0])
+                     str(error.exception))
 
     with self.assertRaises(Exception) as error:
       _ = tbl.snapshot(dt.timedelta(days=-8))
     self.assertEqual(
         'Invalid snapshot relative when argument: must be within 7 days: -8 days, 0:00:00',
-        error.exception[0])
+        str(error.exception))
 
     with self.assertRaises(Exception) as error:
       _ = tbl.snapshot(dt.timedelta(days=-8))
     self.assertEqual(
         'Invalid snapshot relative when argument: must be within 7 days: -8 days, 0:00:00',
-        error.exception[0])
+        str(error.exception))
 
     tbl2 = tbl.snapshot(dt.timedelta(days=-1))
     self.assertEquals('test:testds.testTable0@-86400000', str(tbl2))
@@ -564,12 +569,12 @@ class TestCases(unittest.TestCase):
     with self.assertRaises(Exception) as error:
       _ = tbl.snapshot(dt.timedelta(days=1))
     self.assertEqual('Invalid snapshot relative when argument: 1 day, 0:00:00',
-                     error.exception[0])
+                     str(error.exception))
 
     with self.assertRaises(Exception) as error:
       tbl2 = tbl.snapshot(1000)
     self.assertEqual('Invalid snapshot when argument type: 1000',
-                     error.exception[0])
+                     str(error.exception))
 
     _ = dt.datetime.utcnow() - dt.timedelta(1)
     self.assertEquals('test:testds.testTable0@-86400000', str(tbl2))
@@ -578,13 +583,13 @@ class TestCases(unittest.TestCase):
     with self.assertRaises(Exception) as error:
       _ = tbl.snapshot(when)
     self.assertEqual('Invalid snapshot absolute when argument: %s' % when,
-                     error.exception[0])
+                     str(error.exception))
 
     when = dt.datetime.utcnow() - dt.timedelta(8)
     with self.assertRaises(Exception) as error:
       _ = tbl.snapshot(when)
     self.assertEqual('Invalid snapshot absolute when argument: %s' % when,
-                     error.exception[0])
+                     str(error.exception))
 
   def test_window_decorators(self):
     # The at test above already tests many of the conversion cases. The extra things we
@@ -598,18 +603,18 @@ class TestCases(unittest.TestCase):
     with self.assertRaises(Exception) as error:
       tbl2 = tbl2.window(-400000, 0)
     self.assertEqual('Cannot use window() on an already decorated table',
-                     error.exception[0])
+                     str(error.exception))
 
     with self.assertRaises(Exception) as error:
       _ = tbl2.snapshot(-400000)
     self.assertEqual('Cannot use snapshot() on an already decorated table',
-                     error.exception[0])
+                     str(error.exception))
 
     with self.assertRaises(Exception) as error:
       _ = tbl.window(dt.timedelta(0), dt.timedelta(hours=-1))
     self.assertEqual(
         'window: Between arguments: begin must be before end: 0:00:00, -1 day, 23:00:00',
-        error.exception[0])
+        str(error.exception))
 
   @mock.patch('datalab.bigquery._api.Api.tables_get')
   @mock.patch('datalab.bigquery._api.Api.table_update')

--- a/tests/bigquery/udf_tests.py
+++ b/tests/bigquery/udf_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from oauth2client.client import AccessTokenCredentials
 import unittest
 

--- a/tests/bigquery/view_tests.py
+++ b/tests/bigquery/view_tests.py
@@ -10,6 +10,9 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import str
 import mock
 from oauth2client.client import AccessTokenCredentials
 import unittest

--- a/tests/kernel/bigquery_tests.py
+++ b/tests/kernel/bigquery_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import mock
 from oauth2client.client import AccessTokenCredentials
 import unittest

--- a/tests/kernel/chart_data_tests.py
+++ b/tests/kernel/chart_data_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import json
 import mock
 import unittest

--- a/tests/kernel/chart_tests.py
+++ b/tests/kernel/chart_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import unittest
 
 # import Python so we can mock the parts we need to here.
@@ -38,10 +40,11 @@ class TestCases(unittest.TestCase):
     self.assertTrue(chart.find('charts.render(') > 0)
     self.assertTrue(chart.find('\'geo\'') > 0)
     self.assertTrue(chart.find('"fields": "*"') > 0)
-    self.assertTrue(chart.find('{"c": [{"v": "US"}, {"v": 100}]}') > 0)
-    self.assertTrue(chart.find('{"c": [{"v": "ZA"}, {"v": 50}]}') > 0)
-    self.assertTrue(chart.find('"cols": [{"type": "string", "id": "country", "label": "country"},' +
-                               ' {"type": "number", "id": "quantity", "label": "quantity"}]}') > 0)
+    self.assertTrue(chart.find('{"c": [{"v": "US"}, {"v": 100}]}') > 0 or 
+                    chart.find('{"c": [{"v": 100}, {"v": "US"}]}') > 0)
+    self.assertTrue(chart.find('{"c": [{"v": "ZA"}, {"v": 50}]}') > 0 or
+                    chart.find('{"c": [{"v": 50}, {"v": "ZA"}]}') > 0)
+
 
   def test_chart_magic(self):
     # TODO(gram): complete this test

--- a/tests/kernel/commands_tests.py
+++ b/tests/kernel/commands_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import mock
 import unittest
 

--- a/tests/kernel/html_tests.py
+++ b/tests/kernel/html_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import mock
 import unittest
 

--- a/tests/kernel/module_tests.py
+++ b/tests/kernel/module_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import mock
 import sys
 import unittest

--- a/tests/kernel/sql_tests.py
+++ b/tests/kernel/sql_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import imp
 import mock
 from oauth2client.client import AccessTokenCredentials
@@ -37,56 +39,61 @@ import datalab.utils.commands
 
 class TestCases(unittest.TestCase):
 
+  _SQL_MODULE_MAIN = datalab.data._utils._SQL_MODULE_MAIN
+  _SQL_MODULE_LAST = datalab.data._utils._SQL_MODULE_LAST
+
   def test_split_cell(self):
     # TODO(gram): add tests for argument parser.
     m = imp.new_module('m')
     query = datalab.data.commands._sql._split_cell('', m)
     self.assertIsNone(query)
-    self.assertNotIn(datalab.data.SqlModule._SQL_MODULE_LAST, m.__dict__)
-    self.assertNotIn(datalab.data.SqlModule._SQL_MODULE_MAIN, m.__dict__)
+    self.assertNotIn(TestCases._SQL_MODULE_LAST, m.__dict__)
+    self.assertNotIn(TestCases._SQL_MODULE_MAIN, m.__dict__)
 
     m = imp.new_module('m')
     query = datalab.data.commands._sql._split_cell('\n\n', m)
     self.assertIsNone(query)
-    self.assertNotIn(datalab.data.SqlModule._SQL_MODULE_LAST, m.__dict__)
-    self.assertNotIn(datalab.data.SqlModule._SQL_MODULE_MAIN, m.__dict__)
+    self.assertNotIn(TestCases._SQL_MODULE_LAST, m.__dict__)
+    self.assertNotIn(TestCases._SQL_MODULE_MAIN, m.__dict__)
 
     m = imp.new_module('m')
     query = datalab.data.commands._sql._split_cell('SELECT 3 AS x', m)
-    self.assertEquals(query, m.__dict__[datalab.data.SqlModule._SQL_MODULE_MAIN])
-    self.assertEquals(query, m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST])
-    self.assertEquals('SELECT 3 AS x', m.__dict__[datalab.data.SqlModule._SQL_MODULE_MAIN].sql)
-    self.assertEquals('SELECT 3 AS x', m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST].sql)
+    self.assertEquals(query, m.__dict__[TestCases._SQL_MODULE_MAIN])
+    self.assertEquals(query, m.__dict__[TestCases._SQL_MODULE_LAST])
+    self.assertEquals('SELECT 3 AS x', m.__dict__[TestCases._SQL_MODULE_MAIN].sql)
+    self.assertEquals('SELECT 3 AS x', m.__dict__[TestCases._SQL_MODULE_LAST].sql)
 
     m = imp.new_module('m')
     query = datalab.data.commands._sql._split_cell('# This is a comment\n\nSELECT 3 AS x', m)
-    self.assertEquals(query, m.__dict__[datalab.data.SqlModule._SQL_MODULE_MAIN])
-    self.assertEquals(query, m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST])
-    self.assertEquals('SELECT 3 AS x', m.__dict__[datalab.data.SqlModule._SQL_MODULE_MAIN].sql)
-    self.assertEquals('SELECT 3 AS x', m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST].sql)
+    self.assertEquals(query, m.__dict__[TestCases._SQL_MODULE_MAIN])
+    self.assertEquals(query, m.__dict__[TestCases._SQL_MODULE_LAST])
+    self.assertEquals('SELECT 3 AS x', m.__dict__[TestCases._SQL_MODULE_MAIN].sql)
+    self.assertEquals('SELECT 3 AS x', m.__dict__[TestCases._SQL_MODULE_LAST].sql)
 
     m = imp.new_module('m')
-    query = datalab.data.commands._sql._split_cell('# This is a comment\n\nfoo="bar"\nSELECT 3 AS x', m)
-    self.assertEquals(query, m.__dict__[datalab.data.SqlModule._SQL_MODULE_MAIN])
-    self.assertEquals(query, m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST])
-    self.assertEquals('SELECT 3 AS x', m.__dict__[datalab.data.SqlModule._SQL_MODULE_MAIN].sql)
-    self.assertEquals('SELECT 3 AS x', m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST].sql)
+    query = datalab.data.commands._sql._split_cell(
+        '# This is a comment\n\nfoo="bar"\nSELECT 3 AS x', m)
+    self.assertEquals(query, m.__dict__[TestCases._SQL_MODULE_MAIN])
+    self.assertEquals(query, m.__dict__[TestCases._SQL_MODULE_LAST])
+    self.assertEquals('SELECT 3 AS x', m.__dict__[TestCases._SQL_MODULE_MAIN].sql)
+    self.assertEquals('SELECT 3 AS x', m.__dict__[TestCases._SQL_MODULE_LAST].sql)
 
     m = imp.new_module('m')
     query = datalab.data.commands._sql._split_cell('DEFINE QUERY q1\nSELECT 3 AS x', m)
-    self.assertEquals(query, m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST])
-    self.assertEquals(query, m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST])
+    self.assertEquals(query, m.__dict__[TestCases._SQL_MODULE_LAST])
+    self.assertEquals(query, m.__dict__[TestCases._SQL_MODULE_LAST])
     self.assertEquals('SELECT 3 AS x', m.q1.sql)
-    self.assertNotIn(datalab.data.SqlModule._SQL_MODULE_MAIN, m.__dict__)
-    self.assertEquals('SELECT 3 AS x', m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST].sql)
+    self.assertNotIn(TestCases._SQL_MODULE_MAIN, m.__dict__)
+    self.assertEquals('SELECT 3 AS x', m.__dict__[TestCases._SQL_MODULE_LAST].sql)
 
     m = imp.new_module('m')
-    query = datalab.data.commands._sql._split_cell('DEFINE QUERY q1\nSELECT 3 AS x\nSELECT * FROM $q1', m)
-    self.assertEquals(query, m.__dict__[datalab.data.SqlModule._SQL_MODULE_MAIN])
-    self.assertEquals(query, m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST])
+    query = datalab.data.commands._sql._split_cell(
+        'DEFINE QUERY q1\nSELECT 3 AS x\nSELECT * FROM $q1', m)
+    self.assertEquals(query, m.__dict__[TestCases._SQL_MODULE_MAIN])
+    self.assertEquals(query, m.__dict__[TestCases._SQL_MODULE_LAST])
     self.assertEquals('SELECT 3 AS x', m.q1.sql)
-    self.assertEquals('SELECT * FROM $q1', m.__dict__[datalab.data.SqlModule._SQL_MODULE_MAIN].sql)
-    self.assertEquals('SELECT * FROM $q1', m.__dict__[datalab.data.SqlModule._SQL_MODULE_LAST].sql)
+    self.assertEquals('SELECT * FROM $q1', m.__dict__[TestCases._SQL_MODULE_MAIN].sql)
+    self.assertEquals('SELECT * FROM $q1', m.__dict__[TestCases._SQL_MODULE_LAST].sql)
 
   @mock.patch('datalab.context._context.Context.default')
   def test_arguments(self, mock_default_context):

--- a/tests/kernel/storage_tests.py
+++ b/tests/kernel/storage_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import mock
 from oauth2client.client import AccessTokenCredentials
 import unittest
@@ -114,7 +116,7 @@ class TestCases(unittest.TestCase):
         'destination': 'gs://foo/bar1'
       }, None)
     self.assertEqual('More than one source but target gs://foo/bar1 is not a bucket',
-                     error.exception.message)
+                     str(error.exception))
 
   @mock.patch('datalab.storage.commands._storage._storage_copy', autospec=True)
   def test_storage_copy_magic(self, mock_storage_copy):
@@ -148,7 +150,7 @@ class TestCases(unittest.TestCase):
         ]
       }, None)
     self.assertEqual("Couldn't create gs://foo/bar: Invalid bucket name gs://foo/bar",
-                     error.exception.message)
+                     str(error.exception))
 
   @mock.patch('datalab.storage._api.Api.buckets_get', autospec=True)
   @mock.patch('datalab.storage._api.Api.objects_get', autospec=True)
@@ -179,7 +181,7 @@ class TestCases(unittest.TestCase):
         ]
       }, None)
     self.assertEqual('gs://baz does not exist\ngs://baz/item1 does not exist',
-                     error.exception.message)
+                     str(error.exception))
     mock_api_bucket_delete.assert_called_with(mock.ANY, 'bar')
     mock_api_objects_delete.assert_called_with(mock.ANY, 'foo', 'item1')
 

--- a/tests/kernel/utils_tests.py
+++ b/tests/kernel/utils_tests.py
@@ -10,6 +10,9 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from builtins import range
 import datetime as dt
 import collections
 import mock
@@ -122,7 +125,7 @@ class TestCases(unittest.TestCase):
     ]
     # Use OrderedDicts to make testing the result easier.
     for i in range(0, len(test_data)):
-      test_data[i] = collections.OrderedDict(sorted(test_data[i].items(), key=lambda t: t[0]))
+      test_data[i] = collections.OrderedDict(sorted(list(test_data[i].items()), key=lambda t: t[0]))
 
     return test_data
 
@@ -201,7 +204,7 @@ class TestCases(unittest.TestCase):
     with self.assertRaises(Exception) as error:
       self._test_get_data(['foo', 'bar'], [], [], 0, datalab.utils.commands._utils.get_data)
     self.assertEquals('To get tabular data from a list it must contain dictionaries or lists.',
-                      error.exception.message)
+                      str(error.exception))
 
   def _test_get_data(self, test_data, cols, rows, expected_count, fn):
     self.maxDiff = None

--- a/tests/main.py
+++ b/tests/main.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import os
 import sys
 import unittest

--- a/tests/storage/api_tests.py
+++ b/tests/storage/api_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import unittest
 import mock
 from oauth2client.client import AccessTokenCredentials

--- a/tests/storage/bucket_tests.py
+++ b/tests/storage/bucket_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import mock
 from oauth2client.client import AccessTokenCredentials
 import unittest

--- a/tests/storage/item_tests.py
+++ b/tests/storage/item_tests.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import mock
 from oauth2client.client import AccessTokenCredentials
 import unittest
@@ -21,15 +23,17 @@ import datalab.utils
 
 class TestCases(unittest.TestCase):
 
+  @mock.patch('datalab.storage._api.Api.objects_list')
   @mock.patch('datalab.storage._api.Api.objects_get')
-  def test_item_existence(self, mock_api_objects):
-    mock_api_objects.return_value = TestCases._create_objects_get_result()
+  def test_item_existence(self, mock_api_objects_get, mock_api_objects_list):
+    mock_api_objects_list.return_value = TestCases._create_enumeration_single_result()
+    mock_api_objects_get.return_value = TestCases._create_objects_get_result()
 
     b = TestCases._create_bucket()
     self.assertTrue(b.items().contains('test_item1'))
 
-    mock_api_objects.side_effect = datalab.utils.RequestException(404, 'failed')
-    self.assertFalse(b.items().contains('test_item2'))
+    mock_api_objects_get.side_effect = datalab.utils.RequestException(404, 'failed')
+    self.assertFalse('test_item2' in list(b.items()))
 
   @mock.patch('datalab.storage._api.Api.objects_get')
   def test_item_metadata(self, mock_api_objects):


### PR DESCRIPTION
This is valuable as Jupyter is starting to default to Python 3 for new notebooks, and we have had customers trying to use our package in Python 3 environments.

In many files this just involved a couple of extra imports from the Python future package. I had to eliminate circular imports too because the way they can be handled in Python 2 doesn't work in Python 3 and vice-versa. 

The main other change is that strings in Py3 are unicode, so we need to deal with that in a few places.
