### PR TITLE
Fix a bug in looking up the project number.

### DIFF
--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -148,11 +148,7 @@ if [ "${ENABLE_USAGE_REPORTING}" = "true" ]
 then
   if [ -n "${PROJECT_ID}" ]
   then
-    USER_EMAIL=`gcloud auth list --format="value(account)"`
-    if [ -n "${USER_EMAIL}" ]
-    then
-      export PROJECT_NUMBER=`gcloud projects describe "${PROJECT_ID}" --format 'value(projectNumber)'`
-    fi
+    export PROJECT_NUMBER=`gcloud projects describe "${PROJECT_ID}" --format 'value(projectNumber)' 2>/dev/null || true`
   fi
 fi
 


### PR DESCRIPTION
Pull request #941 fixed a bug where our attempt to lookup the project
number would fail if the user was not signed in. However, that is just
a special case of the more general issue of not being able to look
up the project number.

We have seen reports of at least one other instance of this issue,
which is the case that a user is signed in but is not a project owner.

In that case, the check that the user is signed in will succeed, but
the attempt to lookup the project number will fail, causing the
Datalab startup to terminate.

This change fixes that by modifying the check to be more general.

Instead of checking if we believe that the lookup will succeed, we
try the lookup and gracefully handle any errors that occurred.