### PR TITLE
Monitoring API

### DIFF
--- a/datalab/kernel/__init__.py
+++ b/datalab/kernel/__init__.py
@@ -31,6 +31,7 @@ import datalab.context as _context
 import datalab.bigquery.commands
 import datalab.context.commands
 import datalab.data.commands
+import datalab.stackdriver.commands
 import datalab.storage.commands
 import datalab.utils.commands
 

--- a/datalab/stackdriver/__init__.py
+++ b/datalab/stackdriver/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Google Cloud Platform library - Stackdriver Functionality."""

--- a/datalab/stackdriver/commands/__init__.py
+++ b/datalab/stackdriver/commands/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+
+from __future__ import absolute_import
+
+from . import _monitoring

--- a/datalab/stackdriver/commands/_monitoring.py
+++ b/datalab/stackdriver/commands/_monitoring.py
@@ -1,0 +1,101 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""IPython Functionality for the Google Monitoring API."""
+from __future__ import absolute_import
+
+try:
+  import IPython
+  import IPython.core.display
+  import IPython.core.magic
+except ImportError:
+  raise Exception('This module can only be loaded in ipython.')
+
+import collections
+import fnmatch
+
+import datalab.stackdriver.monitoring as gcm
+import datalab.utils.commands
+
+
+@IPython.core.magic.register_line_magic
+def monitoring(line):
+  """Implements the monitoring line magic for ipython notebooks.
+
+  Args:
+    line: the contents of the storage line.
+  Returns:
+    The results of executing the cell.
+  """
+  parser = datalab.utils.commands.CommandParser(prog='monitoring', description=(
+      'Execute various Monitoring-related operations. Use "%monitoring '
+      '<command> -h" for help on a specific command.'))
+
+  list_parser = parser.subcommand(
+      'list', 'List the metrics or resource types in a monitored project.')
+
+  list_metric_parser = list_parser.subcommand(
+      'metrics',
+      'List the metrics that are available through the Monitoring API.')
+  list_metric_parser.add_argument(
+      '-t', '--type',
+      help='The type of metric(s) to list; can include wildchars.')
+  list_metric_parser.add_argument(
+      '-p', '--project', help='The project on which to execute the request.')
+  list_metric_parser.set_defaults(func=_list_metric_descriptors)
+
+  list_resource_parser = list_parser.subcommand(
+      'resource_types',
+      ('List the monitored resource types that are available through the '
+       'Monitoring API.'))
+  list_resource_parser.add_argument(
+      '-p', '--project', help='The project on which to execute the request.')
+  list_resource_parser.add_argument(
+      '-t', '--type',
+      help='The resource type(s) to list; can include wildchars.')
+  list_resource_parser.set_defaults(func=_list_resource_descriptors)
+
+  return datalab.utils.commands.handle_magic_line(line, None, parser)
+
+
+def _list_resource_descriptors(args, _):
+  """Lists the resource descriptors in the project."""
+  project_id = args['project']
+  pattern = args['type'] or '*'
+  data = [
+      collections.OrderedDict([
+          ('Resource type', resource.type),
+          ('Labels', ', '. join([l.key for l in resource.labels])),
+      ])
+      for resource in gcm._utils.list_resource_descriptors(project_id)
+      if fnmatch.fnmatch(resource.type, pattern)
+  ]
+  return IPython.core.display.HTML(
+      datalab.utils.commands.HtmlBuilder.render_table(data))
+
+
+def _list_metric_descriptors(args, _):
+  """Lists the metric descriptors in the project."""
+  project_id = args['project']
+  pattern = args['type'] or '*'
+  data = [
+      collections.OrderedDict([
+          ('Metric type', metric.type),
+          ('Kind', metric.metric_kind),
+          ('Value', metric.value_type),
+          ('Labels', ', '. join([l.key for l in metric.labels])),
+      ])
+      for metric in gcm._utils.list_metric_descriptors(project_id)
+      if fnmatch.fnmatch(metric.type, pattern)
+  ]
+  return IPython.core.display.HTML(
+      datalab.utils.commands.HtmlBuilder.render_table(data))

--- a/datalab/stackdriver/monitoring/__init__.py
+++ b/datalab/stackdriver/monitoring/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Google Cloud Platform library - Monitoring Functionality."""
+
+from __future__ import absolute_import
+
+from gcloud.monitoring import Aligner, Reducer
+from ._timeseries import Query

--- a/datalab/stackdriver/monitoring/_timeseries.py
+++ b/datalab/stackdriver/monitoring/_timeseries.py
@@ -1,0 +1,95 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Provides access to metric data as pandas dataframes."""
+
+from __future__ import absolute_import
+
+import gcloud.monitoring
+import pandas
+
+from . import _utils
+
+
+class Query(gcloud.monitoring.Query):
+  """Query object for retrieving metric data."""
+
+  def __init__(self,
+               metric_type=gcloud.monitoring.Query.DEFAULT_METRIC_TYPE,
+               end_time=None, days=0, hours=0, minutes=0,
+               project_id=None, context=None):
+    """Initializes the core query parameters.
+
+    The start time (exclusive) is determined by combining the
+    values of "days", "hours", and "minutes", and subtracting
+    the resulting duration from "end_time".
+
+    It is also allowed to omit the end time and duration here,
+    in which case the select_interval() method must be called
+    before the query is executed.
+
+    Args:
+      metric_type: The metric type name. The default value is
+          "compute.googleapis.com/instance/cpu/utilization", but
+          please note that this default value is provided only for
+          demonstration purposes and is subject to change.
+      end_time: The end time (inclusive) of the time interval for which
+          results should be returned, as a datetime object. The default
+          is the start of the current minute.
+      days: The number of days in the time interval.
+      hours: The number of hours in the time interval.
+      minutes: The number of minutes in the time interval.
+      project_id: An optional project ID or number to override the one provided
+          by the context.
+      context: An optional Context object to use instead of the global default.
+
+    Raises:
+        ValueError: "end_time" was specified but "days", "hours", and "minutes"
+            are all zero. If you really want to specify a point in time, use
+            the select_interval() method.
+    """
+    client = _utils.make_client(project_id, context)
+    super(Query, self).__init__(client, metric_type,
+                                end_time=end_time,
+                                days=days, hours=hours, minutes=minutes)
+
+  def labels_as_dataframe(self):
+    """Returns the resource and metric metadata as a dataframe.
+
+    Returns:
+      A pandas dataframe containing the resource type and resource and metric
+      labels. Each row in this dataframe corresponds to the metadata from one
+      time series.
+    """
+    headers = [{'resource': ts.resource.__dict__, 'metric': ts.metric.__dict__}
+               for ts in self.iter(headers_only=True)]
+    if not headers:
+      return pandas.DataFrame()
+    df = pandas.io.json.json_normalize(headers)
+
+    # Add a 2 level column header.
+    df.columns = pandas.MultiIndex.from_tuples(
+        [col.rsplit('.', 1) for col in df.columns])
+
+    # Re-order the columns.
+    resource_keys = gcloud.monitoring._dataframe._sorted_resource_labels(
+        df['resource.labels'].columns)
+    sorted_columns = [('resource', 'type')]
+    sorted_columns += [('resource.labels', key) for key in resource_keys]
+    sorted_columns += sorted(col for col in df.columns
+                             if col[0] == 'metric.labels')
+    df = df[sorted_columns]
+
+    # Sort the data, and clean up index values, and NaNs.
+    df = df.sort_values(sorted_columns).reset_index(drop=True)
+    df = df.fillna('')
+    return df

--- a/datalab/stackdriver/monitoring/_utils.py
+++ b/datalab/stackdriver/monitoring/_utils.py
@@ -1,0 +1,40 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.  See the License for the specific language governing permissions and limitations under
+# the License.
+
+"""Provides utility methods for the Monitoring API."""
+
+from __future__ import absolute_import
+
+import gcloud.monitoring
+
+import datalab.context
+
+
+def make_client(project_id=None, context=None):
+  context = context or datalab.context.Context.default()
+  project_id = project_id or context.project_id
+  return gcloud.monitoring.Client(
+      project=project_id,
+      credentials=context.credentials,
+  )
+
+
+def list_resource_descriptors(project_id=None, context=None):
+  """Retuns a list of all resource descriptors."""
+  client = make_client(project_id, context)
+  return client.list_resource_descriptors()
+
+
+def list_metric_descriptors(project_id=None, context=None):
+  """Retuns a list of all metric descriptors."""
+  client = make_client(project_id, context)
+  return client.list_metric_descriptors()

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,9 @@ setup(
     'datalab.data.commands',
     'datalab.kernel',
     'datalab.notebook',
+    'datalab.stackdriver',
+    'datalab.stackdriver.commands',
+    'datalab.stackdriver.monitoring',
     'datalab.storage',
     'datalab.storage.commands',
     'datalab.utils',
@@ -65,6 +68,7 @@ for accessing Google's Cloud Platform services such as Google BigQuery.
   install_requires=[
     'future==0.15.2',
     'futures==3.0.5',
+    'gcloud==0.14.0',
     'httplib2==0.9.2',
     'oauth2client==2.0.2',
     'pandas>=0.17.1',


### PR DESCRIPTION
This initial version of the monitoring client for Datalab allows users
to query timeseries data. It introduces a new module under datalab that
users can import using:

    from datalab.stackdriver import monitoring

Querying timeseries data:

There is a `Query` class that allows users to query timeseries data
for their monitored resources. They can initialize the query by specifying a
metric type and time interval, and refine it by adding filters to it.

The timeseries data is returned as a pandas DataFrame that allows users
to further manipulate the data and visualize it within Datalab.

IPython magics:

There are a couple of IPython magic commands to allow users to list
details of the available metrics and resource types. E.g.:

    %%monitoring list metrics

The base library:

This library is built on top of the gcloud-python monitoring library,
and you can look at its docs here:
https://gcloud-python.readthedocs.io/en/latest/monitoring-usage.html

The Datalab library adds interactive features to it to make it more user
friendly for use in an interactive fashion.

The authors of this code are @rimey and myself, both at Google.