### PR TITLE
With the exception of %sql, don't convert line magic to cell magic

### DIFF
--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -531,8 +531,8 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
 
     var originalExecute = kernel.prototype.execute;
     kernel.prototype.execute = function (code, callbacks, options) {
-      // If this is a line magic but has a non-empty cell body change it to a cell magic.
-      if (code.length > 2 && code[0] == '%' && code[1] != '%') {
+      // If this is a sql line magic but has a non-empty cell body change it to a cell magic.
+      if (code.startsWith('%sql')) {
         var lines = code.split('\n');
         if (lines.length > 1) {
           for (var i = 1; i < lines.length; i++) {


### PR DESCRIPTION
Fixes #996 

Restores the following functionality which would not work after #567:

```
%storage read --object gs://cloud-datalab-samples/cars.csv --variable cars
print(cars)
```

In #567 , line magic commands were automatically converted to cell magic if the cell body was not empty. Based on #375, it may be helpful to automatically convert line magic `%sql` to cell magic.
