### PR TITLE
Fix an issue that 'custom.js' cannot be loaded.

### DIFF
--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -176,7 +176,7 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
       sendJupyterFile(path.substr(1), response);
     }
   }
-  else if (path.lastIndexOf('/custom.js') > 0) {
+  else if (path.lastIndexOf('/custom.js') >= 0) {
     // NOTE: Uncomment to use external content mapped into the container.
     //       This is only useful when actively developing the content itself.
     // var text = fs.readFileSync('/sources/datalab/static/datalab.js', { encoding: 'utf8' });


### PR DESCRIPTION
I think the issue has been there for a while. And my recent commit might have changed the js load sequence, which exposes the issue.

According to https://github.com/googledatalab/datalab/blob/master/sources/web/datalab/templates/tree.html#L170, when require(['custom'], function()..) is called, it will load '/custom.js', which will return 404. If the line is executed later, jupyter will load 'custom.js' from '/custom/custom.js', which is served correctly.