### PR TITLE
Remove the setting of the HOME environment variable during setup.

### DIFF
--- a/containers/datalab/content/run-with-gce.sh
+++ b/containers/datalab/content/run-with-gce.sh
@@ -40,7 +40,6 @@ ERR_GATEWAY_FAILED=7
 # a config directory under the mounted volume (so that the results of
 # 'gcloud auth login' are persisted).
 source /datalab/setup-env.sh
-export HOME=/content
 
 export PROJECT_ID=${PROJECT_ID:-`gcloud config list -q --format 'value(core.project)' 2> /dev/null`}
 export ZONE=${ZONE:-`gcloud config list -q --format 'value(compute.zone)' 2> /dev/null`}


### PR DESCRIPTION
This was causing issues when running Datalab on Windows, as strange
issues seem to occur if you have your HOME variable set to an
externally mapped volume on Windows.