### PR TITLE
Support hosts that block websockets.

### DIFF
--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -371,6 +371,10 @@ export function handleRequest(request: http.ServerRequest, response: http.Server
 
 function getBaseTemplateData(request: http.ServerRequest): common.Map<string> {
   var userId: string = userManager.getUserId(request);
+  var proxyWebSockets: string = process.env.PROXY_WEB_SOCKETS;
+  if (proxyWebSockets != 'true') {
+    proxyWebSockets = 'false';
+  }
   var reportingEnabled: string = process.env.ENABLE_USAGE_REPORTING;
   if (reportingEnabled) {
     var userSettings: common.Map<string> = settings.loadUserSettings(userId);
@@ -385,6 +389,7 @@ function getBaseTemplateData(request: http.ServerRequest): common.Map<string> {
     configUrl: appSettings.configUrl,
     baseUrl: '/',
     reportingEnabled: reportingEnabled,
+    proxyWebSockets: proxyWebSockets
   };
   if (process.env.DATALAB_ENV == 'local') {
     templateData['isSignedIn'] = auth.isSignedIn().toString();

--- a/sources/web/datalab/package.json
+++ b/sources/web/datalab/package.json
@@ -8,6 +8,7 @@
     "mkdirp": "^0.5.0",
     "node-uuid": "^1.4.1",
     "request": "^2.71.0",
+    "socket.io": "^1.3.6",
     "tcp-port-used": "^0.1.2",
     "ws": "^0.4.32",
     "node-cache": "~3.0.0"

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -27,6 +27,7 @@ import net = require('net');
 import path = require('path');
 import request = require('request');
 import reverseProxy = require('./reverseProxy');
+import sockets = require('./sockets');
 import settings_ = require('./settings');
 import static_ = require('./static');
 import url = require('url');
@@ -247,7 +248,12 @@ export function run(settings: common.Settings): void {
   staticHandler = static_.createHandler(settings);
 
   server = http.createServer(requestHandler);
-  server.on('upgrade', socketHandler);
+  var proxyWebSockets: string = process.env.PROXY_WEB_SOCKETS;
+  if (proxyWebSockets == 'true') {
+    sockets.wrapServer(server);
+  } else {
+    server.on('upgrade', socketHandler);
+  }
 
   logging.getLogger().info('Starting DataLab server at http://localhost:%d',
                            settings.serverPort);

--- a/sources/web/datalab/sockets.ts
+++ b/sources/web/datalab/sockets.ts
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2015 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/// <reference path="../../../externs/ts/node/node.d.ts" />
+/// <reference path="../../../externs/ts/node/socket.io.d.ts" />
+/// <reference path="../../../externs/ts/node/node-ws.d.ts" />
+/// <reference path="common.d.ts" />
+
+import http = require('http');
+import jupyter = require('./jupyter');
+import logging = require('./logging');
+import socketio = require('socket.io');
+import url = require('url');
+import util = require('util');
+import WebSocket = require('ws');
+
+interface Session {
+  id: number;
+  url: string;
+  socket: SocketIO.Socket;
+  webSocket: WebSocket;
+}
+
+interface SessionMessage {
+  url: string;
+}
+
+interface DataMessage {
+  channel: string;
+  data: string;
+}
+
+var sessionCounter = 0;
+
+/**
+ * Creates a WebSocket connected to the Jupyter server for the URL in the specified session.
+ */
+function createWebSocket(port: number, session: Session): WebSocket {
+  var socketUrl = 'ws://127.0.0.1:' + port + url.parse(session.url).path;
+  logging.getLogger().debug('Creating WebSocket to %s for session %d', socketUrl, session.id);
+
+  var ws = new WebSocket(socketUrl);
+  ws.on('open', function() {
+      // Stash the resulting WebSocket, now that it is in open state
+      session.webSocket = ws;
+      session.socket.emit('open', { url: session.url });
+    })
+    .on('close', function() {
+      // Remove the WebSocket from the session, once it is in closed state
+      logging.getLogger().debug('WebSocket [%d] closed', session.id);
+      session.webSocket = null;
+      session.socket.emit('close', { url: session.url });
+    })
+    .on('message', function(data: any) {
+      // Propagate messages arriving on the WebSocket to the client.
+      logging.getLogger().debug('WebSocket [%d] message\n%j', session.id, data);
+      session.socket.emit('data', { data: data });
+    })
+    .on('error', function(e: any) {
+      logging.getLogger().error('WebSocket [%d] error\n%j', session.id, e);
+      if (e.code == 'ECONNREFUSED') {
+        // This happens in the following situation -- old kernel that has gone away
+        // likely due to a restart/shutdown... and an old notebook client attempts to
+        // reconnect to the old kernel. That connection will be refused.
+        // In this case, there is no point in keeping this socket.io connection open.
+        session.socket.disconnect(/* close */ true);
+      }
+    });
+
+  return ws;
+}
+
+/**
+ * Closes the WebSocket instance associated with the session.
+ */
+function closeWebSocket(session: Session): void {
+  if (session.webSocket) {
+    session.webSocket.close();
+    session.webSocket = null;
+  }
+}
+
+/**
+ * Handles communication over the specified socket.
+ */
+function socketHandler(socket: SocketIO.Socket) {
+  sessionCounter++;
+
+  // Each socket is associated with a session that tracks the following:
+  // - id: a counter for use in log output
+  // - url: the url used to connect to the Jupyter server
+  // - socket: the socket.io socket reference, which generates message
+  //           events for anything sent by the browser client, and allows
+  //           emitting messages to send to the browser
+  // - webSocket: the corresponding WebSocket connection to the Jupyter
+  //              server.
+  // Within a session, messages recieved over the socket.io socket (from the browser)
+  // are relayed to the WebSocket, and messages recieved over the WebSocket socket are
+  // relayed back to the socket.io socket (to the browser).
+  var session: Session = {
+    id: sessionCounter,
+    url: '',
+    socket: socket,
+    webSocket: null
+  };
+
+  logging.getLogger().debug('Socket connected for session %d', session.id);
+
+  socket.on('disconnect', function() {
+    logging.getLogger().debug('Socket disconnected for session %d', session.id);
+
+    // Handle client disconnects to close WebSockets, so as to free up resources
+    closeWebSocket(session);
+  });
+
+  socket.on('start', function(message: SessionMessage) {
+    logging.getLogger().debug('Start in session %d with url %s', session.id, message.url);
+
+    try {
+      var port = jupyter.getPort(socket.request)
+      session.url = message.url;
+      session.webSocket = createWebSocket(port, session);
+    }
+    catch (e) {
+      logging.getLogger().error(e, 'Unable to create WebSocket connection to %s', message.url);
+      session.socket.disconnect(/* close */ true);
+    }
+  });
+
+  socket.on('stop', function(message: SessionMessage) {
+    logging.getLogger().debug('Stop in session %d with url %s', session.id, message.url);
+
+    closeWebSocket(session);
+  });
+
+  socket.on('data', function(message: DataMessage) {
+    // The client sends this message per data message to a particular channel. Propagate the
+    // message over to the WebSocket associated with the specified channel.
+
+    logging.getLogger().debug('Send data in session %d\n%s',
+                              session.id, message.data);
+    if (session.webSocket) {
+      session.webSocket.send(message.data, function(e) {
+        if (e) {
+          logging.getLogger().error(e, 'Failed to send message to websocket');
+        }
+      });
+    }
+    else {
+      logging.getLogger().error('Unable to send message; WebSocket is not open');
+    }
+  });
+}
+
+export function wrapServer(server: http.Server): void {
+  var io = socketio.listen(server, {
+    transports: [ 'polling' ],
+    allowUpgrades: false
+  });
+
+  io.of('/session')
+    .on('connection', socketHandler);
+}

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -12,6 +12,98 @@
  * the License.
  */
 
+// Override WebSocket
+(function() {
+    var proxyWebSockets = (document.body.getAttribute('data-proxy-web-sockets') == 'true');
+    if (!proxyWebSockets) {
+	return;
+    }
+
+    if (!window.io) {
+	// If socket.io was not loaded into the page, then do not override the existing
+	// WebSocket functionality.
+	return;
+    }
+
+    function WebSocketShim(url) {
+	var self = this;
+	this._url = url;
+	this.readyState = WebSocketShim.CLOSED;
+
+	var socketUri = location.protocol + '//' + location.host + '/session';
+	var socketOptions = {
+	    upgrade: false,
+	    multiplex: false
+	};
+
+	function errorHandler() {
+	    if (self.onerror) {
+		self.onerror({ target: self });
+	    }
+	}
+	var socket = io.connect(socketUri, socketOptions);
+	socket.on('connect', function() {
+	    socket.emit('start', { url: url });
+	});
+	socket.on('disconnect', function() {
+	    self._socket = null;
+	    self.readyState = WebSocketShim.CLOSED;
+	    if (self.onclose) {
+		self.onclose({ target: self });
+	    }
+	});
+	socket.on('open', function(msg) {
+	    self._socket = socket;
+	    self.readyState = WebSocketShim.OPEN;
+	    if (self.onopen) {
+		self.onopen({ target: self });
+	    }
+	});
+	socket.on('close', function(msg) {
+	    self._socket = null;
+	    self.readyState = WebSocketShim.CLOSED;
+	    if (self.onclose) {
+		self.onclose({ target: self });
+	    }
+	});
+	socket.on('data', function(msg) {
+	    if (self.onmessage) {
+		self.onmessage({ target: self, data: msg.data });
+	    }
+	});
+	socket.on('error', errorHandler);
+	socket.on('connect_error', errorHandler);
+	socket.on('reconnect_error', errorHandler);
+    }
+    WebSocketShim.prototype = {
+	onopen: null,
+	onclose: null,
+	onmessage: null,
+	onerror: null,
+
+	send: function(data) {
+	    if (this.readyState != WebSocketShim.OPEN) {
+		throw new Error('WebSocket is not yet opened');
+	    }
+	    this._socket.emit('data', { data: data });
+	},
+
+	close: function() {
+	    if (this.readyState == WebSocketShim.OPEN) {
+		this.readyState = WebSocketShim.CLOSED;
+
+		this._socket.emit('stop', { url: this._url });
+		this._socket.close();
+	    }
+	}
+    };
+    WebSocketShim.CLOSED = 0;
+    WebSocketShim.OPEN = 1;
+
+    var nativeWebSocket = window.WebSocket;
+    window.WebSocket = WebSocketShim;
+})();
+
 var debug = {
   enabled: true,
   log: function() { console.log.apply(console, arguments); }

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -22,7 +22,8 @@
   data-signed-in="<%isSignedIn%>"
   data-user-id="<%userId%>"
   data-reporting-enabled="<%reportingEnabled%>"
-  data-project-hash="<%projectHash%>">
+  data-project-hash="<%projectHash%>"
+  data-proxy-web-sockets="<%proxyWebSockets%>">
 
   <script>
      window.datalab = {};
@@ -302,6 +303,7 @@
     </div>
   </div>
   <script src="/static/components/es6-promise/promise.min.js"></script>
+  <script src="/socket.io/socket.io.js"></script>
   <script src="/static/components/requirejs/require.js"></script>
   <script>
     window.mathjax_url = '';


### PR DESCRIPTION
Previously, Datalab proxied web-socket connections over HTTP, so that
it could run in App Engine Flex (which does not support websockets).

That code was removed when we transitioned to the locally-run setup,
as we did not think that it was necessary anymore.

However, even in the locally-run setup, a user may want to run in
an environment that does not support web-sockets. One such example
is users who want to run Datalab using Google's Cloud Shell Web
Preview feature (https://cloud.google.com/shell/docs/using-web-preview).

This change adds support for such environments by conditionally
proxying web sockets over HTTP based on an environment variable that
can be set by the user.

The code for this is just the old proxy code from the App Engine
Flex version of Datalab, but wrapped in checks based on the new
user setting.

This works for the entirely-locally run version, but additional
work will be required for this to also work with kernel gateways,
as the proxied web socket connections look like cross-domain web
sockets, which are currently blocked.