### PR TITLE
Fix a bug in the importing of the _query package.

### DIFF
--- a/datalab/bigquery/_table.py
+++ b/datalab/bigquery/_table.py
@@ -250,6 +250,8 @@ class Table(object):
     Raises:
       Exception if the sample query could not be executed or query response was malformed.
     """
+    # Do import here to avoid top-level circular dependencies.
+    from . import _query
     sql = self._repr_sql_()
     return _query.Query.sampling_query(sql, context=self._context, count=count, fields=fields,
                                        sampling=sampling).results(use_cache=use_cache)


### PR DESCRIPTION
PR #25 changed the codebase to be Python 3 compatible. As part of
that change, the import of the '_query' package had to be removed
from the top of the _table.py file in order to break a cyclic import.

The way this was done was by moving the import inside of the `to_query`
method. However, the `_query` package is also referenced inside of
the `sample` method.

The consequence of this was that the code usually worked exactly
as expected, *however* if the `sample` method was called before the
first time the `to_query` method was called, then the code would
raise an error about the `_query` global name not being found.

This change should not introduce any errors, since the import was
already potentially being performed multiple times (once for each
call to the `to_query` method).