### PR TITLE
Add code collapse button to code cells

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -327,7 +327,7 @@ div.cell {
   border-radius: 0px;
   padding: 0px;
   padding-left: 0px;
-  margin-bottom: 10px;
+  margin-bottom: 15px;
   position: relative;
 }
 div.cell.selected, div.cell.text_cell.selected, div.cell.code_cell.selected {
@@ -377,16 +377,19 @@ div.output_text {
   line-height: inherit;
 }
 div.code-collapse-btn {
-  padding: 1px;
-  margin 0px;
+  display: none;
+  position: absolute;
+  bottom: -5px;
+  left: calc(50% - 10px);
   height: 20px;
+  width: 40px;
+  padding: 0px;
+  z-index: 3;
 }
-span.code-collapse-span {
-  width: 100%;
-  height: 100%;
-  padding: 1px;
-  font-width: bold;
+div.selected .code-collapse-btn {
+  display: block;
 }
+
 div.input_prompt, div.output_prompt, div.out_prompt_overlay {
   min-width: 0px;
   display: none;
@@ -395,6 +398,24 @@ div.input_prompt, div.output_prompt, div.out_prompt_overlay {
 }
 div.input_prompt {
   min-width: 30px;
+}
+div.inner_cell {
+  padding-bottom: 5px;
+}
+.codehidden * div.inner_cell {
+  display: none;
+}
+div.input {
+  position: relative;
+}
+.codehidden>div.input {
+  height: 20px;
+  border: 1px;
+  border-style: solid;
+  border-color: #ddd;
+}
+.codehidden * div.code-collapse-btn {
+  display: block;
 }
 div.output_area {
   margin-top: 4px;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -376,7 +376,17 @@ div.status div.progress {
 div.output_text {
   line-height: inherit;
 }
-
+div.code-collapse-btn {
+  padding: 1px;
+  margin 0px;
+  height: 20px;
+}
+span.code-collapse-span {
+  width: 100%;
+  height: 100%;
+  padding: 1px;
+  font-width: bold;
+}
 div.input_prompt, div.output_prompt, div.out_prompt_overlay {
   min-width: 0px;
   display: none;

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -353,6 +353,18 @@ function createCellMiniToolbarButton(classNames, title, callback) {
 }
 
 /**
+ * Create code collapse button
+ */
+function createCodeCollapseButton() {
+  let buttonDiv = document.createElement('div');
+  buttonDiv.className = 'code-collapse-btn';
+  let span = document.createElement('span');
+  span.className = 'btn btn-default fa fa-code code-collapse-span');
+  buttonDiv.appendChild(span);
+  return buttonDiv;
+}
+
+/**
  * Patch the cell's element to add a minitoolbar div to contain extra buttons
  */
 function addCellMiniToolbar(cell) {


### PR DESCRIPTION
This change adds a button to the end of the input div to collapse the input area and keep only output area (and widgets if any) visible. It works just like the cell collapse button, visible only on selected cells, and stays visible for collapsed cells even if not selected.

Screenshots:
![image](https://cloud.githubusercontent.com/assets/1424661/19709694/5438172e-9add-11e6-95ae-5633e51506ec.png)

![image](https://cloud.githubusercontent.com/assets/1424661/19709704/652dd9ec-9add-11e6-928e-8fed4af2d37e.png)
