### PR TITLE
Fix timing issues in the loading of the app bar

### DIFF
--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -190,96 +190,91 @@ function initializePage(dialog, saveFn) {
     dialog.modal(dialogOptions);
   }
 
-  // Load the appbar shared component using jquery
-  // The sign in/out functionality and the about button depend on the appbar's
-  //   HTML having been loaded, so wait for it before running this code
-  $("#appBar").load("/static/appbar.html", function() {
-    // Prepare sign in/out UI
-    $('#accountDropdownButton').on('click', function (event) {
-      $(this).parent().toggleClass('open');
-      if (window.datalab && window.datalab.session) {
-        window.datalab.session.execute("datalab_project_id()", function(error, projectId) {
-          if (error === null || error === undefined) {
-            $('#projectLabel').text("Active project: " + projectId);
-            $('#projectLabel').show();
-          }
-        });
-      }
-    });
-    $('body').on('click', function (e) {
-      if (!$('#accountDropdown').is(e.target)
-          && $('#accountDropdown').has(e.target).length === 0
-          && $('.open').has(e.target).length === 0
-      ) {
-          $('#accountDropdown').removeClass('open');
-      }
-    });
-    var signedIn = document.body.getAttribute('data-signed-in');
-    if (signedIn != undefined) {  // i.e. running locally.
-      if (signedIn == "true") {
-        $('#signOutGroup').show();
-        var username = document.body.getAttribute('data-account');
-        $("#usernameLabel").text("Signed in as " + username);
-        if (username.indexOf('gserviceaccount.com') < 0) {
-          $('#signOutButton').show();
+  // Prepare sign in/out UI
+  $('#accountDropdownButton').on('click', function (event) {
+    $(this).parent().toggleClass('open');
+    if (window.datalab && window.datalab.session) {
+      window.datalab.session.execute("datalab_project_id()", function(error, projectId) {
+        if (error === null || error === undefined) {
+          $('#projectLabel').text("Active project: " + projectId);
+          $('#projectLabel').show();
         }
-      } else {
-        $('#signInButton').show();
+      });
+    }
+  });
+  $('body').on('click', function (e) {
+    if (!$('#accountDropdown').is(e.target)
+        && $('#accountDropdown').has(e.target).length === 0
+        && $('.open').has(e.target).length === 0
+    ) {
+        $('#accountDropdown').removeClass('open');
+    }
+  });
+  var signedIn = document.body.getAttribute('data-signed-in');
+  if (signedIn != undefined) {  // i.e. running locally.
+    if (signedIn == "true") {
+      $('#signOutGroup').show();
+      var username = document.body.getAttribute('data-account');
+      $("#usernameLabel").text("Signed in as " + username);
+      if (username.indexOf('gserviceaccount.com') < 0) {
+        $('#signOutButton').show();
       }
-      $('#signInButton').click(function() {
-        saveFn();
-        window.location = '/signin?referer=' + encodeURIComponent(window.location);
-      });
-      $('#signOutButton').click(function() {
-        saveFn();
-        window.location = '/signout?referer=' + encodeURIComponent(window.location);
-      });
+    } else {
+      $('#signInButton').show();
     }
-
-    // More UI that relies on appbar load
-    // Prepare the theme selector radio boxes
-    lightThemeRadioOption = document.getElementById("lightThemeRadioOption")
-    darkThemeRadioOption = document.getElementById("darkThemeRadioOption")
-    xhr(getSettingKeyAddress("theme"), function() {
-      lightThemeRadioOption.checked = this.responseText === "\"light\"";
-      darkThemeRadioOption.checked = this.responseText === "\"dark\"";
-    })
-    lightThemeRadioOption.onclick = function() {
-      setTheme("light");
-      darkThemeRadioOption.checked = false;
-    };
-    darkThemeRadioOption.onclick = function() {
-      setTheme("dark");
-      lightThemeRadioOption.checked = false;
-    };
-
-    function setTheme(theme) {
-      xhr(getSettingKeyAddress("theme") + "&value=" + theme, function() {
-        // Reload the stylesheet by resetting its address with a random (time) version querystring
-        sheetAddress = document.getElementById("themeStylesheet").href + "?v=" + Date.now()
-        document.getElementById("themeStylesheet").setAttribute('href', sheetAddress);
-      })
-    }
-
-    // If inside a notebook, prepare notebook-specific help link inside the sidebar
-    if (document.getElementById('sidebarArea') !== null) {
-      $('#keyboardHelpLink').click(function(e) {
-        showHelp(document.getElementById('shortcutsHelp').textContent);
-        e.preventDefault();
-      });
-      $('#keyboardHelpLink').show()
-      $('#markdownHelpLink').click(function(e) {
-        showHelp(document.getElementById('markdownHelp').textContent);
-        e.preventDefault();
-      });
-      $('#markdownHelpLink').show()
-      $('#notebookHelpDivider').show()
-    }
-    $('#aboutButton').click(showAbout);
-    $('#feedbackButton').click(function() {
-      window.open('https://groups.google.com/forum/#!newtopic/google-cloud-datalab-feedback');
+    $('#signInButton').click(function() {
+      saveFn();
+      window.location = '/signin?referer=' + encodeURIComponent(window.location);
     });
-  }); // End of shared appbar component load
+    $('#signOutButton').click(function() {
+      saveFn();
+      window.location = '/signout?referer=' + encodeURIComponent(window.location);
+    });
+  }
+
+  // More UI that relies on appbar load
+  // Prepare the theme selector radio boxes
+  lightThemeRadioOption = document.getElementById("lightThemeRadioOption")
+  darkThemeRadioOption = document.getElementById("darkThemeRadioOption")
+  xhr(getSettingKeyAddress("theme"), function() {
+    lightThemeRadioOption.checked = this.responseText === "\"light\"";
+    darkThemeRadioOption.checked = this.responseText === "\"dark\"";
+  })
+  lightThemeRadioOption.onclick = function() {
+    setTheme("light");
+    darkThemeRadioOption.checked = false;
+  };
+  darkThemeRadioOption.onclick = function() {
+    setTheme("dark");
+    lightThemeRadioOption.checked = false;
+  };
+
+  function setTheme(theme) {
+    xhr(getSettingKeyAddress("theme") + "&value=" + theme, function() {
+      // Reload the stylesheet by resetting its address with a random (time) version querystring
+      sheetAddress = document.getElementById("themeStylesheet").href + "?v=" + Date.now()
+      document.getElementById("themeStylesheet").setAttribute('href', sheetAddress);
+    })
+  }
+
+  // If inside a notebook, prepare notebook-specific help link inside the sidebar
+  if (document.getElementById('sidebarArea') !== null) {
+    $('#keyboardHelpLink').click(function(e) {
+      showHelp(document.getElementById('shortcutsHelp').textContent);
+      e.preventDefault();
+    });
+    $('#keyboardHelpLink').show()
+    $('#markdownHelpLink').click(function(e) {
+      showHelp(document.getElementById('markdownHelp').textContent);
+      e.preventDefault();
+    });
+    $('#markdownHelpLink').show()
+    $('#notebookHelpDivider').show()
+  }
+  $('#aboutButton').click(showAbout);
+  $('#feedbackButton').click(function() {
+    window.open('https://groups.google.com/forum/#!newtopic/google-cloud-datalab-feedback');
+  });
 }
 
 function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {

--- a/sources/web/datalab/templates/edit.html
+++ b/sources/web/datalab/templates/edit.html
@@ -11,6 +11,8 @@
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
   <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" />
+
+  <script src="/static/components/jquery/jquery.min.js"></script>
 </head>
 <body class="edit_app"
   data-project=""
@@ -80,8 +82,11 @@
        }
     });
     window.datalab = {};
+
+    $("#appBar").load("/static/appbar.html", function() {
+      require(['edit/js/main.min']);
+    });
   </script>
-  <script src="/static/edit/js/main.min.js" charset="utf-8"></script>
   <script src="//www.gstatic.com/feedback/api.js" async="true" defer="true"></script>
 </body>
 </html>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -10,6 +10,8 @@
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
   <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" id="stylesheet" />
+
+  <script src="/static/components/jquery/jquery.min.js"></script>
 </head>
 <body class="notebook_app"
   data-project=""
@@ -295,10 +297,13 @@
            'contents': 'services/contents',
          }
        }
-     });
-     window.datalab = {};
+    });
+    window.datalab = {};
+
+    $("#appBar").load("/static/appbar.html", function() {
+      require(['notebook/js/main.min']);
+    });
   </script>
-  <script src="/static/notebook/js/main.min.js" charset="utf-8"></script>
   <script src="//www.gstatic.com/feedback/api.js" async="true" defer="true"></script>
   <script type="text/fragment" id="cellStatus">
     <div class="status" style="display: none;">

--- a/sources/web/datalab/templates/sessions.html
+++ b/sources/web/datalab/templates/sessions.html
@@ -10,6 +10,8 @@
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
   <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" />
+
+  <script src="/static/components/jquery/jquery.min.js"></script>
 </head>
 <body class="session_list"
   data-base-url="<%baseUrl%>"
@@ -50,6 +52,7 @@
   </div>
   <script src="/static/components/es6-promise/promise.min.js"></script>
   <script src="/static/components/requirejs/require.js"></script>
+  <script src="<%configUrl%>"></script>
   <script>
     require.config({
       baseUrl: '/static/',
@@ -97,11 +100,13 @@
            'contents': 'services/contents',
          }
        }
-     });
-     window.datalab = {};
+    });
+    window.datalab = {};
+
+    $("#appBar").load("/static/appbar.html", function() {
+      require(['tree/js/main.min']);
+    });
   </script>
-  <script src="<%configUrl%>"></script>
-  <script src="/static/tree/js/main.min.js" charset="utf-8"></script>
   <script src="//www.gstatic.com/feedback/api.js" async="true" defer="true"></script>
 </body>
 </html>

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -10,6 +10,8 @@
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
   <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" />
+
+  <script src="/static/components/jquery/jquery.min.js"></script>
 </head>
 <body class="notebook_list"
   data-base-url="<%baseUrl%>"
@@ -164,9 +166,12 @@
            'contents': 'services/contents',
          }
        }
-     });
+    });
+
+    $("#appBar").load("/static/appbar.html", function() {
+      require(['tree/js/main.min']);
+    });
   </script>
-  <script src="/static/tree/js/main.min.js" charset="utf-8"></script>
   <script src="//www.gstatic.com/feedback/api.js" async="true" defer="true"></script>
 </body>
 </html>


### PR DESCRIPTION
The splitting out of the app bar into a single, reusable HTML file
introduced an unexpected timing issue where the Javascript code served
by the Jupyter notebook server was trying to modify DOM elements which
did not yet exist.

This change fixes that issue by ensuring that the app bar HTML is loaded
before the notebook server Javascript is loaded. Since the loading of
the app bar HTML requires JQuery, this required us to add JQuery as one
of the scripts loaded in each of the HTML templates.

This fixes #998 