### PR TITLE
Flexible pydatalab

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -130,15 +130,16 @@ RUN pip install google-cloud-dataflow==0.4.1
 ADD nbconvert /datalab/nbconvert
 ADD config/ipython.py /etc/ipython/ipython_config.py
 ADD config/nbconvert.py /etc/jupyter/jupyter_notebook_config.py
+# Directory "py" may be empty and in that case it will git clone pydatalab from repo
+ADD py /datalab/lib/pydatalab
 
 # Do IPython configuration and install build artifacts
 # Then link stuff needed for nbconvert to a location where Jinja will find it.
 # I'd prefer to just use absolute path in Jinja imports but those don't work.
 RUN ipython profile create default && \
     jupyter notebook --generate-config && \
-    mkdir -p /datalab/lib && \
-    cd /datalab/lib && \
-    git clone https://github.com/googledatalab/pydatalab.git && \
+    if [ -d /datalab/lib/pydatalab/.git ]; then echo "use local lib"; else \
+      git clone https://github.com/googledatalab/pydatalab.git /datalab/lib/pydatalab; fi && \
     cd /datalab/lib/pydatalab && \
     tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts && \
     pip install . && \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -131,15 +131,18 @@ ADD nbconvert /datalab/nbconvert
 ADD config/ipython.py /etc/ipython/ipython_config.py
 ADD config/nbconvert.py /etc/jupyter/jupyter_notebook_config.py
 # Directory "py" may be empty and in that case it will git clone pydatalab from repo
-ADD pydatalab /datalab/lib/
+ADD pydatalab /datalab/lib/pydatalab
 
 # Do IPython configuration and install build artifacts
 # Then link stuff needed for nbconvert to a location where Jinja will find it.
 # I'd prefer to just use absolute path in Jinja imports but those don't work.
 RUN ipython profile create default && \
     jupyter notebook --generate-config && \
-    if [ -d /datalab/lib/pydatalab/.git ]; then echo "use local lib"; else \
-      git clone https://github.com/googledatalab/pydatalab.git /datalab/lib/pydatalab; fi && \
+    if [ -d /datalab/lib/pydatalab/.git ]; then \
+        echo "use local lib"; \
+      else \
+        git clone https://github.com/googledatalab/pydatalab.git /datalab/lib/pydatalab; \
+      fi && \
     cd /datalab/lib/pydatalab && \
     tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts && \
     pip install . && \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -131,7 +131,7 @@ ADD nbconvert /datalab/nbconvert
 ADD config/ipython.py /etc/ipython/ipython_config.py
 ADD config/nbconvert.py /etc/jupyter/jupyter_notebook_config.py
 # Directory "py" may be empty and in that case it will git clone pydatalab from repo
-ADD py /datalab/lib/pydatalab
+ADD pydatalab /datalab/lib/
 
 # Do IPython configuration and install build artifacts
 # Then link stuff needed for nbconvert to a location where Jinja will find it.

--- a/containers/base/build.sh
+++ b/containers/base/build.sh
@@ -20,10 +20,10 @@
 
 # Build the docker image
 if [ -n "$1" ]; then
-  rsync -avp "$1" py;
+  rsync -avp "$1" pydatalab;
 else
   # Create empty dir to make docker build happy.
-  mkdir -p py;
+  mkdir -p pydatalab;
 fi
 docker build -t datalab-base .
-rm -rf py
+rm -rf pydatalab

--- a/containers/base/build.sh
+++ b/containers/base/build.sh
@@ -13,7 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Builds the Google Cloud DataLab base docker image
+# Builds the Google Cloud DataLab base docker image. Usage:
+#   build.sh [path_of_pydatalab_dir]
+# If [path_of_pydatalab_dir] is provided, it will copy the content of that dir into image.
+# Otherwise, it will get the pydatalab by "git clone" from pydatalab repo.
 
 # Build the docker image
+if [ -n "$1" ]; then rsync -avp $1 py; else mkdir -p py; fi
 docker build -t datalab-base .
+rm -rf py

--- a/containers/base/build.sh
+++ b/containers/base/build.sh
@@ -19,6 +19,11 @@
 # Otherwise, it will get the pydatalab by "git clone" from pydatalab repo.
 
 # Build the docker image
-if [ -n "$1" ]; then rsync -avp $1 py; else mkdir -p py; fi
+if [ -n "$1" ]; then
+  rsync -avp "$1" py;
+else
+  # Create empty dir to make docker build happy.
+  mkdir -p py;
+fi
 docker build -t datalab-base .
 rm -rf py

--- a/containers/datalab/build.sh
+++ b/containers/datalab/build.sh
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Builds the Google Cloud DataLab docker image
+# Builds the Google Cloud DataLab docker image. Usage:
+#   build.sh [path_of_pydatalab_dir]
+# If [path_of_pydatalab_dir] is provided, it will copy the content of that dir into image.
+# Otherwise, it will get the pydatalab by "git clone" from pydatalab repo.
 
 # Create a versioned Dockerfile based on current date and git commit hash
 VERSION=`date +%Y%m%d`
@@ -29,7 +32,7 @@ rsync -avp ../../build/ build
 
 # Build the base docker image
 cd ../base
-docker build -t datalab-base .
+./build.sh $1
 cd ../datalab
 
 # Build the docker image

--- a/containers/datalab/build.sh
+++ b/containers/datalab/build.sh
@@ -32,7 +32,7 @@ rsync -avp ../../build/ build
 
 # Build the base docker image
 cd ../base
-./build.sh $1
+./build.sh "$1"
 cd ../datalab
 
 # Build the docker image

--- a/containers/gateway/build.sh
+++ b/containers/gateway/build.sh
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Builds the Google Cloud DataLab docker image
+# Builds the Google Cloud DataLab gateway docker image. Usage:
+#   build.sh [path_of_pydatalab_dir]
+# If [path_of_pydatalab_dir] is provided, it will copy the content of that dir into image.
+# Otherwise, it will get the pydatalab by "git clone" from pydatalab repo.
 
 # Create a versioned Dockerfile based on current date and git commit hash
 VERSION=`date +%Y%m%d`
@@ -29,7 +32,7 @@ rsync -avp ../../build/ build
 
 # Build the base docker image
 cd ../base
-docker build -t datalab-base .
+./build.sh $1
 cd ../gateway
 
 # Build the docker image

--- a/containers/gateway/build.sh
+++ b/containers/gateway/build.sh
@@ -32,7 +32,7 @@ rsync -avp ../../build/ build
 
 # Build the base docker image
 cd ../base
-./build.sh $1
+./build.sh "$1"
 cd ../gateway
 
 # Build the docker image


### PR DESCRIPTION
(Sorry, I messed up the branch and then deleted it, so the comments are lost. But I think all of them are addressed).

Right now it is hard to make changes to pydatalab locally and then have datalab container picking it up, because it always git-clone pydatalab from repo. The change adds a mechanism (build.sh ) to optionally picking up pydatalab from a local directory.