### PR TITLE
Improve accuracy the login/logout logic

### DIFF
--- a/sources/web/datalab/auth.ts
+++ b/sources/web/datalab/auth.ts
@@ -53,7 +53,9 @@ function base64decodeSegment(str: string) {
 export function getGcloudAccount(): string {
   // Ask gcloud which account we are using.
   try {
-    var account = childProcess.execSync('gcloud config list --format "value(core.account)"', {env: process.env});
+    var account = childProcess.execSync(
+      'gcloud auth list --filter=status:ACTIVE --format "value(account)"',
+      {env: process.env});
     account = account.toString().trim();
     return account;
   } catch (err) {

--- a/sources/web/datalab/auth.ts
+++ b/sources/web/datalab/auth.ts
@@ -146,8 +146,8 @@ function persistCredentials(tokens: any): string {
 }
 
 export function isSignedIn(): boolean {
-  // If not local, then we should have service account available so consider that signed in.
-  return (process.env.DATALAB_ENV != 'local' || fs.existsSync(appCredFile));
+  var gcloudAccount:string = getGcloudAccount();
+  return (gcloudAccount != '' && gcloudAccount != 'unknown');
 }
 
 function getPortNumber(request: http.ServerRequest): number {

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -391,10 +391,9 @@ function getBaseTemplateData(request: http.ServerRequest): common.Map<string> {
     reportingEnabled: reportingEnabled,
     proxyWebSockets: proxyWebSockets
   };
-  if (process.env.DATALAB_ENV == 'local') {
-    templateData['isSignedIn'] = auth.isSignedIn().toString();
-  }
-  if (auth.isSignedIn()) {
+  var signedIn = auth.isSignedIn();
+  templateData['isSignedIn'] = signedIn.toString();
+  if (signedIn) {
     templateData['account'] = auth.getGcloudAccount();
     if (process.env.PROJECT_NUMBER) {
       var hash = crypto.createHash('sha256');

--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -54,7 +54,7 @@
         <div id="signOutGroup" style="display:none">
           <label id="usernameLabel" style="padding:0 0 10px 0"></label>
           <label id="projectLabel" style="display:none; padding:0 0 10px 0"></label>
-          <button id="signOutButton" title="Sign Out" class="btn btn-danger" style="width: 100%; float: none">Sign Out</button>
+          <button id="signOutButton" title="Sign Out" class="btn btn-danger" style="display:none; width: 100%; float: none">Sign Out</button>
         </div>
         <hr />
         <div>

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -220,6 +220,9 @@ function initializePage(dialog, saveFn) {
         $('#signOutGroup').show();
         var username = document.body.getAttribute('data-account');
         $("#usernameLabel").text("Signed in as " + username);
+        if (username.indexOf('gserviceaccount.com') < 0) {
+          $('#signOutButton').show();
+        }
       } else {
         $('#signInButton').show();
       }


### PR DESCRIPTION
This change includes two improvements to the logic around logging in
and logging out:

1. Remove usage of the 'DATALAB_ENV' environment variable in the logic
   for determining if the user is signed-in, and instead directly
   query the 'gcloud' tool.
2. Remove the 'signout' button if the signed-in account is a service
   account. This is for running the Datalab UI inside of a GCE VM
   with a GCE service account. In that situation the service account
   is tied to the VM and cannot be detatched, so the 'signout' button
   did nothing in that case.