### PR TITLE
Add an allowOriginOverride setting to override the Access-Control-Allow-Origin header

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -72,6 +72,11 @@ declare module common {
      */
     metadataHost: string;
 
+    /**
+     * The value for the access-control-allow-origin header. This
+     * allows another frontend to connect to Datalab.
+     */
+    allowOriginOverride: string;
   }
 
   interface Map<T> {

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -14,6 +14,7 @@
   "supportUserOverride": false,
   "configUrl": "https://storage.googleapis.com/cloud-datalab/deploy/config_local.js",
   "docsGcsPath": "gs://cloud-datalab/deploy/docs/",
+  "allowOriginOverride": "",
   "jupyterArgs": [
     "notebook",
     "-y",

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -425,15 +425,13 @@ function sendTemplate(key: string, data: common.Map<string>, response: http.Serv
 
 function responseHandler(proxyResponse: http.ClientResponse,
                          request: http.ServerRequest, response: http.ServerResponse) {
-  if (proxyResponse.headers['access-control-allow-origin'] !== undefined) {
-    if (appSettings.allowOriginOverride) {
-      proxyResponse.headers['access-control-allow-origin'] = appSettings.allowOriginOverride;
-    } else {
-      // Delete the allow-origin = * header that is sent (likely as a result of a workaround
-      // notebook configuration to allow server-side websocket connections that are
-      // interpreted by Jupyter as cross-domain).
-      delete proxyResponse.headers['access-control-allow-origin'];
-    }
+  if (appSettings.allowOriginOverride) {
+    proxyResponse.headers['access-control-allow-origin'] = appSettings.allowOriginOverride;
+  } else if (proxyResponse.headers['access-control-allow-origin'] !== undefined) {
+    // Delete the allow-origin = * header that is sent (likely as a result of a workaround
+    // notebook configuration to allow server-side websocket connections that are
+    // interpreted by Jupyter as cross-domain).
+    delete proxyResponse.headers['access-control-allow-origin'];
   }
 
   if (proxyResponse.statusCode != 200) {

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -426,10 +426,14 @@ function sendTemplate(key: string, data: common.Map<string>, response: http.Serv
 function responseHandler(proxyResponse: http.ClientResponse,
                          request: http.ServerRequest, response: http.ServerResponse) {
   if (proxyResponse.headers['access-control-allow-origin'] !== undefined) {
-    // Delete the allow-origin = * header that is sent (likely as a result of a workaround
-    // notebook configuration to allow server-side websocket connections that are
-    // interpreted by Jupyter as cross-domain).
-    delete proxyResponse.headers['access-control-allow-origin'];
+    if (appSettings.allowOriginOverride) {
+      proxyResponse.headers['access-control-allow-origin'] = appSettings.allowOriginOverride;
+    } else {
+      // Delete the allow-origin = * header that is sent (likely as a result of a workaround
+      // notebook configuration to allow server-side websocket connections that are
+      // interpreted by Jupyter as cross-domain).
+      delete proxyResponse.headers['access-control-allow-origin'];
+    }
   }
 
   if (proxyResponse.statusCode != 200) {


### PR DESCRIPTION
Add an allowOriginOverride config setting to workaround Datalab's default behavior of deleting the Access-Control-Allow-Origin that is sent back from Jupyter.  When this setting is overridden with another frontend's URL, that frontend will be able to make XHR requests to the Datalab frontend.

PTAL @yebrahim @ojarjur @qimingj 