### PR TITLE
Add 'Open as Text' Button in Toolbar

### DIFF
--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -34,7 +34,7 @@ button:hover {
   background-color: #333;
   color: #ddd;
 }
-.btn-default:hover {
+.btn-default:hover, .btn-default:focus {
   background-color: #222;
   color: #ddd;
 }

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -279,7 +279,11 @@ div.btn-toolbar .toolbar-btn.active {
 #uploadButton {
   padding: 4px 8px;
 }
-
+#editorButton {
+  display: none;
+  float: right;
+  top: 5px;
+}
 /* Notebook page */
 #notebook {
   font-family: Lato, 'Open Sans', Helvetica, sans-serif;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -281,8 +281,6 @@ div.btn-toolbar .toolbar-btn.active {
 }
 #editorButton {
   display: none;
-  float: right;
-  top: 5px;
 }
 /* Notebook page */
 #notebook {

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -1241,10 +1241,11 @@ function initializeNotebookList(ipy, notebookList, newNotebook, events, dialog, 
     });
   }
 
+  // Extend the selection changed method to show/hide the editor button
   notebookSelectedFn = notebookList._selection_changed;
   notebookList._selection_changed = function() {
     notebookSelectedFn.apply(this, arguments);
-    if (notebookList.selected.length === 1)
+    if (notebookList.selected.length === 1 && notebookList.selected[0].type !== 'directory')
       $('#editorButton').show();
     else
       $('#editorButton').hide();

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -240,7 +240,7 @@ function initializePage(dialog, saveFn) {
         path = path.substr('/notebooks'.length);
         path = path.substr(0, path.lastIndexOf('/'));
       }
-      path = '/content' + path;
+      path = encodeURIComponent('/content' + path);
       prefix = window.location.protocol + '//' + window.location.host;
 
       window.open(prefix + '/_proxy/8083/#/repository?path=' + path);

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -240,7 +240,7 @@ function initializePage(dialog, saveFn) {
         path = path.substr('/notebooks'.length);
         path = path.substr(0, path.lastIndexOf('/'));
       }
-      path = encodeURIComponent('/content' + path);
+      path = '/content' + path;
       prefix = window.location.protocol + '//' + window.location.host;
 
       window.open(prefix + '/_proxy/8083/#/repository?path=' + path);
@@ -1234,8 +1234,25 @@ function initializeNotebookList(ipy, notebookList, newNotebook, events, dialog, 
     e.target.blur();
   }
 
+  function openEditor(e) {
+    prefix = location.protocol + '//' + location.host + "/edit/";
+    Jupyter.notebook_list.selected.forEach(notebook => {
+      window.open(prefix + notebook.path, '_blank');
+    });
+  }
+
+  notebookSelectedFn = notebookList._selection_changed;
+  notebookList._selection_changed = function() {
+    notebookSelectedFn.apply(this, arguments);
+    if (notebookList.selected.length === 1)
+      $('#editorButton').show();
+    else
+      $('#editorButton').hide();
+  }
+
   document.getElementById('addNotebookButton').addEventListener('click', addNotebook, false);
   document.getElementById('addFolderButton').addEventListener('click', addFolder, false);
+  document.getElementById('editorButton').addEventListener('click', openEditor, false);
 
   (function buildBreadcrumbContent() {
     var path = location.pathname;

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -86,13 +86,13 @@
                             <span class="fa fa-files-o"></span> Copy
                           </button>
                           <button id="renameButton" type="button" class="toolbar-btn rename-button" title="Rename selected item(s)">
-                            <span class="fa fa-text-height"></span> Rename
+                            <span class="fa fa-edit"></span> Rename
                           </button>
                           <button id="deleteButton" type="button" class="toolbar-btn delete-button" title="Deleted selected item(s)">
                             <span class="fa fa-trash-o"></span> Delete
                           </button>
                           <button id="editorButton" type="button" class="toolbar-btn editor-button" title="Open selected file in editor">
-                            <span class="fa fa-edit"></span> Open as Text
+                            <span class="fa fa-file-text-o"></span> Open as Text
                           </button>
                         </div>
                       </div>

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -91,8 +91,8 @@
                           <button id="deleteButton" type="button" class="toolbar-btn delete-button" title="Deleted selected item(s)">
                             <span class="fa fa-trash-o"></span> Delete
                           </button>
-                          <button id="editorButton" type="button" class="btn btn-default editor-button" title="Open selected file in editor">
-                            <span class="fa fa-edit"></span> Text Editor
+                          <button id="editorButton" type="button" class="toolbar-btn editor-button" title="Open selected file in editor">
+                            <span class="fa fa-edit"></span> Open as Text
                           </button>
                         </div>
                       </div>

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -85,8 +85,11 @@
                           <button id="duplicateButton" type="button" class="toolbar-btn duplicate-button" title="Create a copy of the selected item(s)">
                             <span class="fa fa-files-o"></span> Copy
                           </button>
+                          <button id="editorButton" type="button" class="toolbar-btn editor-button" style="display: none" title="Open selected item(s) in editor">
+                            <span class="fa fa-edit"></span> Text Editor
+                          </button>
                           <button id="renameButton" type="button" class="toolbar-btn rename-button" title="Rename selected item(s)">
-                            <span class="fa fa-edit"></span> Rename
+                            <span class="fa fa-text-height"></span> Rename
                           </button>
                           <button id="deleteButton" type="button" class="toolbar-btn delete-button" title="Deleted selected item(s)">
                             <span class="fa fa-trash-o"></span> Delete

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -85,14 +85,14 @@
                           <button id="duplicateButton" type="button" class="toolbar-btn duplicate-button" title="Create a copy of the selected item(s)">
                             <span class="fa fa-files-o"></span> Copy
                           </button>
-                          <button id="editorButton" type="button" class="toolbar-btn editor-button" style="display: none" title="Open selected item(s) in editor">
-                            <span class="fa fa-edit"></span> Text Editor
-                          </button>
                           <button id="renameButton" type="button" class="toolbar-btn rename-button" title="Rename selected item(s)">
                             <span class="fa fa-text-height"></span> Rename
                           </button>
                           <button id="deleteButton" type="button" class="toolbar-btn delete-button" title="Deleted selected item(s)">
                             <span class="fa fa-trash-o"></span> Delete
+                          </button>
+                          <button id="editorButton" type="button" class="btn btn-default editor-button" title="Open selected file in editor">
+                            <span class="fa fa-edit"></span> Text Editor
                           </button>
                         </div>
                       </div>


### PR DESCRIPTION
This PR adds a button that appears when (exactly) one file is selected in the notebook list view, and opens a Jupyter editor for that file when clicked. Selecting no files, more than one file, or folders hides the button.

![image](https://cloud.githubusercontent.com/assets/1424661/20730409/d842e40e-b63a-11e6-826f-90fbac24f1d6.png)
