### PR TITLE
Resolve issue where link in Datalab new version message is difficult to read

### DIFF
--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -78,6 +78,9 @@ a:hover {
 .dropdown-menu li a {
   color: #ddd;
 }
+#updateMessageArea a {
+  color: #333;
+}
 
 /* Inside Notebooks */
 #contentArea,#notebook-container {

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -1049,7 +1049,7 @@ function initializeNotebookList(ipy, notebookList, newNotebook, events, dialog, 
     var message = 'You are using DataLab 0.5.' + version + '. ' +
         (optional ? 'An optional' : 'A recommended') + ' update (0.5.' + versionInfo.latest +
         ') is available (see <a href="https://github.com/googledatalab/datalab/wiki/Release-Info"' +
-        '>what\'s new)</a>.'
+        '>what\'s new</a>).'
     messageDiv.innerHTML = message;
     messageDiv.classList.add('alert');
     messageDiv.classList.add(optional ? 'alert-warning' : 'alert-danger');


### PR DESCRIPTION
Fixes #1001

Also corrected subtle issue in the Datalab new version message where left bracket was red and right bracket was the color of the link.