### PR TITLE
Support logging in via the command line at startup.

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -38,6 +38,7 @@ ENV DATALAB_VERSION _version_
 ENV DATALAB_COMMIT _commit_
 ENV DEPLOY_VM "false"
 ENV ENABLE_USAGE_REPORTING true
+ENV CLI_LOGIN false
 
 # Startup
 ENTRYPOINT [ "/datalab/run.sh" ]


### PR DESCRIPTION
Previous versions of Datalab would trigger a CLI based OAuth flow at
startup if they needed the user's credentials to set up a connection
with the backend in a GCE VM.

We recently replaced that with a web-based OAuth flow that mimiced the
sign-in button in the Datalab UI.

However, both that login flow at startup and the sign-in button in the
UI require that the UI be accessed via the hostname 'localhost'.

That is not sufficient for the case of someone wanting to run Datalab
inside of the Google Cloud Shell. In that environment the user can still
access port 8081 via the "Web preview" feature, and that access is still
secure (since only that user can access it), but the hostname will
not be 'localhost'.

This change adds support for that use case by adding a "CLI_LOGIN"
environment variable to the Docker image. If that variable is set to
"true", then the startup script will trigger a CLI based OAuth flow if
the user is not already signed in.