### PR TITLE
Some packages were installed twice during the build process

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -40,31 +40,31 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
 
 # Setup Python packages. Rebuilding numpy/scipy is expensive so we move this early
 # to reduce the chance that prior steps can cause changes requiring a rebuild.
-    pip install -U --no-cache-dir numpy==1.11.0 && \
-    pip install -U --no-cache-dir pandas==0.18.0 && \
-    pip install -U --no-cache-dir scipy==0.17.0 && \
+    pip install -U --no-cache-dir numpy==1.11.2 && \
+    pip install -U --no-cache-dir pandas==0.19.1 && \
+    pip install -U --no-cache-dir scipy==0.18.0 && \
     pip install -U --no-cache-dir scikit-learn==0.17.1 && \
     pip install -U --no-cache-dir sympy==0.7.6.1 && \
     pip install -U --no-cache-dir statsmodels==0.6.1 && \
 
-    pip install -U --no-cache-dir tornado==4.3 \
-                   --no-cache-dir pyzmq==15.2.0 \
+    pip install -U --no-cache-dir tornado==4.4.2 \
+                   --no-cache-dir pyzmq==16.0.2 \
                    --no-cache-dir jinja2==2.8 \
                    --no-cache-dir jsonschema==2.5.1 \
                    --no-cache-dir python-dateutil==2.5.0 \
-                   --no-cache-dir pytz==2015.4 \
+                   --no-cache-dir pytz==2016.7 \
                    --no-cache-dir pandocfilters==1.3.0 \
                    --no-cache-dir pygments==2.1.3 \
                    --no-cache-dir argparse==1.2.1 \
-                   --no-cache-dir mock==1.2.0 \
+                   --no-cache-dir mock==2.0.0 \
                    --no-cache-dir requests==2.9.1 \
                    --no-cache-dir oauth2client==2.0.2 \
                    --no-cache-dir httplib2==0.9.2 \
                    --no-cache-dir futures==3.0.5 && \
-    pip install -U --no-cache-dir matplotlib==1.5.1 && \
+    pip install -U --no-cache-dir matplotlib==1.5.3 && \
     pip install -U --no-cache-dir ggplot==0.6.8 && \
     pip install -U --no-cache-dir seaborn==0.7.0 && \
-    pip install -U --no-cache-dir notebook==4.2.0 && \
+    pip install -U --no-cache-dir notebook==4.2.3 && \
     pip install -U --no-cache-dir PyYAML==3.11 && \
     pip install -U --no-cache-dir six==1.9.0 && \
     pip install -U --no-cache-dir ipywidgets==5.2.2 && \


### PR DESCRIPTION
I've updated the package versions in `containers/base/Dockerfile` to reflect the actual package versions that exist in Datalab. The reason for this change is that several packages were being installed twice during the build process. The changes in this PR will help reduce the number of times that we see the following text in the build log:

```
  Found existing installation: <package>
    Uninstalling  <package>:
      Successfully uninstalled  <package>
Successfully installed <package>
```

Here are the package versions that are installed in Datalab after including the changes from this PR.
```
>>>import pip
>>>for dist in pip.get_installed_distributions():
>>>   print dist
pip 9.0.1
widgetsnbextension 1.2.6
wheel 0.29.0
wcwidth 0.1.7
uritemplate 0.6
traitlets 4.3.1
tornado 4.4.2
terminado 0.6
tensorflow 0.11.0rc0
sympy 0.7.6.1
statsmodels 0.6.1
six 1.10.0
singledispatch 3.4.0.3
simplejson 3.10.0
simplegeneric 0.8.1
setuptools 30.1.0
seaborn 0.7.0
scipy 0.18.0
scikit-learn 0.17.1
rsa 3.4.2
requests 2.9.1
pyzmq 16.0.2
PyYAML 3.11
pytz 2016.7
python-gflags 3.1.0
python-dateutil 2.5.0
pyparsing 2.1.10
Pygments 2.1.3
pyasn1 0.1.9
pyasn1-modules 0.0.8
ptyprocess 0.5.1
psutil 4.3.0
protorpc 0.11.1
protobuf 3.0.0
prompt-toolkit 1.0.9
ply 3.8
plotly 1.12.5
Pillow 3.4.1
pickleshare 0.7.4
pexpect 4.2.1
pbr 1.10.0
patsy 0.4.1
pathlib2 2.1.0
pandocfilters 1.3.0
pandas 0.19.1
pandas-profiling 1.3.0
oauth2client 2.0.2
numpy 1.11.2
notebook 4.2.3
nltk 3.2.1
nbformat 4.2.0
nbconvert 4.2.0
nb2kg 0.0.1.dev0
mock 2.0.0
mistune 0.7.3
matplotlib 1.5.3
MarkupSafe 0.23
jupyter-core 4.2.1
jupyter-client 4.4.0
jsonschema 2.5.1
Jinja2 2.8
ipywidgets 5.2.2
ipython 5.1.0
ipython-genutils 0.1.0
ipykernel 4.4.1
httplib2 0.9.2
grpcio 1.0.1
grpc-google-pubsub-v1 0.9.3
grpc-google-logging-v2 0.9.3
googleapis-common-protos 1.5.0
google-gax 0.13.0
google-cloud 0.19.0
google-cloud-dataflow 0.4.2
google-apitools 0.5.6
google-api-python-client 1.5.1
ggplot 0.6.8
gapic-google-pubsub-v1 0.9.3
gapic-google-logging-v2 0.9.3
futures 3.0.5
future 0.15.2
functools32 3.2.3.post2
funcsigs 1.0.2
enum34 1.1.6
entrypoints 0.2.2
dpkt 1.8.8
dill 0.2.5
decorator 4.0.10
datalab 0.1.1612032248
cycler 0.10.0
crcmod 1.7
configparser 3.5.0
cloudml 0.1.6a0
certifi 2016.9.26
bs4 0.0.1
brewer2mpl 1.4.1
beautifulsoup4 4.5.1
backports.shutil-get-terminal-size 1.0.0
backports-abc 0.5
avro 1.8.1
```