### PR TITLE
Cleanup the notebook view UI

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -100,8 +100,6 @@ body {
   order: 1;
   -webkit-flex: 0 1 auto;
   flex: 0 1 auto;
-  -webkit-box-shadow: 1px 2px 8px 0px rgba(0, 0, 0, 0.25);
-  box-shadow: 1px 2px 8px 0px rgba(0, 0, 0, 0.25);
 }
 #contentArea {
   -webkit-order: 2;

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -182,7 +182,7 @@
               </ul>
             </div>
           </div>
-          <div class="btn-toolbar pull-right">
+          <div class="btn-toolbar pull-left">
             <div class="btn-group">
               <button id="addCodeCellButton" type="button" class="btn" title="Append a new code cell">
                 <span class="fa fa-plus-square"></span> Add Code


### PR DESCRIPTION
1. Remove some unnecessary and inconsistent shadows.
2. Remove space between the "Notebook" dropdown and the editing buttons.