### PR TITLE
Add a new Docker image for running with a backend on GCP.

### DIFF
--- a/containers/gcp/Dockerfile
+++ b/containers/gcp/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM datalab
+MAINTAINER Google Cloud DataLab
+
+# Add open-ssh, so that we can tunnel to the GCE VM.
+RUN apt-get -y -qq install openssh-client
+
+ADD content/ /datalab
+
+# Startup
+ENTRYPOINT [ "/datalab/run-with-gce.sh" ]

--- a/containers/gcp/README.md
+++ b/containers/gcp/README.md
@@ -1,0 +1,70 @@
+# DataLab-on-GCP Docker Image
+
+This directory defines a Docker image for running Datalab against a kernel
+gateway running in the Google Cloud Platform.
+
+This combines the flexibility and control of storing your notebooks
+locally with the performance of running your kernels in the cloud,
+close to where your data is stored.
+
+## Building
+
+To build the image simply run the `build.sh` script in this
+directory.
+
+```sh
+./build.sh
+```
+
+## Running
+
+After building, you can run the built image using the `run.sh`
+script in this directory. This requires a GCP project to host the
+kernel gateway, and a GCE zone where it should be located. These
+must be either provided as environment variables, or via the gcloud
+default configuration:
+
+```sh
+PROJECT_ID="${PROJECT}" ZONE="${COMPUTE_ZONE}" ./run.sh
+```
+
+or
+
+```sh
+gcloud config set project "${PROJECT}"
+gcloud config set compute/zone "${ZONE}"
+./run.sh
+```
+
+## Authentication
+
+### Used for creating the kernel gateway VM
+
+The bundled `run.sh` script will mount your local gcloud config
+directory into the Datalab container, so that you do not have to
+reauthenticate inside of the container. This means that the VM
+running the kernel gateway will be created using the credentials
+of your 'active' account in gcloud.
+
+### Used by the running kernels
+
+Since the kernels are run inside of a GCE VM, they will use the
+credentials of that VM for all of their operations. If, instead,
+you want to use your personal credentials, then use the 'datalab'
+Docker image defined in the `containers/datalab` directory to
+run your kernels locally.
+
+## Extending
+
+The Docker image used for running the kernel gateway in your VM
+is the one in your project's Google Container Registry bucket
+named "gcr.io/${PROJECT_ID}/datalab-gateway".
+
+If it is missing, that image will be built locally based on the
+Dockerfile in the `containers/gateway` directory, and then pushed
+to your project by the `./run.sh` script.
+
+To override this behavior, simply build your extended image using
+the instructions in the `containers/gateway` directory, and then
+push your extended image to the Google Container Registry with the
+name "gcr.io/${PROJECT_ID}/datalab-gateway".

--- a/containers/gcp/build.sh
+++ b/containers/gcp/build.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds the docker image for running Datalab on the Google Cloud Platform.
+
+USAGE="USAGE: ${0} [-p] [-h]
+
+Where '-p' indicates that the 'datalab-gateway' Docker image should be
+built locally and pushed to the Google Container Registry for the
+project defined in the environment variable 'PROJECT_ID' (or, if that
+variable is not provided, the default project set in the gcloud config).
+"
+
+FORCE_PUSH=""
+while getopts ":ph" OPT; do
+  case $OPT in
+    p)
+      FORCE_PUSH="true"
+      ;;
+    h)
+      echo "${USAGE}"
+      exit 0
+      ;;
+    \?)
+      echo "Unknown args: -${OPTARG}"
+      echo "${USAGE}"
+      exit 1
+      ;;
+  esac
+done
+
+if [ "${FORCE_PUSH}" == "true" ]; then
+  PROJECT_ID=${PROJECT_ID:-`gcloud config list 2> /dev/null | grep 'project = ' | cut -d ' ' -f 3`}
+  if [ -z "${PROJECT_ID}" ]; then
+    echo "You must specify a target project to which to push the gateway image"
+    exit 1
+  fi
+
+  GATEWAY_IMAGE="gcr.io/${PROJECT_ID}/datalab-gateway"
+  echo "Forcing a build and push of the image ${GATEWAY_IMAGE}"
+  cd ../gateway
+  ./build.sh
+  cd ../gcp
+
+  docker tag -f datalab-gateway "${GATEWAY_IMAGE}"
+  gcloud --project="${PROJECT_ID}" docker push "${GATEWAY_IMAGE}"
+fi
+
+# Build the base docker image
+cd ../datalab
+./build.sh
+cd ../gcp
+
+# Build the docker image
+docker build -t datalab-gcp .

--- a/containers/gcp/run.sh
+++ b/containers/gcp/run.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+# Copyright 2015 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the docker container locally. Auth will happen in the browser when
+# the user first opens Datalab after accepting the EULA.
+
+# Passing in 'shell' flag causes the docker container to break into a
+# command prompt, which is useful for tinkering within the container before
+# manually starting the server.
+
+CONTENT=${HOME}
+ENTRYPOINT="/datalab/run-with-gce.sh"
+if [ "$1" != "" ]; then
+  if [ "$1" != "shell" ]; then
+    CONTENT=$1
+    shift
+  fi
+  if [ "$1" == "shell" ]; then
+    ENTRYPOINT="/bin/bash"
+  fi
+fi
+
+USAGE="USAGE: ${0} [<CONTENT_DIR>]
+
+Where <CONTENT_DIR> is the directory holding the notebooks that you want
+to use with Datalab.
+
+Additionally (for debugging), you can pass in a 'shell' argument to open
+a shell inside of the Datalab container, rather than starting Datalab.
+
+    ${0} [<CONTENT_DIR>] shell
+
+You must have the 'gcloud' command line tool installed, and have at least
+one (active) account authenticated with gcloud, in order for the container
+to be able to set up the kernel gateway for you. Instructions for installing
+gcloud are here: https://cloud.google.com/sdk/downloads.
+
+To ensure that a previously installed version of gcloud is up-to-date, run:
+
+    gcloud components update gcloud core
+
+To set up an active account in gcloud, run:
+
+    gcloud auth login
+
+Finally, you must also specify a project ID and zone. The project ID is the
+ID of the Google Cloud Platform project that will host the kernel gateway and
+the zone is the Google Compute Engine zone where the kernel gateway will run.
+
+These may be specified by either setting the PROJECT_ID and ZONE environment
+variables, or by setting the default project and zone using the gcloud tool:
+
+    gcloud config set project <PROJECT_ID>
+    gcloud config set compute/zone <ZONE>
+"
+
+# Verify that the necessary prerequisites have been set
+GCLOUD_CONFIG=`gcloud info --quiet --format 'value(config.paths.global_config_dir)'`
+GCLOUD_ACCOUNT=`gcloud auth list --format 'value(active_account)'`
+
+PROJECT_ID=${PROJECT_ID:-`gcloud config list 2> /dev/null | grep 'project = ' | cut -d ' ' -f 3`}
+ZONE=${ZONE:-`gcloud config list 2> /dev/null | grep 'zone = ' | cut -d ' ' -f 3`}
+
+if [[ -z "${CONTENT}" || -z "${GCLOUD_CONFIG}" || -z "${GCLOUD_ACCOUNT}" || -z "${PROJECT_ID}" || -z "${ZONE}" ]]; then
+  echo "${USAGE}"
+  exit 1
+fi
+
+# Ensure that the target project has a copy of the gateway image.
+# We do this rather than pointing the VM directly at a public
+# image so that:
+#
+# 1. The VM will not accidentally pick up a new version when rebooted.
+# and
+# 2. The project can switch to a version of the image with custom extensions.
+GATEWAY_IMAGE="gcr.io/${PROJECT_ID}/datalab-gateway"
+
+# Only update the gateway image if it has not been pushed to the project yet.
+# We want to enforce that the image is there, but do not want to
+# override a previously pushed image in case the project has a
+# customized gateway image.
+gcloud docker pull "${GATEWAY_IMAGE}" || PUSH_IMAGE="true"
+if [ "${PUSH_IMAGE}" == "true" ]; then
+  # TODO(ojarjur): Remove this block after the
+  # "gcr.io/cloud-datalab/datalab-gateway" image is published, and
+  # instead just pull that image.
+  if [ "$(docker images -q datalab-gateway)" == "" ]; then
+    # We do not have a local version of the datalab-gateway image, so build it
+    cd ../gateway
+    ./build.sh
+    cd ../gcp
+  fi
+
+  docker tag -f datalab-gateway "${GATEWAY_IMAGE}"
+  gcloud --project="${PROJECT_ID}" docker push "${GATEWAY_IMAGE}"
+fi
+
+# On linux docker runs directly on host machine, so bind to 127.0.0.1 only
+# to avoid it being accessible from network.
+# On other platform, it needs to bind to all ip addresses so VirtualBox can
+# access it. Users need to make sure in their VirtualBox port forwarding
+# settings only 127.0.0.1 is bound.
+if [ "$OSTYPE" == "linux"* ]; then
+  PORTMAP="127.0.0.1:8081:8080"
+else
+  PORTMAP="8081:8080"
+fi
+# Use this flag to map in web server content during development
+#  -v $REPO_DIR/sources/web:/sources \
+docker run -it --entrypoint=$ENTRYPOINT \
+  -p $PORTMAP \
+  -v "${CONTENT}:/content" \
+  -v "${GCLOUD_CONFIG}:/content/datalab/.config" \
+  -e "PROJECT_ID=${PROJECT_ID}" \
+  -e "ZONE=${ZONE}" \
+  datalab-gcp


### PR DESCRIPTION
This encapsulates all of the logic for spinning up a GCE
VM running a Datalab kernel gateway, setting up an SSH
tunnel connected to that VM, and then running a local
Datalab instance pointed at that SSH tunnel.

This should make it much simpler to run Datalab with kernels in the cloud.