### PR TITLE
Fail on error in build scripts

### DIFF
--- a/containers/base/build.sh
+++ b/containers/base/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/datalab/build.sh
+++ b/containers/datalab/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/datalab/debug.sh
+++ b/containers/datalab/debug.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/datalab/logs.sh
+++ b/containers/datalab/logs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/datalab/run-extended.sh
+++ b/containers/datalab/run-extended.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/datalab/stage.sh
+++ b/containers/datalab/stage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/gateway/build.sh
+++ b/containers/gateway/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/gateway/content/run.sh
+++ b/containers/gateway/content/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/gateway/content/setup-env.sh
+++ b/containers/gateway/content/setup-env.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/containers/gateway/run.sh
+++ b/containers/gateway/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Use -e in all shell scripts to fail on error. Right now the build script doesn't stop on error, so running the `run.sh` command afterwards actually uses older images if any.

Fixes #989 