### PR TITLE
Pull the GCC source code from a mirror instead of FTP.

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -32,7 +32,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
 RUN mkdir -p /srcs && \
     cd /srcs && \
     apt-get source -d python-zmq wget git ca-certificates pkg-config libpng-dev && \
-    wget ftp://ftp.gnu.org/gnu/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2 && \
+    wget https://mirrors.kernel.org/gnu/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2 && \
     cd /
 
 # Setup Python packages. Rebuilding numpy/scipy is expensive so we move this early


### PR DESCRIPTION
The GNU project lists multiple mirrors for their source code and asks on their
site that one of the mirrors be used for downloading rather than reading
directly from their FTP server.

This change switches us from downloading directly from the GNU FTP server to
instead pulling from the first HTTP-based mirror listed in the US on this
site: https://www.gnu.org/prep/ftp.en.html