### PR TITLE
Clean up the docs directory

### DIFF
--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -163,14 +163,21 @@ then
 fi
 
 mkdir -p /content/datalab/notebooks
-mkdir -p /content/datalab/docs
 
-if [ -d /content/datalab/docs/notebooks/.git ]
-then
-  (cd /content/datalab/docs/notebooks; git fetch origin master; git reset --hard origin/master)
+if [ -d /content/datalab/docs ]; then
+  # The docs directory already exists, so we have to either update or initialize it as a git repository
+  pushd ./
+  cd /content/datalab/docs
+  if [ -d /content/datalab/docs/.git ]; then
+    git fetch origin master; git reset --hard origin/master
+  else
+    git init; git remote add origin https://github.com/googledatalab/notebooks.git; git fetch origin; 
+  fi
+  popd
 else
-  (cd /content/datalab/docs; git clone -b master --single-branch https://github.com/googledatalab/notebooks.git)
+  (cd /content/datalab; git clone -n --single-branch https://github.com/googledatalab/notebooks.git docs)
 fi
+(cd /content/datalab/docs; git config core.sparsecheckout true; echo $'intro/\nsamples/\ntutorials/\n*.ipynb\n' > .git/info/sparse-checkout; git checkout master)
 
 # Run the user's custom extension script if it exists. To avoid platform issues with 
 # execution permissions, line endings, etc, we create a local sanitized copy.

--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -28,7 +28,7 @@
         <li><a href="http://pandas.pydata.org/pandas-docs/stable/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Pandas</span></a></li>
         <li><a href="http://scikit-learn.org/stable/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>SciKit-Learn</span></a></li>
         <li class="divider"></li>
-        <li><a href="/tree/datalab/docs/notebooks" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Samples and Tutorials</span></a></li>
+        <li><a href="/tree/datalab/docs" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Samples and Tutorials</span></a></li>
       </ul>
     </div>
     <div class="btn-group">


### PR DESCRIPTION
This change simplifies the `datalab/docs` directory in two ways:

1. Remove an unnecessary level of directory hierarchy, so that the
   docs are now stored under `datalab/docs` instead of
   `datalab/docs/notebooks`.
2. Perform a sparse checkout of the repo to only get the doc files
   into the docs directory, rather than all of the repository
   contents. The other files are still available to the user in the
   cloned git history, but they are not in the working directory
   by default.