### PR TITLE
Add scripts for running Datalab in a split setup.

### DIFF
--- a/containers/datalab/run-with-gce.sh
+++ b/containers/datalab/run-with-gce.sh
@@ -1,0 +1,94 @@
+#!/bin/bash -e
+
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+USAGE="USAGE: ${0} [<PROJECT> <ZONE> [<DOCKER_BRIDGE_IP>]]
+
+Where <PROJECT> is the ID of the Google Cloud Platform project that will host
+the kernel gateway, <ZONE> is the Google Compute Engine zone where the kernel
+gateway will run, and <DOCKER_BRIDGE_IP> is the IP address of the 'docker0'
+network bridge.
+
+The <PROJECT> and <ZONE> arguments can be omitted if you set the default
+project and zone using the gcloud tool:
+
+    gcloud config set project <PROJECT>
+    gcloud config set compute/zone <ZONE>
+
+If the <DOCKER_BRIDGE_IP> argument is omitted, then the tool will attempt
+to look it up using the 'ifconfig' command.
+"
+
+ERR_USAGE=1
+ERR_DEPLOY=2
+
+DOCS="This script runs Datalab connected to a kernel gateway running in a GCE VM.
+
+The script will first look to see if there is an existing kernel gateway VM,
+and if it cannot find one then it will create one using the
+'../gateway/deploy.sh' script.
+
+The connection between the locally-running Datalab instance and the kernel
+gateway will be tunnelled through an SSH session to the VM hosting the kernel
+gateway. When this script is terminated, it will also kill that SSH session.
+
+If a new GCE VM is created, then it will remain running until deleted, so
+please remember to delete that VM if you no longer need it to avoid incurring
+unnecessary costs.
+"
+
+PROJECT=${1:-`gcloud config list 2> /dev/null | grep 'project = ' | cut -d ' ' -f 3`}
+ZONE=${2:-`gcloud config list 2> /dev/null | grep 'zone = ' | cut -d ' ' -f 3`}
+DOCKER_IP=${3:-`ifconfig docker0 | grep inet\ addr: | cut -d ':' -f 2 | cut -d ' ' -f 1`}
+
+if [[ -z "${PROJECT}" || -z "${ZONE}" || -z "${DOCKER_IP}" ]]; then
+  echo "${USAGE}"
+  exit ${ERR_USAGE}
+fi
+
+echo "${DOCS}"
+
+INSTANCE=`gcloud compute instances list --regex "datalab-kernel-gateway-[0-9]*" --limit 1 --format "value(name)"`
+if [[ -z "${INSTANCE}" ]]; then
+  echo "Could not find an existing GCE VM. Will create one..."
+  pushd ./
+  cd ../gateway
+  ./deploy.sh || exit ${ERR_DEPLOY}
+  popd
+  INSTANCE=`gcloud compute instances list --regex "datalab-kernel-gateway-[0-9]*" --limit 1 --format "value(name)"`
+fi
+
+echo "Will connect to the kernel gateway running on ${INSTANCE}"
+
+# We want to run the SSH command in the background but save the PID
+# so we can kill it on exit. However, if we ran the command through
+# gcloud, then the PID we would get would be that of the gcloud
+# command, which exits after starting the SSH command.
+#
+# To get around this, we only use gcloud to print the SSH command
+# (via the --dry-run flag), and then run that SSH command directly.
+SSH_CMD=`gcloud compute ssh --dry-run --project "${PROJECT}" --zone "${ZONE}" --ssh-flag="-NL" --ssh-flag="${DOCKER_IP}:8082:localhost:8080" "${INSTANCE}"`
+${SSH_CMD} &
+SSH_PID="$!"
+
+# Install a trap that will kill the background SSH process on exit.
+trap "kill -9 ${SSH_PID}" EXIT
+
+echo "Started SSH tunnel with PID ${SSH_PID}"
+
+EXPERIMENTAL_KERNEL_GATEWAY_URL="http://${DOCKER_IP}:8082" ./run.sh
+
+# The following command should be redundant given the trap above, but better safe than sorry.
+kill -9 "${SSH_PID}"

--- a/containers/gateway/deploy.sh
+++ b/containers/gateway/deploy.sh
@@ -1,0 +1,118 @@
+#!/bin/bash -e
+
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+USAGE="USAGE: ${0} <PROJECT> <ZONE>
+
+Alternatively, you can set the default project and zone using the gcloud tool:
+
+    gcloud config set project <PROJECT>
+    gcloud config set compute/zone <ZONE>
+"
+
+ERR_USAGE=1
+ERR_CANCELLED=2
+ERR_DOCKER_BUILD=3
+ERR_DOCKER_PUSH=4
+ERR_NETWORK_CREATE=5
+ERR_FIREWALL_RULE=6
+ERR_INSTANCE_CREATE=7
+
+DOCS="This script deploys the Datalab kernel gateway to a GCE VM.
+
+This will:
+
+1. Build the gateway image and push it to GCR.
+2. Ensure that the project contains a network named
+   'datalab-kernels' with inbound SSH connections allowed
+3. Crate a new VM in the default zone connected to the
+   'datalab-kernels' network.
+4. Run the gateway image in that VM
+
+The resulting VM can be used by running the 'run-with-gce.sh'
+script in the 'containers/datalab' directory to set up an
+instance of Datalab connected to that VM via an SSH tunnel.
+"
+
+PROJECT=${1:-`gcloud config list 2> /dev/null | grep 'project = ' | cut -d ' ' -f 3`}
+ZONE=${2:-`gcloud config list 2> /dev/null | grep 'zone = ' | cut -d ' ' -f 3`}
+
+if [[ -z "${PROJECT}" || -z "${ZONE}" ]]; then
+  echo "${USAGE}"
+  exit ${ERR_USAGE}
+fi
+
+echo "${DOCS}"
+
+echo "Will deploy a GCE VM to project ${PROJECT} in zone ${ZONE}"
+read -p "Proceed? [y/N] " PROCEED
+
+if [[ "${PROCEED}" != "y" ]]; then
+  echo "Deploy cancelled"
+  exit ${ERR_CANCELLED}
+fi
+
+# TODO(ojarjur): Add support for pulling a pre-built version of the
+# datalab-gateway image, rather than building from source.
+./build.sh || exit ${ERR_DOCKER_BUILD}
+IMAGE="gcr.io/${PROJECT}/datalab-gateway"
+docker tag -f datalab-gateway "${IMAGE}"
+gcloud docker push "${IMAGE}" || exit ${ERR_DOCKER_PUSH}
+
+NETWORK="datalab-kernels"
+if [[ -z `gcloud compute networks list | grep ${NETWORK}` ]]; then
+  echo "Creating the compute network '${NETWORK}'"
+  gcloud compute networks create "${NETWORK}" --project "${PROJECT}" --description "Network for Datalab kernel gateway VMs" || exit ${ERR_NETWORK_CREATE}
+  gcloud compute firewall-rules create allow-ssh --project "${PROJECT}" --allow tcp:22 --description 'Allow SSH access' --network "${NETWORK}" || exit ${ERR_FIREWALL_RULE}
+fi
+
+INSTANCE="datalab-kernel-gateway-${RANDOM}"
+CONFIG="apiVersion: v1
+kind: Pod
+metadata:
+  name: datalab-kernel-gateway
+spec:
+  containers:
+    - name: datalab-kernel-gateway
+      image: ${IMAGE}
+      command: ['/datalab/run.sh']
+      imagePullPolicy: IfNotPresent
+      ports:
+        - containerPort: 8080
+          hostPort: 8080
+      env:
+        - name: DATALAB_ENV
+          value: GCE
+"
+
+echo "Creating the compute VM ${INSTANCE} with config: ${CONFIG}"
+gcloud compute instances create "${INSTANCE}" \
+    --project "${PROJECT}" \
+    --zone "${ZONE}" \
+    --network "${NETWORK}" \
+    --image-family "container-vm" \
+    --image-project "google-containers" \
+    --metadata "google-container-manifest=${CONFIG}" \
+    --machine-type "n1-highmem-2" \
+    --scopes "cloud-platform" || exit ${ERR_INSTANCE_CREATE}
+
+echo "Finished creating the vm ${INSTANCE} running a Datalab kernel gateway
+
+When you no longer need it, please remember to delete the instance to avoid incurring additional costs.
+
+The command to delete this instance is:
+
+    gcloud compute instances delete ${INSTANCE} --project ${PROJECT} --zone ${ZONE}
+"


### PR DESCRIPTION
This change adds to new scripts that make it easy to run the Datalab UI
locally while connecting it to a kernel gateway running inside a GCE VM.

Specifically, the two new scripts are:

1. containers/gateway/deploy.sh - for setting up the kernel gateway.
2. containers/gateway/run-with-gce.sh - for running the Datalab UI.

The main entry point for a user wanting to run their kernels in the
cloud will be the 'run-with-gce.sh' script, which will run the
'deploy.sh' script iff there isn't already a VM running a kernel gateway.