### PR TITLE
Add more buttons to cell minitoolbar: code collapse, run, and clear

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -327,7 +327,7 @@ div.cell {
   border-radius: 0px;
   padding: 0px;
   padding-left: 0px;
-  margin-bottom: 10px;
+  margin-bottom: 15px;
   position: relative;
 }
 div.cell.selected, div.cell.text_cell.selected, div.cell.code_cell.selected {
@@ -376,6 +376,19 @@ div.status div.progress {
 div.output_text {
   line-height: inherit;
 }
+div.code-collapse-btn {
+  display: none;
+  position: absolute;
+  bottom: -5px;
+  left: calc(50% - 10px);
+  height: 20px;
+  width: 40px;
+  padding: 0px;
+  z-index: 3;
+}
+div.selected .code-collapse-btn {
+  display: block;
+}
 
 div.input_prompt, div.output_prompt, div.out_prompt_overlay {
   min-width: 0px;
@@ -385,6 +398,24 @@ div.input_prompt, div.output_prompt, div.out_prompt_overlay {
 }
 div.input_prompt {
   min-width: 30px;
+}
+div.inner_cell {
+  padding-bottom: 5px;
+}
+.codehidden * div.inner_cell {
+  display: none;
+}
+div.input {
+  position: relative;
+}
+.codehidden>div.input {
+  height: 20px;
+  border: 1px;
+  border-style: solid;
+  border-color: #ddd;
+}
+.codehidden * div.code-collapse-btn {
+  display: block;
 }
 div.output_area {
   margin-top: 4px;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -389,7 +389,6 @@ div.code-collapse-btn {
 div.selected .code-collapse-btn {
   display: block;
 }
-
 div.input_prompt, div.output_prompt, div.out_prompt_overlay {
   min-width: 0px;
   display: none;
@@ -438,7 +437,13 @@ a.anchor-link {
 div.minitoolbar {
   position: absolute;
   left: -16px;
+  z-index: 10;
   display: none;
+}
+button.minitoolbar-toggle {
+  width: 25px;
+  height: 25px;
+  padding: 0;
 }
 div.minitoolbar>span {
   padding: 2px;
@@ -454,6 +459,9 @@ div.cellPlaceholder {
   width: 100%;
   text-align: left;
   display: none;
+}
+div.collapse-cell {
+  padding-right: 5px;
 }
 
 /* CodeMirror Customization */

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -387,7 +387,7 @@ div.cellhidden div.input, div.cellhidden div.output_wrapper, .codehidden * div.i
   display: none;
 }
 .codehidden>div.input {
-  height: 25px;
+  height: 33px;
   border: 1px;
   border-style: solid;
   border-color: #ddd;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -330,7 +330,7 @@ div.cell {
   border-radius: 0px;
   padding: 0px;
   padding-left: 0px;
-  margin-bottom: 15px;
+  margin-bottom: 10px;
   position: relative;
 }
 div.cell.selected, div.cell.text_cell.selected, div.cell.code_cell.selected {
@@ -379,10 +379,11 @@ div.status div.progress {
 div.output_text {
   line-height: inherit;
 }
-div.selected div.minitoolbar, .cellhidden>div.minitoolbar, .codehidden>div.minitoolbar {
+div.selected div.minitoolbar, .cellhidden>div.minitoolbar, .codehidden>div.minitoolbar,
+div.cellhidden div.cellPlaceholder {
   display: block;
 }
-.codehidden * div.inner_cell {
+div.cellhidden div.input, div.cellhidden div.output_wrapper, .codehidden * div.inner_cell {
   display: none;
 }
 .codehidden>div.input {
@@ -402,9 +403,6 @@ div.input_prompt, div.output_prompt, div.out_prompt_overlay {
 }
 div.input_prompt {
   min-width: 30px;
-}
-div.inner_cell {
-  padding-bottom: 5px;
 }
 div.output_area {
   margin-top: 4px;
@@ -449,9 +447,6 @@ div.cellPlaceholder {
   width: 100%;
   text-align: left;
   display: none;
-}
-div.collapse-cell {
-  padding-right: 5px;
 }
 
 /* CodeMirror Customization */

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -188,6 +188,9 @@ body {
 #sidebarContent {
   padding: 10px 20px;
 }
+#notebook-container {
+  padding: 35px;
+}
 .container {
   min-width: 200px;
   width: 100%;
@@ -285,7 +288,7 @@ div.btn-toolbar .toolbar-btn.active {
 }
 #ipython-main-app {
   position: relative;
-  padding: 10px 40px;
+  padding: 10px;
 }
 div.end_space {
   min-height: 20px;
@@ -376,18 +379,20 @@ div.status div.progress {
 div.output_text {
   line-height: inherit;
 }
-div.code-collapse-btn {
-  display: none;
-  position: absolute;
-  bottom: -5px;
-  left: calc(50% - 10px);
-  height: 20px;
-  width: 40px;
-  padding: 0px;
-  z-index: 3;
-}
-div.selected .code-collapse-btn {
+div.selected div.minitoolbar, .cellhidden>div.minitoolbar, .codehidden>div.minitoolbar {
   display: block;
+}
+.codehidden * div.inner_cell {
+  display: none;
+}
+.codehidden>div.input {
+  height: 25px;
+  border: 1px;
+  border-style: solid;
+  border-color: #ddd;
+}
+div.input {
+  position: relative;
 }
 div.input_prompt, div.output_prompt, div.out_prompt_overlay {
   min-width: 0px;
@@ -400,21 +405,6 @@ div.input_prompt {
 }
 div.inner_cell {
   padding-bottom: 5px;
-}
-.codehidden * div.inner_cell {
-  display: none;
-}
-div.input {
-  position: relative;
-}
-.codehidden>div.input {
-  height: 20px;
-  border: 1px;
-  border-style: solid;
-  border-color: #ddd;
-}
-.codehidden * div.code-collapse-btn {
-  display: block;
 }
 div.output_area {
   margin-top: 4px;
@@ -436,7 +426,7 @@ a.anchor-link {
 }
 div.minitoolbar {
   position: absolute;
-  left: -16px;
+  left: -30px;
   z-index: 10;
   display: none;
 }

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -311,11 +311,12 @@ function collapseCell(cell) {
     return '<div class="rendered_html">' + cell.element.find('pre.CodeMirror-line')[0].outerHTML + dots + '</div>';
   }
 
+  cell.element.addClass('cellhidden');
+
   cell.element.find('div.input').hide();
   cell.element.find('div.output_wrapper').hide();
   cell.element.find('div.widget-area>').hide();
 
-  cell.element.find('div.minitoolbar').show();
   cell.element.find('div.cellPlaceholder').show();
   cell.element.find('div.cellPlaceholder')[0].innerHTML = getCollapsedCellHeader(cell);
 
@@ -330,6 +331,8 @@ function collapseCell(cell) {
  * Uncollapse entire cell
  */
 function uncollapseCell(cell) {
+  cell.element.removeClass('cellhidden');
+
   cell.element.find('div.input').show();
   cell.element.find('div.output_wrapper').show();
   cell.element.find('div.widget-area>').show();
@@ -342,6 +345,9 @@ function uncollapseCell(cell) {
   collapseSpan.classList.remove(UNCOLLAPSE_BUTTON_CLASS);
 
   cell.metadata[CELL_METADATA_COLLAPSED] = false;
+
+  // uncollapse code section as well
+  uncollapseCode(cell);
 }
 
 /**
@@ -1095,20 +1101,6 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
     // patch any cell created from now on
     events.on('create.Cell', function(e, params) {
       patchCellUI(params.cell);
-    });
-
-    // on cell select, show the toolbar on all collapsed cells as well as currently selected code cell
-    events.on('select.Cell', function(e, params) {
-      cell = params.cell;
-      // there's no reliable 'blur' event exposed by Jupyter
-      // so we have to unselect all markdown and uncollapsed cells manually
-      Jupyter.notebook.get_cells().forEach(function(cell) {
-        if (cell.cell_type === 'code' &&
-          (!(CELL_METADATA_COLLAPSED in cell.metadata) || cell.metadata[CELL_METADATA_COLLAPSED] === false))
-          cell.element.find('div.minitoolbar')[0].style.display = 'none';
-      });
-      if (cell.cell_type === 'code')
-        cell.element.find('div.minitoolbar')[0].style.display = 'block';
     });
 
     events.on('set_dirty.Notebook', function(e) {

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -281,6 +281,9 @@ function initializePage(dialog, saveFn) {
 const CELL_METADATA_COLLAPSED = 'hiddenCell';
 const COLLAPSE_BUTTON_CLASS = 'fa-minus';
 const UNCOLLAPSE_BUTTON_CLASS = 'fa-plus';
+const CELL_METADATA_CODE_COLLAPSED = 'codeCollapsed';
+const COLLAPSE_CODE_BUTTON_CLASS = 'fa-angle-up';
+const UNCOLLAPSE_CODE_BUTTON_CLASS = 'fa-angle-down';
 
 function toggleCollapseCell(cell) {
   isCollapsed = cell.metadata[CELL_METADATA_COLLAPSED] || false;
@@ -308,7 +311,7 @@ function collapseCell(cell) {
     return '<div class="rendered_html">' + cell.element.find('pre.CodeMirror-line')[0].outerHTML + dots + '</div>';
   }
 
-  cell.element.find('div.inner_cell').hide();
+  cell.element.find('div.input').hide();
   cell.element.find('div.output_wrapper').hide();
   cell.element.find('div.widget-area>').hide();
 
@@ -327,7 +330,7 @@ function collapseCell(cell) {
  * Uncollapse entire cell
  */
 function uncollapseCell(cell) {
-  cell.element.find('div.inner_cell').show();
+  cell.element.find('div.input').show();
   cell.element.find('div.output_wrapper').show();
   cell.element.find('div.widget-area>').show();
 
@@ -353,9 +356,66 @@ function createCellMiniToolbarButton(classNames, title, callback) {
 }
 
 /**
- * Patch the cell's element to add a minitoolbar div to contain extra buttons
+ * Toggle collapsing cell's code
  */
-function addCellMiniToolbar(cell) {
+function toggleCollapseCode(cell) {
+  isCollapsed = cell.metadata[CELL_METADATA_CODE_COLLAPSED] || false;
+  if (isCollapsed) {
+    uncollapseCode(cell);
+  } else {
+    collapseCode(cell);
+  }
+}
+
+/**
+ * Collapse the code part of the cell
+ */
+function collapseCode(cell) {
+  if (cell.cell_type !== 'code') {
+    // can't collapse markdown cells
+    return;
+  }
+
+  cell.element.addClass('codehidden');
+
+  cell.element.find('div.code-collapse-btn>span').addClass(UNCOLLAPSE_CODE_BUTTON_CLASS);
+  cell.element.find('div.code-collapse-btn>span').removeClass(COLLAPSE_CODE_BUTTON_CLASS);
+
+  cell.metadata[CELL_METADATA_CODE_COLLAPSED] = true;
+}
+
+/**
+ * Uncollapse the code part of the cell
+ */
+function uncollapseCode(cell) {
+  cell.element.removeClass('codehidden');
+
+  cell.element.find('div.code-collapse-btn>span').addClass(COLLAPSE_CODE_BUTTON_CLASS);
+  cell.element.find('div.code-collapse-btn>span').removeClass(UNCOLLAPSE_CODE_BUTTON_CLASS);
+
+  cell.metadata[CELL_METADATA_CODE_COLLAPSED] = false;
+}
+
+/**
+ * Create code collapse button
+ */
+function createCodeCollapseButton(cell) {
+  let buttonDiv = document.createElement('div');
+  buttonDiv.className = 'btn btn-default code-collapse-btn';
+  buttonDiv.title = 'Collapse/Expand code';
+  buttonDiv.addEventListener('click', () => {
+    toggleCollapseCode(cell);
+  });
+  let span = document.createElement('span');
+  span.className = 'fa ' + COLLAPSE_CODE_BUTTON_CLASS;
+  buttonDiv.appendChild(span);
+  return buttonDiv;
+}
+
+/**
+ * Patch the cell's element to add collapse cell and code buttons
+ */
+function patchCellUI(cell) {
 
   let toolbarDiv = document.createElement('div');
   toolbarDiv.className = 'minitoolbar';
@@ -385,6 +445,15 @@ function addCellMiniToolbar(cell) {
   // collapse cells according to their saved metadata if any
   if (CELL_METADATA_COLLAPSED in cell.metadata && cell.metadata[CELL_METADATA_COLLAPSED] === true) {
     collapseCell(cell);
+  }
+
+  // collapse cell code button
+  let collapseCodeButton = createCodeCollapseButton(cell);
+  cell.element.find('div.inner_cell')[0].insertAdjacentElement('afterend', collapseCodeButton);
+
+  // collapse cell code according to their saved metadata if any
+  if (CELL_METADATA_CODE_COLLAPSED in cell.metadata && cell.metadata[CELL_METADATA_CODE_COLLAPSED] === true) {
+    collapseCode(cell);
   }
 }
 
@@ -1010,15 +1079,15 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
 
   events.on('notebook_loaded.Notebook', function() {
 
-    // create the cell toolbar
+    // patch current cells to add custom ui
     Jupyter.notebook.get_cells().forEach(function(cell) {
       if (cell.cell_type === 'code')
-        addCellMiniToolbar(cell)
+        patchCellUI(cell)
     });
 
     // patch any cell created from now on
     events.on('create.Cell', function(e, params) {
-      addCellMiniToolbar(params.cell);
+      patchCellUI(params.cell);
     });
 
     // on cell select, show the toolbar on all collapsed cells as well as currently selected code cell


### PR DESCRIPTION
Added more buttons to the minitoolbar and converted it to a dropdown menu with a hamburger button. The new options added are: code collapse, run, and clear cell. Hiding is done mostly in CSS, except for parts where JS code is needed (hiding ipywidgets).

![image](https://cloud.githubusercontent.com/assets/1424661/19841633/d7300cf8-9ecb-11e6-92b4-18474521b979.png)
