### PR TITLE
Added a release rollback script

### DIFF
--- a/tools/release/publish.sh
+++ b/tools/release/publish.sh
@@ -60,9 +60,14 @@ docker tag -f ${DATALAB_IMAGE} gcr.io/${PROJECT_ID}/datalab:local
 gcloud docker -- push gcr.io/${PROJECT_ID}/datalab:local
 
 gsutil cp gs://${PROJECT_ID}/deploy/config_local.js ./config_local.js
-OLD_VERSION=`cat ./config_local.js | grep latest | cut -d ':' -f 2`
+OLD_VERSION=`cat ./config_local.js | grep last | cut -d ':' -f 2`
+CURRENT_VERSION=`cat ./config_local.js | grep latest | cut -d ':' -f 2`
 NEW_VERSION=" ${BUILD},"
-echo "Replacing ${OLD_VERSION} with ${NEW_VERSION}"
-sed -i -e "s/${OLD_VERSION}/${NEW_VERSION}/" ./config_local.js
+
+echo "Replacing latest=${CURRENT_VERSION} with latest=${NEW_VERSION}"
+sed -i -e "s/${CURRENT_VERSION}/${NEW_VERSION}/" ./config_local.js
+echo "Replacing last=${OLD_VERSION} with last=${CURRENT_VERSION}"
+sed -i -e "s/${OLD_VERSION}/${CURRENT_VERSION}/" ./config_local.js
+
 gsutil cp ./config_local.js gs://${PROJECT_ID}/deploy/config_local_${BUILD}.js
 gsutil cp ./config_local.js gs://${PROJECT_ID}/deploy/config_local.js

--- a/tools/release/publish.sh
+++ b/tools/release/publish.sh
@@ -28,6 +28,10 @@
 #  2. "BUILD": The label of the builds to pull down and publish. If omitted
 #     this will default to the current date (which is what the build.sh
 #     script uses by default).
+#
+# The script sets a 'previous' variable in the config_local script to define
+# the rollback version. This script should NOT be executed more than once
+# using the same image, as it will overwrite this previous field.
 
 PROJECT_ID="${PROJECT_ID:-cloud-datalab}"
 TEST_PROJECT_ID="${TEST_PROJECT_ID:-`gcloud config list -q --format 'value(core.project)' 2> /dev/null`}"

--- a/tools/release/publish.sh
+++ b/tools/release/publish.sh
@@ -60,13 +60,13 @@ docker tag -f ${DATALAB_IMAGE} gcr.io/${PROJECT_ID}/datalab:local
 gcloud docker -- push gcr.io/${PROJECT_ID}/datalab:local
 
 gsutil cp gs://${PROJECT_ID}/deploy/config_local.js ./config_local.js
-OLD_VERSION=`cat ./config_local.js | grep last | cut -d ':' -f 2`
+OLD_VERSION=`cat ./config_local.js | grep previous | cut -d ':' -f 2`
 CURRENT_VERSION=`cat ./config_local.js | grep latest | cut -d ':' -f 2`
 NEW_VERSION=" ${BUILD},"
 
 echo "Replacing latest=${CURRENT_VERSION} with latest=${NEW_VERSION}"
 sed -i -e "s/${CURRENT_VERSION}/${NEW_VERSION}/" ./config_local.js
-echo "Replacing last=${OLD_VERSION} with last=${CURRENT_VERSION}"
+echo "Replacing previous=${OLD_VERSION} with previous=${CURRENT_VERSION}"
 sed -i -e "s/${OLD_VERSION}/${CURRENT_VERSION}/" ./config_local.js
 
 gsutil cp ./config_local.js gs://${PROJECT_ID}/deploy/config_local_${BUILD}.js

--- a/tools/release/rollback.sh
+++ b/tools/release/rollback.sh
@@ -27,19 +27,23 @@
 # 1. "PROJECT_ID": Sets the name of the target project where the
 #    images will be pulled from and pushed to. Defaults to "cloud-datalab"
 # 2. "ROLLBACK_BUILD": The label of the build to pull down and rollback to.
-#    If omitted, this will extract the 'last' field from the config_local.js
+#    If omitted, this will extract the 'porevious' field from the config_local.js
 
 PROJECT_ID="${PROJECT_ID:-cloud-datalab}"
 
 gsutil cp gs://${PROJECT_ID}/deploy/config_local.js ./config_local.js
-REGEX='latest: ([0-9]+),.*last: ([0-9]+),'
-[[ $(cat config_local.js) =~ $REGEX ]]
-LATEST_BUILD=${BASH_REMATCH[1]}
-OLD_BUILD=${BASH_REMATCH[2]}
-LAST_BUILD="${ROLLBACK_BUILD:-$OLD_BUILD}"
+REGEX='latest: ([0-9]+),.*previous: ([0-9]+)'
+if [[ $(cat config_local.js) =~ $REGEX ]]; then
+  LATEST_BUILD=${BASH_REMATCH[1]}
+  OLD_BUILD=${BASH_REMATCH[2]}
+  PREVIOUS_BUILD="${ROLLBACK_BUILD:-$OLD_BUILD}"
+else
+  echo "Could not extract previous build to rollback to. Aborting."
+  exit 1
+fi
 
-GATEWAY_IMAGE="gcr.io/${PROJECT_ID}/datalab-gateway:${LAST_BUILD}"
-DATALAB_IMAGE="gcr.io/${PROJECT_ID}/datalab:local-${LAST_BUILD}"
+GATEWAY_IMAGE="gcr.io/${PROJECT_ID}/datalab-gateway:${PREVIOUS_BUILD}"
+DATALAB_IMAGE="gcr.io/${PROJECT_ID}/datalab:local-${PREVIOUS_BUILD}"
 
 read -p "Proceed to release ${GATEWAY_IMAGE} and ${DATALAB_IMAGE} as latest? [Y/n]: " answer
 if echo $answer | grep -iq -v '^y'; then
@@ -47,9 +51,9 @@ if echo $answer | grep -iq -v '^y'; then
 fi
 
 echo "Moving config_local.js to config_local_${LATEST_BUILD}.js"
-echo "Updating config_local_${LAST_BUILD}.js to be config_local.js"
+echo "Updating config_local_${PREVIOUS_BUILD}.js to be config_local.js"
 gsutil cp gs://${PROJECT_ID}/deploy/config_local.js gs://${PROJECT_ID}/deploy/config_local_${LATEST_BUILD}.js
-gsutil cp gs://${PROJECT_ID}/deploy/config_local_${LAST_BUILD}.js gs://${PROJECT_ID}/deploy/config_local.js
+gsutil cp gs://${PROJECT_ID}/deploy/config_local_${PREVIOUS_BUILD}.js gs://${PROJECT_ID}/deploy/config_local.js
 
 echo "Pulling the rollback gateway and Datalab images: ${GATEWAY_IMAGE}, ${DATALAB_IMAGE}"
 gcloud docker -- pull ${GATEWAY_IMAGE}

--- a/tools/release/rollback.sh
+++ b/tools/release/rollback.sh
@@ -27,15 +27,14 @@
 # 1. "PROJECT_ID": Sets the name of the target project where the
 #    images will be pulled from and pushed to. Defaults to "cloud-datalab"
 # 2. "ROLLBACK_BUILD": The label of the build to pull down and rollback to.
-#    If omitted, this will extract the 'porevious' field from the config_local.js
+#    If omitted, this will extract the 'previous' field from the config_local.js
 
 PROJECT_ID="${PROJECT_ID:-cloud-datalab}"
 
 gsutil cp gs://${PROJECT_ID}/deploy/config_local.js ./config_local.js
-REGEX='latest: ([0-9]+),.*previous: ([0-9]+)'
+REGEX='previous: ([0-9]+)'
 if [[ $(cat config_local.js) =~ $REGEX ]]; then
-  LATEST_BUILD=${BASH_REMATCH[1]}
-  OLD_BUILD=${BASH_REMATCH[2]}
+  OLD_BUILD=${BASH_REMATCH[1]}
   PREVIOUS_BUILD="${ROLLBACK_BUILD:-$OLD_BUILD}"
 else
   echo "Could not extract previous build to rollback to. Aborting."
@@ -50,9 +49,7 @@ if echo $answer | grep -iq -v '^y'; then
   exit 1
 fi
 
-echo "Moving config_local.js to config_local_${LATEST_BUILD}.js"
 echo "Updating config_local_${PREVIOUS_BUILD}.js to be config_local.js"
-gsutil cp gs://${PROJECT_ID}/deploy/config_local.js gs://${PROJECT_ID}/deploy/config_local_${LATEST_BUILD}.js
 gsutil cp gs://${PROJECT_ID}/deploy/config_local_${PREVIOUS_BUILD}.js gs://${PROJECT_ID}/deploy/config_local.js
 
 echo "Pulling the rollback gateway and Datalab images: ${GATEWAY_IMAGE}, ${DATALAB_IMAGE}"

--- a/tools/release/rollback.sh
+++ b/tools/release/rollback.sh
@@ -1,0 +1,64 @@
+#!/bin/bash -e
+
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script defines the rollback process for Datalab.
+#
+# It assumes that there is at least one build that has been released using
+# the build.sh and publish.sh scripts. The rollback works by getting the
+# previous release name from the config_local.js file in Google Cloud
+# Storage. The desired rollback can also be specified as an argument.
+
+# The script supports two (optional) environment variables that can be
+# defined externally to modify its behavior:
+#
+# 1. "PROJECT_ID": Sets the name of the target project where the
+#    images will be pulled from and pushed to. Defaults to "cloud-datalab"
+# 2. "ROLLBACK_BUILD": The label of the build to pull down and rollback to.
+#    If omitted, this will extract the 'last' field from the config_local.js
+
+PROJECT_ID="${PROJECT_ID:-cloud-datalab}"
+
+gsutil cp gs://${PROJECT_ID}/deploy/config_local.js ./config_local.js
+REGEX='latest: ([0-9]+),.*last: ([0-9]+),'
+[[ $(cat config_local.js) =~ $REGEX ]]
+LATEST_BUILD=${BASH_REMATCH[1]}
+OLD_BUILD=${BASH_REMATCH[2]}
+LAST_BUILD="${ROLLBACK_BUILD:-$OLD_BUILD}"
+
+GATEWAY_IMAGE="gcr.io/${PROJECT_ID}/datalab-gateway:${LAST_BUILD}"
+DATALAB_IMAGE="gcr.io/${PROJECT_ID}/datalab:local-${LAST_BUILD}"
+
+read -p "Proceed to release ${GATEWAY_IMAGE} and ${DATALAB_IMAGE} as latest? [Y/n]: " answer
+if echo $answer | grep -iq -v '^y'; then
+  exit 1
+fi
+
+echo "Moving config_local.js to config_local_${LATEST_BUILD}.js"
+echo "Updating config_local_${LAST_BUILD}.js to be config_local.js"
+gsutil cp gs://${PROJECT_ID}/deploy/config_local.js gs://${PROJECT_ID}/deploy/config_local_${LATEST_BUILD}.js
+gsutil cp gs://${PROJECT_ID}/deploy/config_local_${LAST_BUILD}.js gs://${PROJECT_ID}/deploy/config_local.js
+
+echo "Pulling the rollback gateway and Datalab images: ${GATEWAY_IMAGE}, ${DATALAB_IMAGE}"
+gcloud docker -- pull ${GATEWAY_IMAGE}
+gcloud docker -- pull ${DATALAB_IMAGE}
+
+echo "Releasing the gateway image: ${GATEWAY_IMAGE}"
+docker tag -f ${GATEWAY_IMAGE} gcr.io/${PROJECT_ID}/datalab-gateway:latest
+gcloud docker -- push gcr.io/${PROJECT_ID}/datalab-gateway:latest
+
+echo "Releasing the Datalab image: ${DATALAB_IMAGE}"
+docker tag -f ${DATALAB_IMAGE} gcr.io/${PROJECT_ID}/datalab:local
+gcloud docker -- push gcr.io/${PROJECT_ID}/datalab:local


### PR DESCRIPTION
The rollback relies on a 'previous' variable defined in the config_local.js file. This PR updates the publish script to put the current release as previous before publishing the new one. This way the rollback script can read the previous release version and copy its config_local.js to be the current one, and release its corresponding images as well.