### PR TITLE
Fix output line height and missing padding in appContent

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -70,7 +70,6 @@ body {
   height: 100%;
 }
 #appContent {
-  position: absolute;
   top: 0px;
   bottom: 0px;
   left: 0px;
@@ -369,6 +368,9 @@ div.status div.progress {
   width: 150px;
   height: 8px;
   margin-bottom: 4px
+}
+div.output_text {
+  line-height: inherit;
 }
 
 div.input_prompt, div.output_prompt, div.out_prompt_overlay {


### PR DESCRIPTION
- Added back missing padding at the top of the notebook list and session.
- Fixes this:
![image](https://cloud.githubusercontent.com/assets/1424661/19488282/04bba70a-951b-11e6-88b6-286c4cb825bc.png)