### PR TITLE
Add an additional layer of defense for deployed gateway VMs.

### DIFF
--- a/containers/datalab/content/deploy.sh
+++ b/containers/datalab/content/deploy.sh
@@ -67,6 +67,7 @@ spec:
       ports:
         - containerPort: 8080
           hostPort: 8080
+          hostIP: 127.0.0.1
       env:
         - name: DATALAB_ENV
           value: GCE


### PR DESCRIPTION
By default, any containers in a Pod that have a port spec will
be exposed on those ports for all network interfaces. However,
for our kernel gateway VMs we only want the kernel gateway to
be accessible via localhost (and will use an SSH tunnel for
access from any other machine).

In order to make the container VM enforce that restriction we
need to add an explicit 'hostIP' line to the Pod spec specifying
that the container should only be accessible via the 127.0.0.1
IP address.

Since we were already placing the VM in a locked-down network,
this is an additional, rather than sole, defense.

This script will likely be deleted soon, but we should still
document the best practice for setting up these gateway VMs
in case anyone wants to copy the script from our git history.