### PR TITLE
Create the SSH tunnel as the logged in user rather than root.

### DIFF
--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -109,14 +109,15 @@ if [[ -n "${INSTANCE}" ]]; then
     fi
   fi
 
-  echo "Will connect to the kernel gateway running on the GCE VM ${INSTANCE}"
+  SSH_USER=`echo ${USER_EMAIL} | cut -d '@' -f 1`
+  echo "Will connect to the kernel gateway running on the GCE VM ${INSTANCE} as ${SSH_USER}"
   gcloud compute ssh --quiet \
     --project "${PROJECT_ID}" \
     --zone "${ZONE}" \
     --ssh-flag="-fNL" \
     --ssh-flag="localhost:8082:localhost:8080" \
     --ssh-key-file="/content/datalab/.config/.ssh/google_compute_engine" \
-    "${INSTANCE}"
+    "${SSH_USER}@${INSTANCE}"
 
   # Test that we can actually call the gateway API via the SSH tunnel
   TUNNEL_FAILED=""

--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -65,6 +65,7 @@ if [[ -n "${INSTANCE}" ]]; then
       echo "Failed to log in to gcloud"
       exit "${ERR_LOGIN}"
     fi
+    USER_EMAIL=`gcloud auth list --format="value(account)"`
   fi
 
   PROJECT_NOT_FOUND=""


### PR DESCRIPTION
By default, everything inside of the Docker container runs as the user
'root'. Previously, we were setting up the SSH tunnel, we defaulted to
the user inside the VM matching the user inside the Docker
container. However, 'root' is special, and some VM images do not allow
SSH-ing as that user.

For example, this prevented the Datalab image from being able to connect
to a kernel gateway running inside of a Google Dataproc cluster.

This change fixes that be making the username inside of the VM match
the username of the logged-in account (e.g. "<username>@gmail.com").