### PR TITLE
Removed 4px green padding on selected cells

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -310,17 +310,18 @@ div.cell {
   border: solid 1px transparent;
   border-radius: 0px;
   padding: 0px;
-  padding-left: 4px;
+  padding-left: 0px;
   margin-bottom: 10px;
 }
 div.cell.selected, div.cell.text_cell.selected, div.cell.code_cell.selected {
+  background: none;
   border: solid 1px #ddd;
-  padding-left: 4px;
+  padding-left: 0px;
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.2);
 }
 .edit_mode div.cell.text_cell.selected, .edit_mode div.code_cell.selected {
   border: solid 1px #ddd;
-  padding-left: 4px;
+  padding-left: 0px;
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.2);
 }
 


### PR DESCRIPTION
Code/markup cells now only show a blue left border after they've been run.