### PR TITLE
Fix an issue that when user is not signed in from inside datalab

### DIFF
--- a/containers/datalab/content/setup-env.sh
+++ b/containers/datalab/content/setup-env.sh
@@ -22,7 +22,11 @@ if [ "${ENABLE_USAGE_REPORTING}" = "true" ]
 then
   if [ -n "${PROJECT_ID}" ]
   then
-    export PROJECT_NUMBER=`gcloud projects describe "${PROJECT_ID}" --format 'value(projectNumber)'`
+    USER_EMAIL=`gcloud auth list --format="value(account)"`
+    if [ -n "${USER_EMAIL}" ]
+    then
+      export PROJECT_NUMBER=`gcloud projects describe "${PROJECT_ID}" --format 'value(projectNumber)'`
+    fi
   fi
 fi
 


### PR DESCRIPTION
container last time they use Datalab, then setting PROJECT_NUMBER env
var will fail and cause Datalab to not start.