### PR TITLE
Remove the keyboard shortcut to move cells up/down from the documentation

### DIFF
--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -326,8 +326,6 @@
       <div><code>m</code>: to markdown</div>
       <div><code>Up</code>: select previous cell</div>
       <div><code>Down</code>: select next cell</div>
-      <div><code>Ctrl+K</code>: move cell up</div>
-      <div><code>Ctrl+J</code>: move cell down</div>
       <div><code>a</code>: insert cell above</div>
       <div><code>b</code>: insert cell below</div>
       <div><code>x</code>: cut cell</div>


### PR DESCRIPTION
Closes #777 

The following keyboard shortcuts are no longer supported in [Jupyter Notebook 4.2](https://github.com/jupyter/notebook/blob/4.2.x/notebook/static/notebook/js/keyboardmanager.js):
- Ctrl+K - move cell up
- Ctrl+J - move cell down

I've confirmed that the other keyboard shortcuts documented in Datalab are still functional.