### PR TITLE
Update Jupyter Gateway setting to JupyterWebsocketPersonality.list_kernels

### DIFF
--- a/containers/gateway/content/run.sh
+++ b/containers/gateway/content/run.sh
@@ -26,4 +26,4 @@ then
 fi
 
 # Start the DataLab kernel gateway
-jupyter kernelgateway --KernelGatewayApp.list_kernels=True --KernelGatewayApp.port=8080 --KernelGatewayApp.ip=0.0.0.0
+jupyter kernelgateway --JupyterWebsocketPersonality.list_kernels=True --KernelGatewayApp.port=8080 --KernelGatewayApp.ip=0.0.0.0


### PR DESCRIPTION
Fixes #924


```
>tony@tonypc:~/Git/datalab-parthea/containers/gateway$ jupyter kernelgateway --help-all
...
...
JupyterWebsocketPersonality options
-----------------------------------
--JupyterWebsocketPersonality.list_kernels=<Bool>
    Default: False
    Permits listing of the running kernels using API endpoints /api/kernels and
    /api/sessions (KG_LIST_KERNELS env var). Note: Jupyter Notebook allows this
    by default but kernel gateway does not.
```