### PR TITLE
Automatically close auth windows loaded with "referer=popup"

### DIFF
--- a/sources/web/datalab/auth.ts
+++ b/sources/web/datalab/auth.ts
@@ -196,7 +196,9 @@ function setOauth2Client(request: http.ServerRequest): void {
 
 function redirect(response: http.ServerResponse, referer: string) {
   if (referer == 'popup') {
-    // If auth is triggered from a pop-up window, close the window.
+    // Other frontends that connect to Datalab may choose to use a popup
+    // instead of a full redirect for auth.  Close the window if this came
+    // from a pop-up.
     response.writeHead(200, { 'Content-Type': 'text/html' });
     response.end(
         '<html><body onload="javascript:close()">Authorization succeeded. ' +

--- a/sources/web/datalab/auth.ts
+++ b/sources/web/datalab/auth.ts
@@ -194,6 +194,20 @@ function setOauth2Client(request: http.ServerRequest): void {
   }
 }
 
+function redirect(response: http.ServerResponse, referer: string) {
+  if (referer == 'popup') {
+    // If auth is triggered from a pop-up window, close the window.
+    response.writeHead(200, { 'Content-Type': 'text/html' });
+    response.end(
+        '<html><body onload="javascript:close()">Authorization succeeded. ' +
+        'This window should close automatically</body></html>');
+  } else {
+    response.statusCode = 302;
+    response.setHeader('Location', referer);
+    response.end();
+  }
+}
+
 export function handleAuthFlow(request: http.ServerRequest, response: http.ServerResponse,
     parsed_url: any, settings: any): void {
   var path = parsed_url.pathname;
@@ -233,9 +247,7 @@ export function handleAuthFlow(request: http.ServerRequest, response: http.Serve
           oauth2Client.setCredentials(tokens);
           // Push them to Jupyter and handle request.
           var email = persistCredentials(tokens);
-          response.statusCode = 302;
-          response.setHeader('Location', query.state);
-          response.end();
+          redirect(response, query.state);
         }
       });
     }
@@ -260,9 +272,7 @@ export function handleAuthFlow(request: http.ServerRequest, response: http.Serve
 
   // Return to referer.
   var referer = decodeURIComponent(query.referer);
-  response.statusCode = 302;
-  response.setHeader('Location', referer);
-  response.end();
+  redirect(response, referer);
 }
 
 export function init(settings: common.Settings) {


### PR DESCRIPTION
Provide a way to automatically close an auth window in case Datalab's /signin flow is loaded from a popup window.  Instead of referer=URL-TO-REDIRECT-TO, issue referer=popup.

PTAL @yebrahim @ojarjur @qimingj 