### PR TITLE
Update links to point to correct repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ DataLab is packaged as a docker container which contains Jupyter/IPython, and a 
 libraries such as numpy, pandas, scikit-learn and matplotlib, in a ready-to-use form.
 
 You can run the docker container locally or in GCE, as described in the
-[wiki](https://github.com/googlecloudplatform/datalab/wiki/Getting-Started).
+[wiki](https://github.com/googledatalab/datalab/wiki/Getting-Started).
 
 ### Contacting Us
 
 For support or help using DataLab, please submit questions tagged with `google-cloud-datalab` on [StackOverflow](http://stackoverflow.com/questions/tagged/google-cloud-datalab).
 
-For any product issues, you can either [submit issues](https://github.com/GoogleCloudPlatform/datalab/issues)
+For any product issues, you can either [submit issues](https://github.com/googledatalab/datalab/issues)
 here on this project page, or you can submit your feedback using the feedback link available
 within the product.
 
@@ -42,14 +42,14 @@ within the product.
 
 ### Building and Running
 
-The [wiki](https://github.com/googlecloudplatform/datalab/wiki/Development-Environment) describes
+The [wiki](https://github.com/googledatalab/datalab/wiki/Development-Environment) describes
 the process of setting up a local development environment, as well as the steps to build and run,
 and the developer workflow.
 
 ### Contributing
 
-Contributions are welcome! Please see our [roadmap](https://github.com/GoogleCloudPlatform/datalab/wiki/Roadmap)
-page. Please check the page on [contributing](https://github.com/GoogleCloudPlatform/datalab/wiki/Contributing)
+Contributions are welcome! Please see our [roadmap](https://github.com/googledatalab/datalab/wiki/Roadmap)
+page. Please check the page on [contributing](https://github.com/googledatalab/datalab/wiki/Contributing)
 for more details.
 
 You can always contribute even without code submissions by submitting issues and suggestions to

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -45,7 +45,7 @@ function initializePage(dialog, saveFn) {
       '<pre>Version: ' + version  + '\nBased on Jupyter (formerly IPython) 4</pre>' +
       '<h5><b>More Information</b></h5>' +
       '<span class="fa fa-external-link-square">&nbsp;</span><a href="https://cloud.google.com" target="_blank">Product information</a><br />' +
-      '<span class="fa fa-external-link-square">&nbsp;</span><a href="https://github.com/GoogleCloudPlatform/datalab" target="_blank">Project on GitHub</a><br />' +
+      '<span class="fa fa-external-link-square">&nbsp;</span><a href="https://github.com/googledatalab/datalab" target="_blank">Project on GitHub</a><br />' +
       '<span class="fa fa-external-link-square">&nbsp;</span><a href="/static/about.txt" target="_blank">License and software information</a><br />' +
       '<span class="fa fa-external-link-square">&nbsp;</span><a href="https://cloud.google.com/terms/" target="_blank">Terms of Service</a><br />' +
       '<span class="fa fa-external-link-square">&nbsp;</span><a href="http://www.google.com/intl/en/policies/" target="_blank">Privacy Policy</a><br />' +
@@ -878,7 +878,7 @@ function initializeNotebookList(ipy, notebookList, newNotebook, events, dialog, 
     var messageDiv = document.getElementById('updateMessageArea');
     var message = 'You are using DataLab 0.5.' + version + '. ' + 
         (optional ? 'An optional' : 'A recommended') + ' update (0.5.' + versionInfo.latest + 
-        ') is available (see <a href="https://github.com/GoogleCloudPlatform/datalab/wiki/Release-Info"' + 
+        ') is available (see <a href="https://github.com/googledatalab/datalab/wiki/Release-Info"' +
         '>what\'s new)</a>.'
     messageDiv.innerHTML = message;
     messageDiv.classList.add('alert');


### PR DESCRIPTION
Update repository links in source code to point to https://github.com/googledatalab instead of https://github.com/GoogleCloudPlatform