### PR TITLE
Simplify the run step for Datalab with a kernel gateway in GCP.

### DIFF
--- a/containers/gcp/content/deploy.sh
+++ b/containers/gcp/content/deploy.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ERR_DOCKER_PUSH=1
+ERR_CANCELLED=1
 ERR_NETWORK_CREATE=2
 ERR_FIREWALL_RULE=3
 ERR_INSTANCE_CREATE=4
@@ -23,12 +23,11 @@ DOCS="We are about to deploy the Datalab kernel gateway to a GCE VM.
 
 This will:
 
-1. Build the gateway image and push it to GCR.
-2. Ensure that the project contains a network named
+1. Ensure that the project contains a network named
    'datalab-kernels' with inbound SSH connections allowed
-3. Crate a new VM in the default zone connected to the
+2. Crate a new VM in the default zone connected to the
    'datalab-kernels' network.
-4. Run the gateway image in that VM
+3. Run the gateway image in that VM
 
 Datalab will then connect to the resulting VM via an SSH tunnel.
 "
@@ -40,6 +39,12 @@ INSTANCE=${3}
 echo "${DOCS}"
 
 echo "Will deploy a GCE VM named '${INSTANCE}' to the project '${PROJECT}' in zone '${ZONE}'"
+read -p "Proceed? [y/N] " PROCEED
+
+if [[ "${PROCEED}" != "y" ]]; then
+  echo "Deploy cancelled"
+  exit ${ERR_CANCELLED}
+fi
 
 NETWORK="datalab-kernels"
 if [[ -z `gcloud --project "${PROJECT}" compute networks list | grep ${NETWORK}` ]]; then

--- a/containers/gcp/content/run-with-gce.sh
+++ b/containers/gcp/content/run-with-gce.sh
@@ -16,20 +16,19 @@
 
 USAGE="USAGE: ${0}
 
-You must also specify a project ID and zone. The project ID is the ID of
+You must also provide a project ID and zone. The project ID is the ID of
 the Google Cloud Platform project that will host the kernel gateway and 
 the zone is the Google Compute Engine zone where the kernel gateway will run.
 
 These may be specified by either setting the PROJECT_ID and ZONE environment
-variables, or by setting the default project and zone using the gcloud tool:
-
-    gcloud config set project <PROJECT_ID>
-    gcloud config set compute/zone <ZONE>
+variables, or by responding to command line prompts.
 "
 
-ERR_USAGE=1
-ERR_LOGIN=2
-ERR_DEPLOY=3
+ERR_LOGIN=1
+ERR_PROJECT_NOT_FOUND=2
+ERR_ZONE_NOT_FOUND=3
+ERR_INSTANCE_NOT_FOUND=3
+ERR_DEPLOY=4
 
 DOCS="This script runs Datalab connected to a kernel gateway running in a GCE VM.
 
@@ -46,72 +45,89 @@ please remember to delete that VM if you no longer need it to avoid incurring
 unnecessary costs.
 "
 
-export DATALAB_ENV="local"
+echo "${DOCS}"
+
+# Run the 'setup-env' script to ensure that gcloud has been told to use
+# a config directory under the mounted volume (so that the results of
+# 'gcloud auth login' are persisted).
 source /datalab/setup-env.sh
 export HOME=/content
 
-export PROJECT_ID=${PROJECT_ID:-`gcloud config list 2> /dev/null | grep 'project = ' | cut -d ' ' -f 3`}
-export ZONE=${ZONE:-`gcloud config list 2> /dev/null | grep 'zone = ' | cut -d ' ' -f 3`}
-
-if [[ -z "${PROJECT_ID}" || -z "${ZONE}" ]]; then
-  echo "${USAGE}"
-  exit ${ERR_USAGE}
-fi
-
-echo "${DOCS}"
-
-# We want to run the kernel gateway in a VM. However, we also want to make sure
-# there is a 1:1 correspondence between end user and kernel gateway, so we need
-# to create a separate VM for each user.
-#
-# To do this, we will name the VM with a prefix tied to the user.
-#
-# NOTE: THIS IS NOT A SECURITY SANDBOX. When running in a GCE VM, Datalab is in
-# an inherently shared environment. This separation is merely to prevent
-# accidental conflicts between users, not to provide any sort of privacy or
-# authentication.
 USER_EMAIL=`gcloud info --format="value(config.account)"`
 if [[ -z "${USER_EMAIL}" ]]; then
-  echo "You must log in via the gcloud tool"
-  echo "    gcloud auth login"
-  exit ${ERR_LOGIN}
+  gcloud auth login || exit "${ERR_LOGIN}"
 fi
 
-echo "Looking up gateway VM for ${USER_EMAIL}..."
+export PROJECT_ID=${PROJECT_ID:-`gcloud config list -q --format 'value(core.project)' 2> /dev/null`}
+export ZONE=${ZONE:-`gcloud config list -q --format 'value(compute.zone)' 2> /dev/null`}
 
-# We would like to give the VM a friendly name based on the user, but VM names
-# can only contain letters, numbers, and hyphens, whereas email addresses can
-# contain any characters.
-#
-# We resolve this conflict by trying a simple escaping of the email address,
-# and if that does not produce a valid instance name, then we just hash the
-# email address and use the hash.
-#
-# The escaping we do is based on a 1:1 mapping from '[-@.a-zA-Z0-9]+' to
-# '[-a-zA-Z0-9]+'. Since this mapping is 1:1, we ensure that the uniqueness
-# of email addresses is maintained. There is additionally a length limit
-# of 63 characters for instance names, so we do not use the escaped email
-# address if it is longer than 32 characters.
-EMAIL_WITH_HYPHENS_ESCAPED=`echo "${USER_EMAIL}" | sed -e 's/-/-h-/g'`
-EMAIL_WITH_AT_ESCAPED=`echo "${EMAIL_WITH_HYPHENS_ESCAPED}" | sed -e 's/@/-at-/g'`
-EMAIL_WITH_DOT_ESCAPED=`echo "${EMAIL_WITH_AT_ESCAPED}" | sed -e 's/\./-dot-/g'`
-ESCAPED_USER_EMAIL=`echo "${EMAIL_WITH_DOT_ESCAPED}" | sed -e 's/[^-a-zA-Z0-9]//g'`
-if [[ -z "${ESCAPED_USER_EMAIL}" || "${#ESCAPED_USER_EMAIL}" > 32 ]]; then
-  # Since the email address contains other characters, we sanitize it
-  # by hashing it. We use the openssl implementation of sha1 for this purpose,
-  # solely for the fact that it should be nearly ubiquitous.
-  USER_HASH=`echo "${USER_EMAIL}" | openssl sha1 -r | cut -d ' ' -f 1`
-  INSTANCE_PREFIX="datalab-${USER_HASH:0:12}"
-else
-  INSTANCE_PREFIX="datalab-${ESCAPED_USER_EMAIL}"
+if [[ -z "${PROJECT_ID}" ]]; then
+  read -p "Please enter the Google Cloud Platform project to use: " PROJECT_ID
+
+  gcloud projects describe "${PROJECT_ID}" || exit "${ERR_PROJECT_NOT_FOUND}"
 fi
 
-INSTANCE=`gcloud compute instances list --project "${PROJECT_ID}" --zone "${ZONE}" --regex "${INSTANCE_PREFIX}-[0-9]*" --limit 1 --format "value(name)"`
+if [[ -z "${ZONE}" ]]; then
+  read -p "Please enter the zone where the VM should be located: " ZONE
+
+  gcloud compute zones --project "${PROJECT_ID}" describe "${ZONE}" || exit "${ERR_ZONE_NOT_FOUND}"
+fi
+
+# Persist the project and zone for future runs.
+gcloud config set project "${PROJECT_ID}"
+gcloud config set compute/zone "${ZONE}"
+
 if [[ -z "${INSTANCE}" ]]; then
-  echo "Could not find an existing gateway VM for '${USER_EMAIL}'. Will create one..."
-  INSTANCE="${INSTANCE_PREFIX}-${RANDOM}"
-  /datalab/deploy.sh "${PROJECT_ID}" "${ZONE}" "${INSTANCE}" || exit ${ERR_DEPLOY}
+  # We want to run the kernel gateway in a VM. However, we also want to make sure
+  # there is a 1:1 correspondence between end user and kernel gateway, so we need
+  # to create a separate VM for each user.
+  #
+  # To do this, we will name the VM with a prefix tied to the user.
+  #
+  # NOTE: THIS IS NOT A SECURITY SANDBOX. When running in a GCE VM, Datalab is in
+  # an inherently shared environment. This separation is merely to prevent
+  # accidental conflicts between users, not to provide any sort of privacy or
+  # authentication.
+  USER_EMAIL=`gcloud info --format="value(config.account)"`
+  echo "Looking up gateway VM for ${USER_EMAIL}..."
+
+  # We would like to give the VM a friendly name based on the user, but VM names
+  # can only contain letters, numbers, and hyphens, whereas email addresses can
+  # contain any characters.
+  #
+  # We resolve this conflict by trying a simple escaping of the email address,
+  # and if that does not produce a valid instance name, then we just hash the
+  # email address and use the hash.
+  #
+  # The escaping we do is based on a 1:1 mapping from '[-@.a-zA-Z0-9]+' to
+  # '[-a-zA-Z0-9]+'. Since this mapping is 1:1, we ensure that the uniqueness
+  # of email addresses is maintained. There is additionally a length limit
+  # of 63 characters for instance names, so we do not use the escaped email
+  # address if it is longer than 32 characters.
+  EMAIL_WITH_HYPHENS_ESCAPED=`echo "${USER_EMAIL}" | sed -e 's/-/-h-/g'`
+  EMAIL_WITH_AT_ESCAPED=`echo "${EMAIL_WITH_HYPHENS_ESCAPED}" | sed -e 's/@/-at-/g'`
+  EMAIL_WITH_DOT_ESCAPED=`echo "${EMAIL_WITH_AT_ESCAPED}" | sed -e 's/\./-dot-/g'`
+  ESCAPED_USER_EMAIL=`echo "${EMAIL_WITH_DOT_ESCAPED}" | sed -e 's/[^-a-zA-Z0-9]//g'`
+  if [[ -z "${ESCAPED_USER_EMAIL}" || "${#ESCAPED_USER_EMAIL}" > 32 ]]; then
+    # Since the email address contains other characters, we sanitize it
+    # by hashing it. We use the openssl implementation of sha1 for this purpose,
+    # solely for the fact that it should be nearly ubiquitous.
+    USER_HASH=`echo "${USER_EMAIL}" | openssl sha1 -r | cut -d ' ' -f 1`
+    INSTANCE_PREFIX="datalab-${USER_HASH:0:12}"
+  else
+    INSTANCE_PREFIX="datalab-${ESCAPED_USER_EMAIL}"
+  fi
+
+  INSTANCE=`gcloud compute instances list --project "${PROJECT_ID}" --zone "${ZONE}" --regex "${INSTANCE_PREFIX}-[0-9]*" --limit 1 --format "value(name)"`
+  if [[ -z "${INSTANCE}" ]]; then
+    echo "Could not find an existing gateway VM for '${USER_EMAIL}'. Will create one..."
+    INSTANCE="${INSTANCE_PREFIX}-${RANDOM}"
+    /datalab/deploy.sh "${PROJECT_ID}" "${ZONE}" "${INSTANCE}" || exit ${ERR_DEPLOY}
+  fi
 fi
+
+# Verify that the specified instance exists...
+gcloud compute instances describe "${INSTANCE}" || exit "${ERR_INSTANCE_NOT_FOUND}"
 
 echo "Will connect to the kernel gateway running on ${INSTANCE}"
 gcloud compute ssh --quiet \

--- a/containers/gcp/run.sh
+++ b/containers/gcp/run.sh
@@ -67,13 +67,11 @@ variables, or by setting the default project and zone using the gcloud tool:
 "
 
 # Verify that the necessary prerequisites have been set
-GCLOUD_CONFIG=`gcloud info --quiet --format 'value(config.paths.global_config_dir)'`
 GCLOUD_ACCOUNT=`gcloud auth list --format 'value(active_account)'`
-
 PROJECT_ID=${PROJECT_ID:-`gcloud config list 2> /dev/null | grep 'project = ' | cut -d ' ' -f 3`}
 ZONE=${ZONE:-`gcloud config list 2> /dev/null | grep 'zone = ' | cut -d ' ' -f 3`}
 
-if [[ -z "${CONTENT}" || -z "${GCLOUD_CONFIG}" || -z "${GCLOUD_ACCOUNT}" || -z "${PROJECT_ID}" || -z "${ZONE}" ]]; then
+if [[ -z "${CONTENT}" || -z "${GCLOUD_ACCOUNT}" || -z "${PROJECT_ID}" || -z "${ZONE}" ]]; then
   echo "${USAGE}"
   exit 1
 fi
@@ -122,7 +120,6 @@ fi
 docker run -it --entrypoint=$ENTRYPOINT \
   -p $PORTMAP \
   -v "${CONTENT}:/content" \
-  -v "${GCLOUD_CONFIG}:/content/datalab/.config" \
   -e "PROJECT_ID=${PROJECT_ID}" \
   -e "ZONE=${ZONE}" \
   datalab-gcp


### PR DESCRIPTION
This change is a response to feedback about the previous steps
being too complicated and/or brittle. The aim of this is to
make the end-user instructions for Datalab-on-GCP as simple as
possible.

Specifically, the following improvements are included:

1. Remove all dependencies on 'gcloud' from the setup and run.
   This has the consequence of the user potentially having to
   sign-in to gcloud a second time if they have already signed
   in to it from the host, but that sign-in is persisted, so
   they will only have to do it one more time.
2. Make the PROJECT_ID and ZONE variables optional rather than
   required. If they are not provided, then the user will be
   prompted to enter them at the command line. Either way, the
   values selected will be persisted so they can be reused by
   later runs of the tool.
3. Add the option of explicitly specifying the name of the VM
   instance when running the tool. This gives more flexibility
   to users who want to manually create the VM themselves, while
   still having Datalab managed the SSH tunnel for them.

With these changes, the new instruction to run Datalab (after
installing Docker) will simply be:

    docker run -it -p "8081:8080" \
      -v "${HOME}:/content" \
      gcr.io/cloud-datalab/<NAME_OF_THE_DOCKER_IMAGE>