### PR TITLE
Fix a bug when specifying a project and zone via command line arguments.

### DIFF
--- a/containers/datalab/run-with-gce.sh
+++ b/containers/datalab/run-with-gce.sh
@@ -65,7 +65,7 @@ if [[ -z "${INSTANCE}" ]]; then
   echo "Could not find an existing GCE VM. Will create one..."
   pushd ./
   cd ../gateway
-  ./deploy.sh || exit ${ERR_DEPLOY}
+  ./deploy.sh "${PROJECT}" "${ZONE}" || exit ${ERR_DEPLOY}
   popd
   INSTANCE=`gcloud compute instances list --regex "datalab-kernel-gateway-[0-9]*" --limit 1 --format "value(name)"`
 fi


### PR DESCRIPTION
There was a bug in the initial checkin for the 'run-with-gce.sh' script
where, if specified on the command line, the selected project and zone
would not be passed to the nested call to the 'deploy.sh' script.

This was because the call to 'deploy.sh' always used the default values
configured with gcloud, so if those differed from the explicitly-passed
values, then the deploy script would try to use the wrong project
and/or zone.

This change fixes that bug by having the project and zone always be
explicitly passed to the call to the 'deploy.sh' script.