### PR TITLE
Enable the notebook notary feature.

### DIFF
--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -168,6 +168,13 @@ then
     jupyter serverextension enable --py nb2kg --sys-prefix
 fi
 
+# Create the notebook notary secret if one does not already exist
+if [ ! -f /content/datalab/.config/notary_secret ]
+then
+  mkdir -p /content/datalab/.config
+  openssl rand -base64 128 > /content/datalab/.config/notary_secret
+fi
+
 # Start the DataLab server
 FOREVER_CMD="forever --minUptime 1000 --spinSleepTime 1000"
 if [ -z "${DATALAB_DEBUG}" ]

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -143,7 +143,9 @@ function createJupyterServerAtPort(port: number, userId: string, userDir: string
     processArgs = processArgs.concat([
       '--NotebookApp.session_manager_class=nb2kg.managers.SessionManager',
       '--NotebookApp.kernel_manager_class=nb2kg.managers.RemoteKernelManager',
-      '--NotebookApp.kernel_spec_manager_class=nb2kg.managers.RemoteKernelSpecManager'
+      '--NotebookApp.kernel_spec_manager_class=nb2kg.managers.RemoteKernelSpecManager',
+      '--NotebookNotary.algorithm=sha256',
+      '--NotebookNotary.secret_file=/content/datalab/.config/notary_secret'
     ]);
   }
 


### PR DESCRIPTION
This change turns on Jupyter's notebook notary feature using
a secret read from a file on the user's machine (which we
automatically generate if it is missing).

This has the consequence that certain types of charts saved in
cell outputs will not be displayed until the user (re)runs the
corresponding cells.