### PR TITLE
Initial support for custom themes

### DIFF
--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -72,14 +72,23 @@ export function loadSettings(): common.Settings {
 }
 
 /**
+ * Loads the path of the configuration directory for the user.
+ *
+ * @returns the path of the user's config directory.
+ */
+export function getUserConfigDir(userId: string): string {
+  var userDir = userManager.getUserDir(userId);
+  var configPath = path.join(userDir, 'datalab', '.config');
+  return configPath;
+}
+
+/**
  * Loads the configuration settings for the user.
  *
  * @returns the key:value mapping of settings for the user.
  */
 export function loadUserSettings(userId: string): common.Map<string> {
-  var userDir = userManager.getUserDir(userId);
-  var settingsPath = path.join(userDir, 'datalab', '.config', SETTINGS_FILE);
-
+  var settingsPath = path.join(getUserConfigDir(userId), SETTINGS_FILE);
   if (!fs.existsSync(settingsPath)) {
     console.log('Settings file %s not found.', settingsPath);
     return {};

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -20,7 +20,9 @@ import fs = require('fs');
 import http = require('http');
 import logging = require('./logging');
 import path = require('path');
+import settings = require('./settings');
 import url = require('url');
+import userManager = require('./userManager');
 
 var JUPYTER_DIR = '/usr/local/lib/python2.7/dist-packages/notebook';
 var CONTENT_TYPES: common.Map<string> = {
@@ -31,10 +33,13 @@ var CONTENT_TYPES: common.Map<string> = {
   '.txt': 'text/plain',
   '.html': 'text/html'
 };
+var CUSTOM_THEME_FILE = 'custom.css';
+var DEFAULT_THEME_FILE = 'light.css';
 
 var contentCache: common.Map<Buffer> = {};
+var watchedDynamicContent: common.Map<boolean> = {};
 
-function getContent(filePath: string, cb: common.Callback<Buffer>): void {
+function getContent(filePath: string, cb: common.Callback<Buffer>, isDynamic: boolean = false): void {
   var content = contentCache[filePath];
   if (content != null) {
     process.nextTick(function() {
@@ -47,6 +52,16 @@ function getContent(filePath: string, cb: common.Callback<Buffer>): void {
         cb(error, null);
       }
       else {
+        if (isDynamic && !watchedDynamicContent[filePath]) {
+          fs.watch(filePath, function(eventType, filename) {
+            logging.getLogger().info('Clearing cache for updated file: %s', filePath);
+            contentCache[filePath] = null;
+            if (eventType == 'rename') {
+              watchedDynamicContent[filePath] = false;
+            }
+          });
+          watchedDynamicContent[filePath] = true;
+        }
         contentCache[filePath] = content;
         cb(null, content);
       }
@@ -58,8 +73,11 @@ function getContent(filePath: string, cb: common.Callback<Buffer>): void {
  * Sends a static file as the response.
  * @param filePath the full path of the static file to send.
  * @param response the out-going response associated with the current HTTP request.
+ * @param alternatePath the path to a static Datalab file to send if the given file is missing.
+ * @param isDynamic indication of whether or not the file contents might change.
  */
-function sendFile(filePath: string, response: http.ServerResponse) {
+function sendFile(filePath: string, response: http.ServerResponse,
+                  alternatePath: string = "", isDynamic: boolean = false) {
   var extension = path.extname(filePath);
   var contentType = CONTENT_TYPES[extension.toLowerCase()] || 'application/octet-stream';
 
@@ -67,14 +85,18 @@ function sendFile(filePath: string, response: http.ServerResponse) {
     if (error) {
       logging.getLogger().error(error, 'Unable to send static file: %s', filePath);
 
-      response.writeHead(500);
-      response.end();
+      if (alternatePath != "") {
+        sendDataLabFile(alternatePath, response);
+      } else {
+        response.writeHead(500);
+        response.end();
+      }
     }
     else {
       response.writeHead(200, { 'Content-Type': contentType });
       response.end(content);
     }
-  });
+  }, isDynamic);
 }
 
 /**
@@ -112,6 +134,17 @@ function datalabFileExists(filePath: string) {
 }
 
 /**
+ * Sends a static 'custom.css' file located within the user's config directory.
+ *
+ * @param userId the ID of the current user.
+ * @param response the out-going response associated with the current HTTP request.
+ */
+function sendUserCustomTheme(userId: string, response: http.ServerResponse): void {
+    var customThemePath = path.join(settings.getUserConfigDir(userId), CUSTOM_THEME_FILE);
+    sendFile(customThemePath, response, DEFAULT_THEME_FILE, true);
+}
+
+/**
  * Implements static file handling.
  * @param request the incoming file request.
  * @param response the outgoing file response.
@@ -130,6 +163,9 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
   }
   else if (path.lastIndexOf('/reporting.html') > 0) {
     sendDataLabFile('reporting.html', response);
+  }
+  else if (path.lastIndexOf('/datalab.css') > 0) {
+    sendDataLabFile('datalab.css', response);
   }
   else if (path.indexOf('/codemirror/mode/') > 0) {
     var split = path.lastIndexOf('/');
@@ -150,13 +186,20 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
     sendDataLabFile('datalab.js', response);
   }
   else if (path.lastIndexOf('/custom.css') > 0) {
-    // NOTE: Uncomment to use external content mapped into the container.
-    //       This is only useful when actively developing the content itself.
-    // var text = fs.readFileSync('/sources/datalab/static/datalab.css', { encoding: 'utf8' });
-    // response.writeHead(200, { 'Content-Type': 'text/css' });
-    // response.end(text);
-
-    sendDataLabFile('datalab.css', response);
+    var userId: string = userManager.getUserId(request);
+    var userSettings: common.Map<string> = settings.loadUserSettings(userId);
+    if ('theme' in userSettings) {
+      var theme: string = userSettings['theme'];
+      if (theme == 'custom') {
+        sendUserCustomTheme(userId, response);
+      } else if (theme == 'dark') {
+        sendDataLabFile('dark.css', response);
+      } else {
+        sendDataLabFile('light.css', response);
+      }
+    } else {
+      sendDataLabFile(DEFAULT_THEME_FILE, response);
+    }
   }
   else if ((path.indexOf('/static/extensions/') == 0) ||
            (path.indexOf('/static/require/') == 0)) {

--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+body {
+  color: #fff;
+  background: #000;
+}
+#mainToolbar, #sidebarToolbar, #sidebarArea {
+  background-color: #444;
+}
+#mainToolbar, #sidebarToolbar {
+  border-bottom: solid 1px #000;
+}
+#notebook-container {
+  background: #000;
+}
+button, .btn {
+  color: #ccc;
+  background-color: transparent;
+}
+button:hover, .btn-toolbar, .btn:hover, .btn:focus {
+  color: #fff;
+}
+.btn.active {
+  color: #557ab7;
+  border-bottom: solid 2px #559ad7;
+}
+#button-select-all {
+  border-color: transparent;
+  background-color: transparent;
+}
+.notebook_app {
+  color: #fff;
+  background: #000;
+}
+#notebook_name:hover {
+  background-color: transparent;
+}
+span.autosave_status {
+  color: #ddd;
+}
+a:hover {
+  color: #5bc0de;
+}
+.breadcrumb, .list_header {
+  color: #6ee;
+  background: #333;
+}
+.list_item:hover {
+  background: #555;
+}
+div.code_cell.session.completed div.input {
+  border-left: solid 4px #559ad7;
+}
+div.code_cell div.input {
+  background-color: #333;
+}
+div.output, div.output_area pre {
+  color: #fff;
+}
+div.output {
+  background-color: #555;
+}
+div.output_stderr {
+  background-color: #a94442;
+}
+.CodeMirror, .CodeMirror pre, .CodeMirror-lines, .CodeMirror-linenumber {
+  color: #fff;
+  background: #333;
+}
+.CodeMirror-gutters {
+  color: #fff;
+  background: #333;
+}
+.cm-keyword {
+  color: #aaf !important;
+}
+.cm-number, .cm-string, .cm-string2 {
+  color: lightgreen !important;
+}
+.cm-def, .cm-variable, .cm-variable-2, .cm-variable-3, .cm-property,
+.cm-qualifier, .cm-operator, .cm-meta, .cm-builtin,
+.cm-tag, .cm-attribute, .cm-header, .cm-hr, .cm-atom {
+  color: #337ab7 !important;
+}
+.cm-link, .cm-url {
+  color: #559ad7 !important;
+}
+code {
+  background-color: #666;
+}
+
+.ansicyan {
+  color: lightblue;
+}
+.ansigreen {
+  color: lightgreen;
+}
+.ansigray {
+  color: lightgray;
+}
+.ansiyellow {
+  color: #ff0;
+}
+.cm-magic, .ansired {
+  color: #f00;
+}
+.item_icon {
+  color: #adadad;
+}
+
+#texteditor-backdrop, #texteditor-backdrop #texteditor-container .CodeMirror-gutter {
+  background: #333;
+}
+
+.rendered_html, div.text_cell_render {
+  color: #fff;
+}
+
+.modal-content {
+  background-color: #333;
+}
+
+.close {
+  color: inherit;
+}
+
+.google-visualization-table {
+  color: #000;
+}

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -24,7 +24,6 @@
 body {
   font-family: 'Open Sans', Helvetica, sans-serif;
   font-size: 14px;
-  background: #fff;
   min-width: 1200px;
 }
 
@@ -47,6 +46,9 @@ body {
   align-content: space-between;
 }
 #appBar {
+  color: white;
+  background-color: #333;
+  box-shadow: 0 0 8px 0 #000;
   -webkit-order: 1;
   order: 1;
   -webkit-flex: 0 1 auto;
@@ -56,12 +58,10 @@ body {
   height: 48px;
   min-height: 48px;
   color: white;
-  background-color: #333;
   padding-left: 10px;
   padding-right: 10px;
   position: relative;
   z-index: 10;
-  box-shadow: 0 0 8px 0 #000;
 }
 #appContent {
   -webkit-order: 2;
@@ -127,7 +127,6 @@ body {
   -webkit-align-self: auto;
   align-self: auto;
   min-width: 100px;
-  background-color: #f3f3f3;
   position: relative;
 }
 #sidebarToolbar.larger {
@@ -135,7 +134,6 @@ body {
   flex-grow: 3;
 }
 #sidebarArea {
-  color: #000;
   padding: 10px 20px;
 }
 #sidebarArea.larger {
@@ -146,12 +144,9 @@ body {
   line-height: 48px;
   vertical-align: middle;
   height: 48px;
-  color: #444;
-  background-color: #f3f3f3;
   padding-left: 10px;
   padding-right: 10px;
   padding-top: 2px;
-  border-bottom: solid 1px #e6e6e6;
   z-index: 8;
 }
 #updateMessageArea {
@@ -183,7 +178,6 @@ body {
   bottom: 0px;
 }
 #sidebarContent {
-  color: #000;
   padding: 10px 20px;
 }
 .container {
@@ -201,12 +195,8 @@ div.btn-group a {
   height: 48px;
   font-size: 16px;
   padding: 4px;
-  color: #ccc;
   margin-right: 10px;
   margin-left: 0px;
-}
-#appBar button:hover {
-  color: #fff;
 }
 #appbar div.btn-group {
   margin-left: 0px !important;
@@ -217,7 +207,6 @@ div.btn-toolbar {
 div.btn-toolbar .btn {
   background-color: transparent;
   border: none;
-  color: #666;
   font-weight: normal;
   font-size: 14px;
   outline: solid 1px transparent !important;
@@ -228,7 +217,6 @@ div.btn-toolbar .btn {
   vertical-align: middle;
 }
 div.btn-toolbar .btn:hover, div.btn-toolbar .btn:focus {
-  color: #000;
   border: none;
 }
 div.btn-toolbar button:focus {
@@ -241,10 +229,8 @@ div.btn-toolbar .btn.dropdown-toggle {
 }
 div.btn-toolbar .btn.active {
   font-weight: bold;
-  color: #337ab7;
   border: none;
   box-shadow: none;
-  border-bottom: solid 2px #337ab7;
 }
 #toggleSidebarButton {
   margin-bottom: 8px;
@@ -282,9 +268,6 @@ div.btn-toolbar .btn.active {
   font-size: 16px;
   padding: 0px;
 }
-.notebook_app {
-  background: #fff;
-}
 #ipython-main-app {
   position: relative;
   padding: 10px 40px;
@@ -312,7 +295,6 @@ span.save_widget span.filename {
   margin: 0px;
 }
 span.autosave_status {
-  color: #ddd;
   font-size: 13px;
   line-height: 35px;
   vertical-align: middle;
@@ -329,12 +311,12 @@ div.cell {
 }
 div.cell.selected, div.cell.text_cell.selected, div.cell.code_cell.selected {
   border: solid 1px #ddd;
+  box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.2);
 }
 .edit_mode div.cell.text_cell.selected, .edit_mode div.code_cell.selected {
   border: solid 1px #ddd;
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.2);
 }
-
 div.code_cell div.input {
   border-left: solid 4px #ddd;
 }
@@ -344,11 +326,7 @@ div.code_cell.session div.input {
 div.code_cell.running div.input {
   border-left: solid 4px #ddd;
 }
-div.code_cell.session.completed div.input {
-  border-left: solid 4px #337ab7;
-}
 div.code_cell div.input {
-  background-color: #f7f7f7;
   border-top: none;
 }
 div.input_area {
@@ -432,26 +410,14 @@ div.selected .CodeMirror-linenumber {
   font-weight: bold !important;
 }
 .cm-keyword {
-  color: #00f !important;
   font-weight: normal !important;
-}
-.cm-number, .cm-string, .cm-string2 {
-  color: #000080 !important;
 }
 .cm-comment {
   color: #008000 !important;
   font-style: normal !important;
 }
-.cm-def, .cm-variable, .cm-variable-2, .cm-variable-3, .cm-property,
-.cm-qualifier, .cm-operator, .cm-meta, .cm-builtin,
-.cm-tag, .cm-attribute, .cm-header, .cm-hr, .cm-atom {
-  color: #000 !important;
-}
 .cm-error {
   color: red !important;
-}
-.cm-link, .cm-url {
-  color: #337ab7 !important;
 }
 .cm-header-1, .cm-header-2, .cm-header-3, .cm-header-4, .cm-header-5, .cm-header-6 {
   font-family: inherit !important;
@@ -464,10 +430,6 @@ div.modal-dialog pre, div.modal-dialog code, #help code, #help pre {
 }
 #help pre {
   border: none;
-}
-
-code {
-  background-color: #eee;
 }
 
 @media print {

--- a/sources/web/datalab/static/light.css
+++ b/sources/web/datalab/static/light.css
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+body {
+  background: #fff;
+}
+#mainToolbar, #sidebarToolbar, #sidebarArea {
+  background-color: #f3f3f3;
+}
+#sidebarArea, #sidebarContent {
+  color: #000;
+}
+#mainToolbar, #sidebarToolbar {
+  color: #444;
+  border-bottom: solid 1px #e6e6e6;
+}
+#appBar button {
+  color: #ccc;
+  background-color: transparent;
+}
+#appBar button:hover {
+  color: #fff;
+}
+div.btn-toolbar .btn {
+  color: #666;
+  background-color: transparent;
+}
+div.btn-toolbar .btn:hover, div.btn-toolbar .btn:focus {
+  color: #000;
+}
+div.btn-toolbar .btn.active {
+  color: #337ab7;
+  border-bottom: solid 2px #337ab7;
+}
+#button-select-all {
+  border-color: transparent;
+  background-color: transparent;
+}
+.notebook_app {
+  background: #fff;
+}
+#notebook_name:hover {
+  background-color: transparent;
+}
+span.autosave_status {
+  color: #ddd;
+}
+div.code_cell.session.completed div.input {
+  border-left: solid 4px #337ab7;
+}
+div.code_cell div.input {
+  background-color: #f7f7f7;
+}
+.cm-keyword {
+  color: #00f !important;
+}
+.cm-number, .cm-string, .cm-string2 {
+  color: #000080 !important;
+}
+.cm-def, .cm-variable, .cm-variable-2, .cm-variable-3, .cm-property,
+.cm-qualifier, .cm-operator, .cm-meta, .cm-builtin,
+.cm-tag, .cm-attribute, .cm-header, .cm-hr, .cm-atom {
+  color: #000 !important;
+}
+.cm-link, .cm-url {
+  color: #337ab7 !important;
+}
+code {
+  background-color: #eee;
+}

--- a/sources/web/datalab/templates/edit.html
+++ b/sources/web/datalab/templates/edit.html
@@ -9,6 +9,7 @@
 
   <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
+  <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
 </head>
 <body class="edit_app"

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -8,6 +8,7 @@
 
   <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
+  <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
 </head>
 <body class="notebook_app"

--- a/sources/web/datalab/templates/sessions.html
+++ b/sources/web/datalab/templates/sessions.html
@@ -8,6 +8,7 @@
 
   <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
+  <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
 </head>
 <body class="session_list"

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -8,6 +8,7 @@
 
   <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
+  <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
 </head>
 <body class="notebook_list"


### PR DESCRIPTION
This adds a new user setting called 'theme' that can be set to
one of 'light', 'dark', or 'custom'.

Both 'light' and 'dark' are canned themes with 'light' matching the
existing Datalab style, and 'dark' modifying that theme to have
dark backgrounds rather than light ones.

The 'custom' setting is for using a user-specified CSS file stored
in the 'datalab/.config' directory named 'custom.css'.

This change does not incorporate a UI for modifying the theme
setting, but the user can change it by directly modifying the
'datalab/.config/settings.json' file.

The canned dark theme still needs some work.