### PR TITLE
Fix ungit path

### DIFF
--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -240,7 +240,7 @@ function initializePage(dialog, saveFn) {
         path = path.substr('/notebooks'.length);
         path = path.substr(0, path.lastIndexOf('/'));
       }
-      path = encodeURIComponent('/content' + path);
+      path = '/content' + path;
       prefix = window.location.protocol + '//' + window.location.host;
 
       window.open(prefix + '/_proxy/8083/#/repository?path=' + path);


### PR DESCRIPTION
Ungit requires an unencoded path to open correctly.