### PR TITLE
Refactor appbar into a shared HTML component

### DIFF
--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -167,6 +167,9 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
   else if (path.lastIndexOf('/datalab.css') > 0) {
     sendDataLabFile('datalab.css', response);
   }
+  else if (path.lastIndexOf('/appbar.html') > 0) {
+    sendDataLabFile('appbar.html', response);
+  }
   else if (path.indexOf('/codemirror/mode/') > 0) {
     var split = path.lastIndexOf('/');
     var newPath = 'codemirror/mode/' + path.substring(split + 1);

--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+</head>
+<body>
+  <span id="logo" class="nav navbar-brand pull-left">
+    <a href="/tree"><img src="/static/logo.png" alt="Google Cloud DataLab" /></a>
+  </span>
+  <span id="save_widget" class="pull-left save_widget">
+    <button class="toolbar-btn" title="Rename notebook"><span id="notebook_name" class="filename"></span></button>
+    <span class="autosave_status"></span>
+  </span>
+  <div class="btn-toolbar pull-right">
+    <div class="btn-group">
+      <button class="toolbar-btn" data-toggle="dropdown" title="Help Links">
+        <span class="fa fa-question-circle"></span>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-right" style="width: 200px">
+        <li><a id="keyboardHelpLink" style="display:none" href="#">Keyboard Shortcuts</a></li>
+        <li><a id="markdownHelpLink" style="display:none" href="#">Markdown Syntax</a></li>
+        <li id="notebookHelpDivider" class="divider" style="display:none"></li>
+        <li><a href="https://cloud.google.com/bigquery/what-is-bigquery" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>BigQuery&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></a></li>
+        <li><a href="https://cloud.google.com/storage/docs/overview" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Cloud Storage&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></a></li>
+        <li class="divider"></li>
+        <li><a href="https://developers.google.com/chart/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Google Charts</span></a></li>
+        <li><a href="http://matplotlib.org/contents.html" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Matplotlib</span></a></li>
+        <li><a href="http://pandas.pydata.org/pandas-docs/stable/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Pandas</span></a></li>
+        <li><a href="http://scikit-learn.org/stable/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>SciKit-Learn</span></a></li>
+        <li class="divider"></li>
+        <li><a href="/tree/datalab/docs/notebooks" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Samples and Tutorials</span></a></li>
+      </ul>
+    </div>
+    <div class="btn-group">
+      <button id="aboutButton" title="About Google Cloud Datalab" class="toolbar-btn">
+        <span class="fa fa-info-circle"></span>
+      </button>
+    </div>
+    <div class="btn-group">
+      <a href="/sessions" target="_blank" id="sessionsButton">
+        <button title="Running Sessions" class="toolbar-btn">
+          <span class="fa fa-tasks"></span>
+        </button>
+      </a>
+    </div>
+    <div id="accountDropdown" class="btn-group">
+      <button id="accountDropdownButton" title="Account" class="toolbar-btn">
+        <span class="fa fa-user"></span>
+      </button>
+      <div class="dropdown-menu dropdown-menu-right">
+        <div id="signInButton" style="display:none">
+          <button title="Sign In" class="btn btn-success" style="width: 100%; float: none">Sign In</button>
+        </div>
+        <div id="signOutGroup" style="display:none">
+          <label id="usernameLabel" style="padding:0 0 10px 0"></label>
+          <button id="signOutButton" title="Sign Out" class="btn btn-danger" style="width: 100%; float: none">Sign Out</button>
+        </div>
+        <hr />
+        <div id="feedbackButton" title="Provide feedback" class="btn">
+          <span class="fa fa-comment" id="feedbackButton"></span>
+          <span>Feedback</span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="/static/appbar.js" />
+</body>
+</html>

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -224,6 +224,9 @@ div.btn-toolbar .toolbar-btn.dropdown-toggle {
   padding-right: 2px;
   margin-left: -2px;
 }
+#accountDropdown div div {
+  padding: 10px 15px 15px 15px;
+}
 div.btn-toolbar .toolbar-btn.active {
   font-weight: bold;
   border: none;

--- a/sources/web/datalab/templates/edit.html
+++ b/sources/web/datalab/templates/edit.html
@@ -21,59 +21,10 @@
   data-feedback-id="<%feedbackId%>"
   data-version-id="<%versionId%>"
   data-signed-in="<%isSignedIn%>"
-  data-user-id="<%userId%>">
+  data-user-id="<%userId%>"
+  data-account="<%account%>">
   <div id="app">
     <div id="appBar">
-      <span id="logo" class="nav navbar-brand pull-left">
-        <a href="/tree"><img src="/static/logo.png" alt="Google Cloud DataLab" /></a>
-      </span>
-      <span id="save_widget" class="pull-left save_widget">
-        <button class="toolbar-btn" title="Rename file"><span id="file_name" class="filename"></span></button>
-        <span class="autosave_status"></span>
-      </span>
-      <div class="btn-toolbar pull-right">
-        <div class="btn-group">
-          <button id="feedbackButton" title="Provide feedback" class="toolbar-btn">
-            <span class="fa fa-comment"></span>
-          </button>
-        </div>
-        <div class="btn-group">
-          <button id="aboutButton" title="About Google Cloud Datalab" class="toolbar-btn">
-            <span class="fa fa-info-circle"></span>
-          </button>
-        </div>
-        <div class="btn-group">
-          <a href="/tree/datalab/docs/notebooks" target="_blank" id="docsButton">
-            <button id="docsButton" title="Samples and Tutorials" class="toolbar-btn">
-              <span class="fa fa-book"></span>
-            </button>
-          </a>
-        </div>
-        <div class="btn-group">
-          <a href="/sessions" target="_blank" id="sessionsButton">
-            <button title="Running Sessions" class="toolbar-btn">
-              <span class="fa fa-tasks"></span>
-            </button>
-          </a>
-        </div>
-        <div class="btn-group">
-          <button id="signInButton" title="Sign In" style="display:none" class="toolbar-btn">Sign In</button>
-          <div id="signOutGroup" style="display:none">
-            <button title="Account" data-toggle="dropdown" class="toolbar-btn">
-              <span class="fa fa-user"></span>
-            </button>
-            <ul class="dropdown-menu dropdown-menu-right" style="padding: 10px">
-              <li>
-                <label>Signed in as <%account%></label>
-              </li>
-              <hr />
-              <li>
-                <button id="signOutButton" title="Sign Out" class="btn btn-danger" style="width: 100%">Sign Out</button>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
     </div>
     <div id="appContent">
       <div id="toolbarArea">

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -21,6 +21,7 @@
   data-version-id="<%versionId%>"
   data-signed-in="<%isSignedIn%>"
   data-user-id="<%userId%>"
+  data-account="<%account%>"
   data-reporting-enabled="<%reportingEnabled%>"
   data-project-hash="<%projectHash%>"
   data-proxy-web-sockets="<%proxyWebSockets%>">
@@ -91,73 +92,6 @@
 
   <div id="app">
     <div id="appBar">
-      <span id="logo" class="nav navbar-brand pull-left">
-        <a href="/tree"><img src="/static/logo.png" alt="Google Cloud DataLab" /></a>
-      </span>
-      <span id="save_widget" class="pull-left save_widget">
-        <button class="toolbar-btn" title="Rename notebook"><span id="notebook_name" class="filename"></span></button>
-        <span class="autosave_status"></span>
-      </span>
-      <div class="btn-toolbar pull-right">
-        <div class="btn-group">
-          <button class="toolbar-btn" data-toggle="dropdown" title="Help Links">
-            <span class="fa fa-question-circle"></span>
-          </button>
-          <ul class="dropdown-menu dropdown-menu-right">
-            <li><a id="keyboardHelpLink" href="#">Keyboard Shortcuts</a></li>
-            <li><a id="markdownHelpLink" href="#">Markdown Syntax</a></li>
-            <li class="divider"></li>
-            <li><a href="https://cloud.google.com/bigquery/what-is-bigquery" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>BigQuery&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></a></li>
-            <li><a href="https://cloud.google.com/storage/docs/overview" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Cloud Storage&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></a></li>
-            <li class="divider"></li>
-            <li><a href="https://developers.google.com/chart/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Google Charts</span></a></li>
-            <li><a href="http://matplotlib.org/contents.html" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Matplotlib</span></a></li>
-            <li><a href="http://pandas.pydata.org/pandas-docs/stable/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Pandas</span></a></li>
-            <li><a href="http://scikit-learn.org/stable/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>SciKit-Learn</span></a></li>
-          </ul>
-        </div>
-        <div class="btn-group">
-          <button id="feedbackButton" title="Provide feedback" class="toolbar-btn">
-            <span class="fa fa-comment"></span>
-          </button>
-        </div>
-        <div class="btn-group">
-          <button id="aboutButton" title="About Google Cloud Datalab" class="toolbar-btn">
-            <span class="fa fa-info-circle"></span>
-          </button>
-        </div>
-        <div class="btn-group">
-          <a href="/tree/datalab/docs/notebooks" target="_blank" id="docsButton">
-            <button id="docsButton" title="Samples and Tutorials" class="toolbar-btn">
-              <span class="fa fa-book"></span>
-            </button>
-          </a>
-        </div>
-        <div class="btn-group">
-          <a href="/sessions" target="_blank" id="sessionsButton">
-            <button title="Running Sessions" class="toolbar-btn">
-              <span class="fa fa-tasks"></span>
-            </button>
-          </a>
-        </div>
-        <div class="btn-group">
-          <button id="signInButton" title="Sign In" style="display:none" class="toolbar-btn">Sign In</button>
-          <div id="signOutGroup" style="display:none">
-            <button title="Account" data-toggle="dropdown" class="toolbar-btn">
-              <span class="fa fa-user"></span>
-            </button>
-            <ul class="dropdown-menu dropdown-menu-right" style="padding: 10px">
-              <li>
-                <label>Signed in as <%account%></label>
-              </li>
-              <hr />
-              <li>
-                <button id="signOutButton" title="Sign Out" class="btn btn-danger" style="width: 100%">Sign Out</button>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
     </div>
     <div id="appContent">
       <div id="toolbarArea">

--- a/sources/web/datalab/templates/sessions.html
+++ b/sources/web/datalab/templates/sessions.html
@@ -17,56 +17,11 @@
   data-feedback-id="<%feedbackId%>"
   data-version-id="<%versionId%>"
   data-signed-in="<%isSignedIn%>"
-  data-user-id="<%userId%>">
+  data-user-id="<%userId%>"
+  data-account="<%account%>">
 
   <div id="app">
     <div id="appBar">
-      <span id="logo" class="nav navbar-brand pull-left">
-        <a href="/tree"><img src="/static/logo.png" alt="Google Cloud DataLab" /></a>
-      </span>
-      <div class="btn-toolbar pull-right">
-        <div class="btn-group">
-          <button id="feedbackButton" title="Provide feedback"  class="toolbar-btn">
-            <span class="fa fa-comment"></span>
-          </button>
-        </div>
-        <div class="btn-group">
-          <button id="aboutButton" title="About Google Cloud Datalab" class="toolbar-btn">
-            <span class="fa fa-info-circle"></span>
-          </button>
-        </div>
-        <div class="btn-group">
-          <a href="/tree/datalab/docs/notebooks" target="_blank" id="docsButton">
-            <button title="Samples and Tutorials" class="toolbar-btn">
-              <span class="fa fa-book"></span>
-            </button>
-          </a>
-        </div>
-        <div class="btn-group">
-          <a href="/sessions" target="_blank" id="sessionsButton">
-            <button title="Running Sessions" class="toolbar-btn">
-              <span class="fa fa-tasks"></span>
-            </button>
-          </a>
-        </div>
-        <div class="btn-group">
-          <button id="signInButton" title="Sign In" style="display:none" class="toolbar-btn">Sign In</button>
-          <div id="signOutGroup" style="display:none">
-            <button title="Account" data-toggle="dropdown" class="toolbar-btn">
-              <span class="fa fa-user"></span>
-            </button>
-            <ul class="dropdown-menu dropdown-menu-right" style="padding: 10px">
-              <li>
-                <label>Signed in as <%account%></label>
-              </li>
-              <hr />
-              <li>
-                <button id="signOutButton" title="Sign Out" class="btn btn-danger" style="width: 100%">Sign Out</button>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
     </div>
     <div id="appContent">
       <div id="mainArea">

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -19,6 +19,7 @@
   data-version-id="<%versionId%>"
   data-signed-in="<%isSignedIn%>"
   data-user-id="<%userId%>"
+  data-account="<%account%>"
   data-reporting-enabled="<%reportingEnabled%>"
   data-project-hash="<%projectHash%>">
 
@@ -54,52 +55,6 @@
 
   <div id="app">
     <div id="appBar">
-      <span id="logo" class="nav navbar-brand pull-left">
-        <a href="/tree"><img src="/static/logo.png" alt="Google Cloud DataLab" /></a>
-      </span>
-      <div class="btn-toolbar pull-right">
-        <div class="btn-group">
-          <button id="feedbackButton" title="Provide feedback" class="toolbar-btn">
-            <span class="fa fa-comment"></span>
-          </button>
-        </div>
-        <div class="btn-group">
-          <button id="aboutButton" title="About Google Cloud Datalab" class="toolbar-btn">
-            <span class="fa fa-info-circle"></span>
-          </button>
-        </div>
-        <div class="btn-group">
-          <a href="/tree/datalab/docs/notebooks">
-            <button title="Samples and Tutorials" class="toolbar-btn">
-              <span class="fa fa-book"></span>
-            </button>
-          </a>
-        </div>
-        <div class="btn-group">
-          <a href="/sessions" target="_blank" id="sessionsButton">
-            <button title="Running Sessions" class="toolbar-btn">
-              <span class="fa fa-tasks"></span>
-            </button>
-          </a>
-        </div>
-        <div class="btn-group">
-          <button id="signInButton" title="Sign In" style="display:none" class="toolbar-btn">Sign In</button>
-          <div id="signOutGroup" style="display:none">
-            <button title="Account" data-toggle="dropdown" class="toolbar-btn">
-              <span class="fa fa-user"></span>
-            </button>
-            <ul class="dropdown-menu dropdown-menu-right" style="padding: 10px">
-              <li>
-                <label>Signed in as <%account%></label>
-              </li>
-              <hr />
-              <li>
-                <button id="signOutButton" title="Sign Out" class="btn btn-danger" style="width: 100%">Sign Out</button>
-              </li>
-            </ul>
-          </div>
-        </div>
-      </div>
     </div>
     <div id="appContent">
       <div id="mainArea">


### PR DESCRIPTION
This change moves the appbar HTML into its own file and uses jquery to load it in each template, this lets us iterate changes on it more easily, but it also unifies the menu for all templates.

The change also moves the Samples and Tutorials button into a link under the help menu.