### PR TITLE
Fix, update, and enable ipywidgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ test
 *.map
 *.egg-info
 *.swp
+*.swo
 

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -64,7 +64,7 @@ RUN pip install -U tornado==4.3 \
     pip install -U notebook==4.2.0 && \
     pip install -U PyYAML==3.11 && \
     pip install -U six==1.9.0 && \
-    pip install -U ipywidgets==5.0.0 && \
+    pip install -U ipywidgets==5.2.2 && \
     pip install -U future==0.15.2 && \
     pip install -U psutil==4.3.0 && \
     pip install -U google-api-python-client==1.5.1  && \
@@ -151,6 +151,7 @@ RUN ipython profile create default && \
     tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts && \
     pip install . && \
     jupyter nbextension install --py datalab.notebook && \
+    jupyter nbextension enable --py widgetsnbextension && \
     rm datalab/notebook/static/*.js && \
     mkdir -p /datalab/nbconvert && \
     cp -R /usr/local/share/jupyter/nbextensions/gcpdatalab/* /datalab/nbconvert && \
@@ -158,8 +159,4 @@ RUN ipython profile create default && \
     mkdir -p /usr/local/lib/python2.7/dist-packages/notebook/static/components/codemirror/mode/text/sql/text && \
     ln -s /usr/local/share/jupyter/nbextensions/gcpdatalab/codemirror/mode/sql.js /usr/local/lib/python2.7/dist-packages/notebook/static/components/codemirror/mode/text/sql/text/sql.js && \
     cd /
-
-# Include this line above to enable ipywidgets. These aren't working 100% yet so 
-# we don't enable them.
-#    jupyter nbextension enable --py widgetsnbextension && \
 

--- a/containers/datalab/build.sh
+++ b/containers/datalab/build.sh
@@ -27,6 +27,12 @@ COMMIT_SUBSTITUTION="s/_commit_/$COMMIT/"
 
 cat Dockerfile.in | sed $VERSION_SUBSTITUTION | sed $COMMIT_SUBSTITUTION > Dockerfile
 
+# Build the datalab frontend
+source ../../tools/initenv.sh
+cd ../../sources/web/
+./build.sh
+cd ../../containers/datalab
+
 # Copy build outputs as a dependency of the Dockerfile
 rsync -avp ../../build/ build
 

--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -214,7 +214,7 @@ table.bqsv th, table.bqsv td {
 .modal-content {
   background-color: #444;
 }
-.modal-header,.modal-body,.modal-footer {
+.modal-header,.modal-body,.modal-body>textarea,.modal-footer {
   background-color: #333;
   color: #ddd;
 }

--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -17,11 +17,9 @@ body {
   color: #ddd;
   background: #444;
 }
-#mainToolbar, #sidebarToolbar, #sidebarArea {
-  background-color: #444;
-}
-#mainToolbar, #sidebarToolbar {
-  border-bottom: solid 1px #000;
+#toolbarArea {
+  background-color: #333;
+  color: #ddd;
 }
 #notebook-container {
   background: #000;
@@ -46,7 +44,7 @@ button:hover {
 }
 .notebook_app {
   color: #ddd;
-  background: #000;
+  background: #444;
 }
 .cmd-palette form {
   background-color: inherit;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -24,12 +24,14 @@
 body {
   font-family: 'Open Sans', Helvetica, sans-serif;
   font-size: 14px;
-  min-width: 1200px;
+  min-width: 1250px;
 }
 
 /* Layout */
 #app {
   position: absolute;
+  overflow: auto;
+  height: 100%;
   left: 0px;
   top: 0px;
   right: 0px;
@@ -44,28 +46,6 @@ body {
   align-items: stretch;
   -webkit-align-content: space-between;
   align-content: space-between;
-}
-#site {
-  -webkit-order: 2;
-  order: 2;
-  -webkit-flex: 1 1 auto;
-  flex: 1 1 auto;
-  -webkit-align-self: stretch;
-  align-self: stretch;
-  display: -webkit-flex;
-  display: flex;
-  -webkit-flex-flow: column nowrap;
-  flex-flow: column nowrap;
-  -webkit-justify-content: flex-start;
-  justify-content: flex-start;
-  -webkit-align-items: stretch;
-  align-items: stretch;
-  -webkit-align-content: space-between;
-  align-content: space-between;
-}
-#appContent {
-  -webkit-order: 2;
-  order: 2;
 }
 #appBar {
   background-color: #333;
@@ -83,9 +63,38 @@ body {
   position: relative;
   z-index: 10;
 }
+#site {
+  -webkit-order: 2;
+  order: 2;
+  position: relative;
+  height: 100%;
+}
+#appContent {
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
+  height: 100%;
+  -webkit-order: 2;
+  order: 2;
+  -webkit-flex: 1 1 auto;
+  flex: 1 1 auto;
+  -webkit-align-self: stretch;
+  align-self: stretch;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-flex-flow: column nowrap;
+  flex-flow: column nowrap;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+  -webkit-align-items: stretch;
+  align-items: stretch;
+  -webkit-align-content: space-between;
+  align-content: space-between;
+}
 #toolbarArea, #contentArea {
-  -webkit-order: 1;
-  order: 1;
+  position: relative;
   -webkit-align-self: stretch;
   align-self: stretch;
   display: -webkit-flex;
@@ -98,57 +107,53 @@ body {
   align-items: stretch;
   -webkit-align-content: space-between;
   align-content: space-between;
+  border-bottom: solid 1px #000;
 }
 #toolbarArea {
   -webkit-order: 1;
   order: 1;
-  -webkit-flex: 0 1 auto;
-  flex: 0 1 auto;
+  justify-content: space-between;
 }
 #contentArea {
+  height: 100%;
   -webkit-order: 2;
   order: 2;
   -webkit-flex: 1 1 auto;
   flex: 1 1 auto;
-  height: 100%;
+  overflow: auto;
 }
-#mainToolbar, #mainArea {
+#mainArea {
   -webkit-order: 1;
   order: 1;
-  -webkit-flex: 1 1 auto;
-  flex: 1 1 auto;
+  -webkit-flex: 70%;
+  flex: 70%;
   -webkit-align-self: auto;
   align-self: auto;
-  min-width: 200px;
   position: relative;
+  min-width: 200px;
 }
-#sidebarToolbar, #sidebarArea {
+#sidebarArea {
   -webkit-order: 2;
   order: 2;
-  -webkit-flex: .5 0 auto;
-  flex: .5 0 auto;
+  -webkit-flex: 30%;
+  flex: 30%;
   -webkit-align-self: auto;
   align-self: auto;
-  min-width: 100px;
   position: relative;
+  padding-top: 10px;
+  min-width: 100px;
 }
 #sidebarToolbar.larger {
   -webkit-flex-grow: 3;
   flex-grow: 3;
 }
-#sidebarArea {
-  padding: 10px 20px;
-}
 #sidebarArea.larger {
-  -webkit-flex-grow: 3;
-  flex-grow: 3;
+  -webkit-flex: 50%;
+  flex: 50%;
 }
 #mainToolbar, #sidebarToolbar {
   line-height: 48px;
   vertical-align: middle;
-  height: 48px;
-  padding-left: 10px;
-  padding-right: 10px;
   padding-top: 2px;
   z-index: 8;
 }

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -45,23 +45,7 @@ body {
   -webkit-align-content: space-between;
   align-content: space-between;
 }
-#appBar {
-  background-color: #333;
-  box-shadow: 0 0 8px 0 #000;
-  -webkit-order: 1;
-  order: 1;
-  -webkit-flex: 0 1 auto;
-  flex: 0 1 auto;
-  -webkit-align-self: auto;
-  align-self: auto;
-  height: 48px;
-  min-height: 48px;
-  padding-left: 10px;
-  padding-right: 10px;
-  position: relative;
-  z-index: 10;
-}
-#appContent {
+#site {
   -webkit-order: 2;
   order: 2;
   -webkit-flex: 1 1 auto;
@@ -79,7 +63,29 @@ body {
   -webkit-align-content: space-between;
   align-content: space-between;
 }
+#appContent {
+  -webkit-order: 2;
+  order: 2;
+}
+#appBar {
+  background-color: #333;
+  box-shadow: 0 0 8px 0 #000;
+  -webkit-order: 1;
+  order: 1;
+  -webkit-flex: 0 1 auto;
+  flex: 0 1 auto;
+  -webkit-align-self: auto;
+  align-self: auto;
+  height: 48px;
+  min-height: 48px;
+  padding-left: 10px;
+  padding-right: 10px;
+  position: relative;
+  z-index: 10;
+}
 #toolbarArea, #contentArea {
+  -webkit-order: 1;
+  order: 1;
   -webkit-align-self: stretch;
   align-self: stretch;
   display: -webkit-flex;
@@ -104,6 +110,7 @@ body {
   order: 2;
   -webkit-flex: 1 1 auto;
   flex: 1 1 auto;
+  height: 100%;
 }
 #mainToolbar, #mainArea {
   -webkit-order: 1;
@@ -151,7 +158,6 @@ body {
 }
 .notebookMainContent, #sidebarContent {
   overflow: auto;
-  position: absolute;
   top: 0px;
   left: 0px;
   right: 0px;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -358,7 +358,7 @@ div.status div.progress {
   margin-bottom: 4px
 }
 
-div.prompt, div.output_prompt, div.out_prompt_overlay {
+div.input_prompt, div.output_prompt, div.out_prompt_overlay {
   min-width: 0px;
   display: none;
   padding: 0px;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -131,6 +131,7 @@ body {
   align-self: auto;
   position: relative;
   min-width: 200px;
+  overflow: auto;
 }
 #sidebarArea {
   -webkit-order: 2;
@@ -167,6 +168,7 @@ body {
   left: 0px;
   right: 0px;
   bottom: 0px;
+  overflow: auto;
 }
 .fileMainContent {
   overflow: auto;

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -310,6 +310,7 @@ function collapseCell(cell) {
 
   cell.element.find('div.inner_cell').hide();
   cell.element.find('div.output_wrapper').hide();
+  cell.element.find('div.widget-area>').hide();
 
   cell.element.find('div.minitoolbar').show();
   cell.element.find('div.cellPlaceholder').show();
@@ -328,6 +329,7 @@ function collapseCell(cell) {
 function uncollapseCell(cell) {
   cell.element.find('div.inner_cell').show();
   cell.element.find('div.output_wrapper').show();
+  cell.element.find('div.widget-area>').show();
 
   cell.element.find('div.cellPlaceholder').hide();
   cell.element.find('div.cellPlaceholder')[0].innerHTML = '';

--- a/sources/web/datalab/static/light.css
+++ b/sources/web/datalab/static/light.css
@@ -14,15 +14,12 @@
 body {
   background: #fff;
 }
-#mainToolbar, #sidebarToolbar, #sidebarArea {
-  background-color: #f3f3f3;
-}
 #sidebarArea, #sidebarContent {
   color: #000;
 }
-#mainToolbar, #sidebarToolbar {
+#toolbarArea {
+  background-color: #eee;
   color: #444;
-  border-bottom: solid 1px #e6e6e6;
 }
 #appBar .toolbar-btn {
   color: #ccc;

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -96,7 +96,7 @@
   <div id="app">
     <div id="appBar">
     </div>
-    <div id="site" style="height: 100% !important; display: block !important">
+    <div id="site">
     <div id="appContent">
       <div id="toolbarArea">
         <div id="mainToolbar">

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
   <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" id="stylesheet" />
+  <link rel="stylesheet" href="/static/components/jquery-ui/themes/smoothness/jquery-ui.min.css" />
 
   <script src="/static/components/jquery/jquery.min.js"></script>
 </head>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -96,6 +96,7 @@
   <div id="app">
     <div id="appBar">
     </div>
+    <div id="site" style="height: 100% !important; display: block !important">
     <div id="appContent">
       <div id="toolbarArea">
         <div id="mainToolbar">
@@ -244,6 +245,7 @@
           </div>
         </div>
       </div>
+    </div>
     </div>
   </div>
   <script src="/static/components/es6-promise/promise.min.js"></script>


### PR DESCRIPTION
- Use the latest version of ipywidgets (5.2.2)
- Add missing CSS and HTML elements for the widgets to work
- Some other fixes to get widgets working properly
- Hide/show widgets area when cells are collapsed
- Build datalab frontend as part of the docker build script

Fixes #843, #890, and #1012

Note: widgets are still not all styled properly for the dark theme, this isn't trivial to do since most of them are styled inline instead in stylesheets.

![image](https://cloud.githubusercontent.com/assets/1424661/19417464/8b819c28-9362-11e6-91b1-00f365b68955.png)