### PR TITLE
Fix issue #1005 by 

### DIFF
--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -326,7 +326,10 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
         var error = null;
         try {
           if (output.msg_type == 'execute_result') {
-            values = output.content.data['text/plain'];
+            values = output.content.data['application/json'];
+            if (!values) {
+              values = output.content.data['text/plain'];
+            }
           }
         }
         catch (e) {


### PR DESCRIPTION
The fix is to check application/json response for kernel execution results first, and if not exist then plain/text ("plain/text" response was added for fetching project id).