### PR TITLE
Add an API for getting the current user settings.

### DIFF
--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -180,11 +180,26 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
     } else {
       response.writeHead(500, { 'Content-Type': 'text/plain' });
     }
+    response.end();
+    return;
   } else {
-    response.writeHead(400, { 'Content-Type': 'text/plain' });
+    var userSettings = loadUserSettings(userId);
+    if ('key' in parsedUrl.query) {
+      var key = parsedUrl.query['key'];
+      if (key in userSettings) {
+        response.writeHead(200, { 'Content-Type': 'application/json' });
+        response.end(JSON.stringify(userSettings[key]));
+      } else {
+        response.writeHead(404, { 'Content-Type': 'text/plain' });
+        response.end();
+      }
+      return;
+    } else {
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify(userSettings));
+      return;
+    }
   }
-
-  response.end();
 }
 
 /**


### PR DESCRIPTION
This change extens the "_settings" endpoint so that it can be used
to fetch the current settings in addition to updating them.

The old behavior was:

    If both 'key' and 'value' are specified, then update that
    setting, otherwise return a 'bad-request' error.

The new behavior is:

    If 'key' and 'value' are specified then update that setting...

    Otherwise, if 'key' is specified then return the value of just
    that one setting...

    Otherwise, return the values of all the settings.