### PR TITLE
Add curl back as a dependency in the base image.

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -27,7 +27,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     apt-get update -y && \
     apt-get install --no-install-recommends -y -q python unzip ca-certificates build-essential \
     libatlas-base-dev liblapack-dev gfortran libpng-dev libfreetype6-dev libxft-dev libxml2-dev \
-    python-dev python-setuptools python-zmq openssh-client wget git pkg-config && \
+    python-dev python-setuptools python-zmq openssh-client wget curl git pkg-config && \
     easy_install pip && \
     mkdir -p /tools && \
 


### PR DESCRIPTION
We use curl in certain scenarios to verify that the kernel gateway
is functioning and accessible, so it is required in some configurations.

It's also just a generally useful tool that most people will want
in their development environment.

This appears to have been the root cause of #1043 