### PR TITLE
Make the port used by Jupyter configurable.

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -50,6 +50,11 @@ declare module common {
     datalabRoot: string;
 
     /**
+     * Initial port to use when searching for a free Jupyter port.
+     */
+    nextJupyterPort: number;
+
+    /**
      * Local directory which stores notebooks in the container
      */
     contentDir: string;

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -8,6 +8,7 @@
   "feedbackId": "",
   "logEndpoint": "stage-dot-cloud-datalab-logs.appspot.com",
   "serverPort": 8080,
+  "nextJupyterPort": 9000,
   "datalabRoot": "",
   "contentDir": "/content",
   "useWorkspace": false,

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -197,6 +197,7 @@ function createJupyterServer(userId: string, remainingAttempts: number) {
     fs.mkdirSync(userDir, parseInt('0755', 8));
   }
 
+  nextJupyterPort = appSettings.nextJupyterPort;
   logging.getLogger().info('Looking for a free port on which to start Jupyter for %s', userId);
   getNextJupyterPort(
     portRetryAttempts,


### PR DESCRIPTION
This just adds a new config setting `nextJupyterPort` which is used as the
initial port used when searching for a free port, as opposed to it being
hardcoded as 9000.

PTAL @yebrahim @ojarjur @qimingj 