### PR TITLE
fix edit page height, padding, and missing line numbers

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -445,7 +445,7 @@ pre, code, .CodeMirror, .CodeMirror pre, .CodeMirror-linenumber {
 div.selected .CodeMirror-gutters {
   border-right: 1px solid #ddd;
 }
-div.selected .CodeMirror-linenumber {
+div.selected .CodeMirror-linenumber, div#texteditor-container .CodeMirror-linenumber {
   visibility: visible;
 }
 .CodeMirror-matchingbracket {

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -67,7 +67,7 @@ body {
   -webkit-order: 2;
   order: 2;
   position: relative;
-  height: 100%;
+  height: 100% !important;
 }
 #appContent {
   top: 0px;
@@ -316,6 +316,10 @@ span.autosave_status {
   display: inline-block;
 }
 
+/* Edit page */
+#texteditor-backdrop {
+  padding: 0px;
+}
 
 /* Cell Customizations */
 div.cell {


### PR DESCRIPTION
- Remove extra top and bottom padding
- Fix height being set to greater than 100%
- Added missing line numbers in the text editor

Fixes #1024 