### PR TITLE
Run ungit inside the datalab container

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -24,6 +24,9 @@ RUN ln -s /datalab/web/static/datalab.css /datalab/nbconvert/datalab.css && \
     cd /datalab/web && /tools/node/bin/npm install && \
     cd / && \
 
+# Install ungit
+    /tools/node/bin/npm install -g ungit@0.10.3 && \
+
 # Install the support for connecting to a kernel gateway
     wget https://github.com/jupyter/kernel_gateway_demos/archive/e653b2bd3ca91ef1af2a13c397766484dcb7b76d.zip && \
     unzip -qq e653b2bd3ca91ef1af2a13c397766484dcb7b76d.zip -d kernel_gateway_demos && \

--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -204,6 +204,9 @@ then
   openssl rand -base64 128 > /content/datalab/.config/notary_secret
 fi
 
+# Start the ungit server
+ungit --port=8083 --no-launchBrowser --forcedLaunchPath=/content/datalab 1> /dev/null &
+
 # Start the DataLab server
 FOREVER_CMD="forever --minUptime 1000 --spinSleepTime 1000"
 if [ -z "${DATALAB_DEBUG}" ]

--- a/sources/web/datalab/reverseProxy.ts
+++ b/sources/web/datalab/reverseProxy.ts
@@ -48,12 +48,22 @@ export function getRequestPort(request: http.ServerRequest, path: string): strin
 }
 
 /**
+ * Checks if a request should be exempted from reverse proxying to the gateway
+ */
+function shouldSkipGateway(port: String) {
+  // skip requests to 8083 for ungit
+  if (port === '8083')
+    return true;
+  return false;
+}
+
+/**
  * Handle request by sending it to the internal http endpoint.
  */
 export function handleRequest(request: http.ServerRequest,
                               response: http.ServerResponse,
                               port: String) {
-  if (process.env.KG_URL) {
+  if (process.env.KG_URL && !shouldSkipGateway(port)) {
     proxy.web(request, response, { target: process.env.KG_URL });
   }
   else {

--- a/sources/web/datalab/reverseProxy.ts
+++ b/sources/web/datalab/reverseProxy.ts
@@ -48,13 +48,11 @@ export function getRequestPort(request: http.ServerRequest, path: string): strin
 }
 
 /**
- * Checks if a request should be exempted from reverse proxying to the gateway
+ * Check if traffic to this port should be proxied back to the gateway
  */
-function shouldSkipGateway(port: String) {
-  // skip requests to 8083 for ungit
-  if (port === '8083')
-    return true;
-  return false;
+function shouldProxyPort(port: String) {
+  // Do not proxy 8083 to gateway, it's open for ungit
+  return !!process.env.KG_URL && port !== '8083';
 }
 
 /**
@@ -63,7 +61,7 @@ function shouldSkipGateway(port: String) {
 export function handleRequest(request: http.ServerRequest,
                               response: http.ServerResponse,
                               port: String) {
-  if (process.env.KG_URL && !shouldSkipGateway(port)) {
+  if (shouldProxyPort(port)) {
     proxy.web(request, response, { target: process.env.KG_URL });
   }
   else {

--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -13,6 +13,11 @@
   </span>
   <div class="btn-toolbar pull-right">
     <div class="btn-group">
+      <button id="ungitButton" title="Open ungit here" class="toolbar-btn">
+        <span class="fa fa-code-fork"></span>
+      </button>
+    </div>
+    <div class="btn-group">
       <button class="toolbar-btn" data-toggle="dropdown" title="Help Links">
         <span class="fa fa-question-circle"></span>
       </button>

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -230,6 +230,21 @@ function initializePage(dialog, saveFn) {
       saveFn();
       window.location = '/signout?referer=' + encodeURIComponent(window.location);
     });
+    $('#ungitButton').click(function() {
+      var path = location.pathname;
+
+      // Extract the current directory name
+      if (path.indexOf('/tree') == 0) {
+        path = path.substr('/tree'.length);
+      } else if (path.indexOf('/notebooks') == 0) {
+        path = path.substr('/notebooks'.length);
+        path = path.substr(0, path.lastIndexOf('/'));
+      }
+      path = encodeURIComponent('/content' + path);
+      prefix = window.location.protocol + '//' + window.location.host;
+
+      window.open(prefix + '/_proxy/8083/#/repository?path=' + path);
+    });
   }
 
   // More UI that relies on appbar load

--- a/sources/web/datalab/static/datalab.txt
+++ b/sources/web/datalab/static/datalab.txt
@@ -67,6 +67,7 @@ cat /datalab/license.txt
 - socket.io [https://www.npmjs.com/package/socket.io]
 - tcp-port-used [https://www.npmjs.com/package/tcp-port-used]
 - ws [https://www.npmjs.com/package/ws]
+- ungit [https://github.com/FredrikNoren/ungit]
 
 ## Other Packages:
 - curl


### PR DESCRIPTION
This PR adds [ungit](https://github.com/FredrikNoren/ungit) inside the datalab container. It runs on port 8083 inside the container, and gets its requests reverse proxied so only the one port used by datalab is open outside the container.

I added a git icon in the app bar to open ungit in the current location. It finds the current directory path and points ungit to it. Note that ungit will ignore any trailing subdirectories after the git root dir.

![image](https://cloud.githubusercontent.com/assets/1424661/20168474/477c739e-a6d7-11e6-800a-fd6e63c909ae.png)
![image](https://cloud.githubusercontent.com/assets/1424661/20168435/1b043ffe-a6d7-11e6-9d1b-912bcb80ec86.png)