### PR TITLE
Make the left padding of cells consistent

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -307,16 +307,20 @@ div.cell {
   border: solid 1px transparent;
   border-radius: 0px;
   padding: 0px;
+  padding-left: 4px;
   margin-bottom: 10px;
 }
 div.cell.selected, div.cell.text_cell.selected, div.cell.code_cell.selected {
   border: solid 1px #ddd;
+  padding-left: 4px;
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.2);
 }
 .edit_mode div.cell.text_cell.selected, .edit_mode div.code_cell.selected {
   border: solid 1px #ddd;
+  padding-left: 4px;
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.2);
 }
+
 div.code_cell div.input {
   border-left: solid 4px #ddd;
 }


### PR DESCRIPTION
This change fixes a usability issue with the display of code and data cells
where they would be displayed with a different amount of left-padding depending
on their state (unselected, selected, or edit-mode).

This fixes that issue by setting the left padding to always be 4 pixels
regardless of what state the cell is in.