### PR TITLE
Improve the visibility around setting a default project.

### DIFF
--- a/datalab/context/_context.py
+++ b/datalab/context/_context.py
@@ -57,6 +57,8 @@ class Context(object):
     Returns:
       The current project id to associate with API requests.
     """
+    if not self._project_id:
+      raise Exception('No project ID found. Perhaps you should set one with the "%projects set ..." magic.')
     return self._project_id
 
   def set_project_id(self, project_id):

--- a/datalab/context/commands/_projects.py
+++ b/datalab/context/commands/_projects.py
@@ -52,5 +52,6 @@ def _list_line(args, _):
 
 
 def _set_line(args, _):
+  id_ = args['id'] if args['id'] else ''
   context = datalab.context.Context.default()
-  context.set_project_id(['id'])
+  context.set_project_id(id_)


### PR DESCRIPTION
A number of the datalab libraries require either:
1. Explicitly passing in a Context object with a project_id set
or
2. Setting the project_id in the default Context instance.

When neither of those were done, the subsequent API calls
could fail with very confusing error messages (such as "Not found").

This changes the libraries so that an error is surfaced earlier,
with an explicit explanation of what has gone wrong, and with
instructions on how to fix the issue.

Specifically, attempts to read the 'project_id' property of
a Context object will raise an error if that property has not
been set. The error message will explain that the 'project_id'
has not been set, and will suggest using the '%projects set'
cell magic to set a default project.

This change also fixes the '%projects set' cell magic so that
it actually sets the project ID to be the passed in argument,
rather than a singleton list of the literal string 'id'.