### PR TITLE
Exposing dark theme - Added a theme dropdown for controling light/dar…

### DIFF
--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -149,9 +149,6 @@ code {
 .item_icon {
   color: #adadad;
 }
-.dropdown-menu > li > a {
-  color: #ddd;
-}
 .google-visualization-table {
   color: #000;
 }

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -224,6 +224,15 @@ div.btn-toolbar .toolbar-btn.dropdown-toggle {
   padding-right: 2px;
   margin-left: -2px;
 }
+#themeDropdown {
+   border-radius: 2px;
+   color: #555;
+   padding: 5px 10px;
+   width: 150px;
+}
+#signOutGroup ul li {
+   padding: 5px 0px 0px 0px;
+}
 div.btn-toolbar .toolbar-btn.active {
   font-weight: bold;
   border: none;

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -126,6 +126,17 @@ function reportEvent(event) {
   window.dataLayer.push(event);
 }
 
+function xhr(url, callback) {
+  let request = new XMLHttpRequest();
+  request.onreadystatechange = callback.bind(request);
+  request.open("GET", url);
+  request.send();
+}
+
+function getSettingKeyAddress(setting) {
+  return window.location.protocol + "//" + window.location.host + "/_settings?key=" + setting;
+}
+
 function initializePage(dialog, saveFn) {
 
   function showAbout() {
@@ -152,6 +163,19 @@ function initializePage(dialog, saveFn) {
   }
 
   $('#aboutButton').click(showAbout);
+
+  // Prepare signOutGroup
+  $('#signOutGroup button').on('click', function (event) {
+    $(this).parent().toggleClass('open');
+  });
+  $('body').on('click', function (e) {
+    if (!$('#signOutGroup').is(e.target)
+        && $('#signOutGroup').has(e.target).length === 0
+        && $('.open').has(e.target).length === 0
+    ) {
+        $('#signOutGroup').removeClass('open');
+    }
+  });
   $('#feedbackButton').click(function() {
     window.open('https://groups.google.com/forum/#!newtopic/google-cloud-datalab-feedback');
   });
@@ -170,6 +194,18 @@ function initializePage(dialog, saveFn) {
       saveFn();
       window.location = '/signout?referer=' + encodeURIComponent(window.location);
     });
+
+    // Prepare the theme selector dropdown
+    themeDropdown = document.getElementById("themeDropdown")
+    xhr(getSettingKeyAddress("theme"), function() {
+      themeDropdown.selectedIndex = this.responseText === "\"dark\"" ? 0 : 1;
+    })
+    themeDropdown.onchange = function() {
+      xhr(getSettingKeyAddress("theme") + "&value=" + (themeDropdown.selectedIndex === 0 ? "dark" : "light"), function() {
+        sheetAddress = document.getElementById("themeStylesheet").href + "?v=" + Date.now()
+        document.getElementById("themeStylesheet").setAttribute('href', sheetAddress);
+      })
+    };
   }
 }
 

--- a/sources/web/datalab/templates/edit.html
+++ b/sources/web/datalab/templates/edit.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
-  <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
+  <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" />
 </head>
 <body class="edit_app"
   data-project=""
@@ -59,12 +59,18 @@
         <div class="btn-group">
           <button id="signInButton" title="Sign In" style="display:none" class="toolbar-btn">Sign In</button>
           <div id="signOutGroup" style="display:none">
-            <button title="Account" data-toggle="dropdown" class="toolbar-btn">
+            <button title="Account" class="toolbar-btn">
               <span class="fa fa-user"></span>
             </button>
-            <ul class="dropdown-menu dropdown-menu-right" style="padding: 10px">
+            <ul class="dropdown-menu dropdown-menu-right" style="padding: 15px">
               <li>
                 <label>Signed in as <%account%></label>
+              </li>
+              <li>
+                <select id="themeDropdown">
+                  <option>Dark Theme</option>
+                  <option>Light Theme</option>
+                </select>
               </li>
               <hr />
               <li>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
-  <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
+  <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" id="stylesheet" />
 </head>
 <body class="notebook_app"
   data-project=""
@@ -143,12 +143,18 @@
         <div class="btn-group">
           <button id="signInButton" title="Sign In" style="display:none" class="toolbar-btn">Sign In</button>
           <div id="signOutGroup" style="display:none">
-            <button title="Account" data-toggle="dropdown" class="toolbar-btn">
+            <button title="Account" class="toolbar-btn">
               <span class="fa fa-user"></span>
             </button>
-            <ul class="dropdown-menu dropdown-menu-right" style="padding: 10px">
+            <ul class="dropdown-menu dropdown-menu-right" style="padding: 15px">
               <li>
                 <label>Signed in as <%account%></label>
+              </li>
+              <li>
+                <select id="themeDropdown">
+                  <option>Dark Theme</option>
+                  <option>Light Theme</option>
+                </select>
               </li>
               <hr />
               <li>

--- a/sources/web/datalab/templates/sessions.html
+++ b/sources/web/datalab/templates/sessions.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
-  <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
+  <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" />
 </head>
 <body class="session_list"
   data-base-url="<%baseUrl%>"
@@ -52,12 +52,18 @@
         <div class="btn-group">
           <button id="signInButton" title="Sign In" style="display:none" class="toolbar-btn">Sign In</button>
           <div id="signOutGroup" style="display:none">
-            <button title="Account" data-toggle="dropdown" class="toolbar-btn">
+            <button title="Account" class="toolbar-btn">
               <span class="fa fa-user"></span>
             </button>
-            <ul class="dropdown-menu dropdown-menu-right" style="padding: 10px">
+            <ul class="dropdown-menu dropdown-menu-right" style="padding: 15px">
               <li>
                 <label>Signed in as <%account%></label>
+              </li>
+              <li>
+                <select id="themeDropdown">
+                  <option>Dark Theme</option>
+                  <option>Light Theme</option>
+                </select>
               </li>
               <hr />
               <li>

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
-  <link rel="stylesheet" href="/static/style/custom.css" type="text/css" />
+  <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" />
 </head>
 <body class="notebook_list"
   data-base-url="<%baseUrl%>"
@@ -85,12 +85,18 @@
         <div class="btn-group">
           <button id="signInButton" title="Sign In" style="display:none" class="toolbar-btn">Sign In</button>
           <div id="signOutGroup" style="display:none">
-            <button title="Account" data-toggle="dropdown" class="toolbar-btn">
+            <button title="Account" class="toolbar-btn">
               <span class="fa fa-user"></span>
             </button>
-            <ul class="dropdown-menu dropdown-menu-right" style="padding: 10px">
+            <ul class="dropdown-menu dropdown-menu-right" style="padding: 15px">
               <li>
                 <label>Signed in as <%account%></label>
+              </li>
+              <li>
+                <select id="themeDropdown">
+                  <option>Dark Theme</option>
+                  <option>Light Theme</option>
+                </select>
               </li>
               <hr />
               <li>


### PR DESCRIPTION
This change fixes the dark theme, and exposes it using a dropdown button under the user profile menu. It uses settings that are persisted by the server piece, and does XHR requests to load and save them. It reloads the stylesheet when a different theme is selected to avoid the user having to reload the whole pages, losing any changes they might have.

Issue #104 