### PR TITLE
Add code cell collapse/uncollapse toggle

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+cd sources/web
+./build.sh
+cd ../../containers/datalab
+./build.sh && ./run.sh

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,0 @@
-cd sources/web
-./build.sh
-cd ../../containers/datalab
-./build.sh && ./run.sh

--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -32,9 +32,20 @@ button {
 button:hover {
   color: #fff;
 }
+.btn-default {
+  background-color: #333;
+  color: #ddd;
+}
+.btn-default:hover {
+  background-color: #222;
+  color: #ddd;
+}
 #button-select-all {
   border-color: transparent;
   background-color: transparent;
+}
+div.hoverable {
+  background-color: #555;
 }
 .notebook_app {
   color: #ddd;

--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -44,9 +44,6 @@ button:hover {
   border-color: transparent;
   background-color: transparent;
 }
-div.hoverable {
-  background-color: #555;
-}
 .notebook_app {
   color: #ddd;
   background: #000;

--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -98,7 +98,7 @@ div.text_cell_render {
   color: #ddd;
 }
 .rendered_html pre, .rendered_html code, .rendered_html {
-  background-color: #333;
+  background-color: none;
   color: #ddd;
 }
 div.cell.selected {

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -312,6 +312,7 @@ div.cell {
   padding: 0px;
   padding-left: 0px;
   margin-bottom: 10px;
+  position: relative;
 }
 div.cell.selected, div.cell.text_cell.selected, div.cell.code_cell.selected {
   background: none;
@@ -324,7 +325,6 @@ div.cell.selected, div.cell.text_cell.selected, div.cell.code_cell.selected {
   padding-left: 0px;
   box-shadow: 0px 0px 6px 0px rgba(0, 0, 0, 0.2);
 }
-
 div.code_cell div.input {
   border-left: solid 4px #ddd;
 }
@@ -383,6 +383,13 @@ div.rendered_html h4, div.rendered_html h5, div.rendered_html h6 {
   margin-top: 0px !important;
 }
 a.anchor-link {
+  display: none;
+}
+div.hoverable {
+  position: absolute;
+  top: -12px;
+  right: 50%;
+  z-index: 9999;
   display: none;
 }
 

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -387,17 +387,13 @@ a.anchor-link {
 }
 div.hoverable {
   position: absolute;
-  top: -15px;
-  right: 5px;
-  0px 0px 6px 0px rgba(0, 0, 0, 0.2);
+  left: -16px;
   display: none;
-  background-color: #eee;
-  padding: 2px;
-  border-radius: 2px;
-  z-index: 2;
 }
-div.hoverable>button {
-  margin: 2px;
+div.hoverable>span {
+  padding: 2px;
+  font-size: xx-small;
+  color: #888;
 }
 div.cellPlaceholder {
   height: 30px;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -388,10 +388,16 @@ a.anchor-link {
 div.hoverable {
   position: absolute;
   top: -15px;
-  right: 0px;
-  z-index: 9999;
+  right: 5px;
   0px 0px 6px 0px rgba(0, 0, 0, 0.2);
   display: none;
+  background-color: #eee;
+  padding: 5px;
+  border-radius: 2px;
+  z-index: 2;
+}
+div.hoverable>button {
+  margin: 2px;
 }
 div.cellPlaceholder {
   height: 30px;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -401,6 +401,7 @@ div.hoverable>button {
 }
 div.cellPlaceholder {
   height: 30px;
+  width: 100%;
   display: none;
 }
 

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -392,7 +392,7 @@ div.hoverable {
   0px 0px 6px 0px rgba(0, 0, 0, 0.2);
   display: none;
   background-color: #eee;
-  padding: 5px;
+  padding: 2px;
   border-radius: 2px;
   z-index: 2;
 }

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -396,8 +396,8 @@ div.hoverable>span {
   color: #888;
 }
 div.cellPlaceholder {
-  height: 30px;
   width: 100%;
+  text-align: left;
   display: none;
 }
 

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -387,9 +387,14 @@ a.anchor-link {
 }
 div.hoverable {
   position: absolute;
-  top: -12px;
-  right: 50%;
+  top: -15px;
+  right: 0px;
   z-index: 9999;
+  0px 0px 6px 0px rgba(0, 0, 0, 0.2);
+  display: none;
+}
+div.cellPlaceholder {
+  height: 30px;
   display: none;
 }
 

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -385,15 +385,20 @@ div.rendered_html h4, div.rendered_html h5, div.rendered_html h6 {
 a.anchor-link {
   display: none;
 }
-div.hoverable {
+div.minitoolbar {
   position: absolute;
   left: -16px;
   display: none;
 }
-div.hoverable>span {
+div.minitoolbar>span {
   padding: 2px;
   font-size: xx-small;
   color: #888;
+}
+div.cellPlaceholder>div>pre {
+  background-color: inherit;
+  margin: 0px;
+  overflow: hidden;
 }
 div.cellPlaceholder {
   width: 100%;

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -295,25 +295,33 @@ function toggleCollapseCell(cell) {
   }
 }
 function collapseCell(cell) {
-  let inputDiv = cell.cell_type === 'code' ? 'div.input' : 'div.inner_cell';
-  collapseSpan = cell.element.find('span.collapse-cell')[0];
-  cell.element.find(inputDiv).hide();
+
+  function getCollapsedCellHeader(cell) {
+    if (cell.cell_type === 'code') {
+      return cell.element.find('pre.CodeMirror-line')[0].children[0].innerHTML;
+    } else {
+      return cell.element.find('div.rendered_html')[0].children[0].innerHTML;
+    }
+  }
+
+  cell.element.find('div.inner_cell').hide();
   // for code cells, also hide the output div
   if (cell.cell_type === 'code')
     cell.element.find('div.output_wrapper').hide();
   cell.element.find('div.cellPlaceholder').show();
+  cell.element.find('div.cellPlaceholder')[0].innerHTML = getCollapsedCellHeader(cell) + '<br><span>. . .</span>';
+  collapseSpan = cell.element.find('span.collapse-cell')[0];
   collapseSpan.classList.remove(COLLAPSE_BUTTON_CLASS);
   collapseSpan.classList.add(UNCOLLAPSE_BUTTON_CLASS);
   cell.metadata[CELL_METADATA_COLLAPSED] = true;
 }
 function uncollapseCell(cell) {
-  let inputDiv = cell.cell_type === 'code' ? 'div.input' : 'div.inner_cell';
-  collapseSpan = cell.element.find('span.collapse-cell')[0];
-  cell.element.find(inputDiv).show();
+  cell.element.find('div.inner_cell').show();
   // for code cells, also show the output div
   if (cell.cell_type == 'code')
     cell.element.find('div.output_wrapper').show();
   cell.element.find('div.cellPlaceholder').hide();
+  collapseSpan = cell.element.find('span.collapse-cell')[0];
   collapseSpan.classList.add(COLLAPSE_BUTTON_CLASS);
   collapseSpan.classList.remove(UNCOLLAPSE_BUTTON_CLASS);
   cell.metadata[CELL_METADATA_COLLAPSED] = false;
@@ -986,6 +994,8 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
     });
     events.on('select.Cell', function(e, params) {
       cell = params.cell;
+      // there's no reliable 'blur' event exposed by Jupyter
+      // so we have to unselect all cells manually
       Jupyter.notebook.get_cells().forEach(function(cell) {
         cell.element.find('div.hoverable')[0].style.display = 'none';
       });

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -304,12 +304,12 @@ function toggleCollapseCellOutput(cell, hide) {
   collapseSpan = cell.element.find('span.collapse-output')[0];
   if (isHidden) {
     cell.expand_output();
-    collapseSpan.classList.add('fa-minus-square-o');
-    collapseSpan.classList.remove('fa-plus-square-o');
+    collapseSpan.classList.add('fa-compress');
+    collapseSpan.classList.remove('fa-expand');
   } else {
     cell.collapse_output();
-    collapseSpan.classList.remove('fa-minus-square-o');
-    collapseSpan.classList.add('fa-plus-square-o');
+    collapseSpan.classList.remove('fa-compress');
+    collapseSpan.classList.add('fa-expand');
   }
   cell.metadata[CELL_METADATA_OUTPUT_COLLAPSED] = !isHidden;
 }
@@ -340,7 +340,7 @@ function addCellMiniToolbar() {
     // collapse output button
     let hideButton = document.createElement('button')
     hideButton.className = 'btn btn-default';
-    hideButton.innerHTML = '<span class="collapse-output fa fa-minus-square-o"></span>';
+    hideButton.innerHTML = '<span class="collapse-output fa fa-compress"></span>';
     hideButton.title = 'Collapse/Expand output';
     hideButton.addEventListener('click', function() {
       toggleCollapseCellOutput(cell);
@@ -376,11 +376,24 @@ function addCellMiniToolbar() {
       toggleCollapseCellOutput(cell, true /*hide*/);
     }
 
+    // cell clear button
+    let clearButton = document.createElement('button')
+    clearButton.className = 'btn btn-default';
+    clearButton.innerHTML = '<span class="fa fa-minus-square-o"></span>';
+    clearButton.title = 'Clear cell output';
+    clearButton.addEventListener('click', function() {
+      cell.clear_output();
+      // let's also expand the cell and cell output
+      toggleCollapseCell(cell, false /*hide*/);
+      toggleCollapseCellOutput(cell, false /*hide*/);
+    });
+    hoverableDiv.appendChild(clearButton);
+
     // cell run button
     let runButton = document.createElement('button')
     runButton.className = 'btn btn-default';
-    runButton.innerHTML = '<span class="collapse-output fa fa-play"></span>';
-    runButton.title = 'Execute cell';
+    runButton.innerHTML = '<span class="fa fa-play"></span>';
+    runButton.title = 'Run cell';
     runButton.addEventListener('click', function() {
       cell.execute();
       // let's also expand the cell and cell output

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -277,6 +277,22 @@ function initializePage(dialog, saveFn) {
   });
 }
 
+/**
+ * Patch the cell's element to add a collapse/expand button
+ */
+function addCollapseExpandButton() {
+  Jupyter.notebook.get_cells().forEach(function(cell) {
+    let buttonHtml = '<div class="hoverable"><button class="btn btn-default"><span class="fa fa-compress"> Collapse</span></button></div>';
+    cell.element.append(buttonHtml);
+    cell.element[0].onmouseenter = function() {
+      this.getElementsByClassName('hoverable')[0].style.display = 'block';
+    };
+    cell.element[0].onmouseleave = function() {
+      this.getElementsByClassName('hoverable')[0].style.display = 'none';
+    };
+  })
+}
+
 function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
   // Various RequireJS additions used for notebook functionality
   require.config({
@@ -295,6 +311,10 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
         exports: 'plotly'
       }
     }
+  });
+
+  $([IPython.events]).on('kernel_ready.Kernel kernel_created.Session notebook_loaded.Notebook', function() {
+    addCollapseExpandButton()
   });
 
   function DataLabSession() {


### PR DESCRIPTION
This PR adds a small toolbar to the left of code cells that currently has only one button to collapse/uncollapse the cell. This works only with code cells. When collapsed, code cells show the first line of their input.

Fixes #1004

![image](https://cloud.githubusercontent.com/assets/1424661/19363756/78cbe6b6-9140-11e6-8f6d-622925e2c251.png)
