### PR TITLE
Initial command line surface for a Datalab management tool

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -81,7 +81,7 @@ def connection_flags(parser):
         dest='port',
         type=int,
         default=8081,
-        help='local port from which to forward traffic to Datalab')
+        help='local port on which Datalab is accessible')
     parser.add_argument(
         '--max-reconnects',
         dest='max_reconnects',

--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -111,19 +111,12 @@ def connection_flags(parser):
             'the log level for the SSH command.'
             '\n\n'
             'The default log level is "error".'))
-
-    browser_group = parser.add_mutually_exclusive_group()
-    browser_group.add_argument(
+    parser.add_argument(
         '--no-launch-browser',
-        dest='launch_browser',
-        action='store_false',
-        help='do not open a browser connected to Datalab')
-    browser_group.add_argument(
-        '--launch-browser',
-        dest='launch_browser',
+        dest='no_launch_browser',
         action='store_true',
-        default=True,
-        help='open a browser connected to Datalab')
+        default=False,
+        help='do not open a browser connected to Datalab')
 
     return
 
@@ -204,7 +197,7 @@ def connect(args, gcloud_compute):
     def on_ready():
         """Callback that handles a successful connection."""
         print('You can now connect to Datalab at ' + datalab_address)
-        if args.launch_browser:
+        if not args.no_launch_browser:
             try:
                 webbrowser.open(datalab_address)
             except webbrowser.Error as e:
@@ -273,7 +266,7 @@ def connect(args, gcloud_compute):
         print('Attempting to reconnect...')
         remaining_reconnects -= 1
         # Don't launch the browser on reconnect...
-        args.launch_browser = False
+        args.no_launch_browser = True
     return
 
 

--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -14,7 +14,6 @@
 
 """Methods for implementing the `datalab connect` command."""
 
-import argparse
 import subprocess
 import tempfile
 import threading
@@ -22,8 +21,7 @@ import urllib2
 import webbrowser
 
 
-description=(
-"""{0} {1} creates a persistent connection to a
+description = ("""{0} {1} creates a persistent connection to a
 Datalab instance running in a Google Compute Engine VM.
 
 This is a thin wrapper around the *ssh(1)* command that takes care
@@ -45,12 +43,10 @@ this command is running.
 """)
 
 
-examples=(
-"""
+examples = ("""
 To connect to 'example-instance' in zone 'us-central1-a', run:
 
-    $ {0} {1} example-instance --zone us-central1-a"""
-)
+    $ {0} {1} example-instance --zone us-central1-a""")
 
 
 def flags(parser):
@@ -64,6 +60,8 @@ def flags(parser):
         metavar='INSTANCE',
         help='name of the instance to which to connect')
     connection_flags(parser)
+    return
+
 
 def connection_flags(parser):
     """Add flags common to every connection-establishing subcommand.
@@ -200,7 +198,7 @@ def connect(args, gcloud_compute):
         health_check_thread.start()
         try:
             create_tunnel()
-        except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError:
             print('Connection broken')
         finally:
             cancelled_event.set()
@@ -211,7 +209,7 @@ def connect(args, gcloud_compute):
     while True:
         try:
             connect_and_check()
-        except KeyboardInterrupt as e:
+        except KeyboardInterrupt:
             return
         if remaining_reconnects == 0:
             return
@@ -237,14 +235,17 @@ def maybe_start(args, gcloud_compute, instance):
     if args.zone:
         get_cmd.extend(['--zone', args.zone])
         start_cmd.extend(['--zone', args.zone])
+    get_cmd.extend(['--format', 'value(status)', instance])
+    start_cmd.extend([instance])
     status = 'UNKNOWN'
     with tempfile.TemporaryFile() as tf:
-        gcloud_compute(args, get_cmd + ['--format', 'value(status)', instance], stdout=tf)
+        gcloud_compute(args, get_cmd, stdout=tf)
         tf.seek(0)
         status = tf.read().strip()
     if status != 'RUNNING':
-        print('Restarting the instance {0} with status {1}'.format(instance, status))
-        gcloud_compute(args, start_cmd + [instance])
+        print('Restarting the instance {0} with status {1}'.format(
+            instance, status))
+        gcloud_compute(args, start_cmd)
     return
 
 

--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -59,7 +59,7 @@ def flags(parser):
     """
     parser.add_argument(
         'instance',
-        metavar='INSTANCE',
+        metavar='NAME',
         help='name of the instance to which to connect')
     connection_flags(parser)
     return

--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -1,0 +1,263 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Methods for implementing the `datalab connect` command."""
+
+import argparse
+import subprocess
+import tempfile
+import threading
+import urllib2
+import webbrowser
+
+
+description=(
+"""{0} {1} creates a persistent connection to a
+Datalab instance running in a Google Compute Engine VM.
+
+This is a thin wrapper around the *ssh(1)* command that takes care
+of authentication and the translation of the instance name into an
+IP address.
+
+This command ensures that the user's public SSH key is present
+in the project's metadata. If the user does not have a public
+SSH key, one is generated using *ssh-keygen(1)* (if the --quiet
+flag is given, the generated key will have an empty passphrase).
+
+Once the connection is established, this command opens a browser
+window pointing at Datalab. To disable the browser opening, add
+the --no-launch-browser flag.
+
+This command will attempt to re-establish the connection if it
+gets dropped. However, that connection will only exist while
+this command is running.
+""")
+
+
+examples=(
+"""
+To connect to 'example-instance' in zone 'us-central1-a', run:
+
+    $ {0} {1} example-instance --zone us-central1-a"""
+)
+
+
+def flags(parser):
+    """Add command line flags for the `connect` subcommand.
+
+    Args:
+      parser: The argparse parser to which to add the flags.
+    """
+    parser.add_argument(
+        'instance',
+        metavar='INSTANCE',
+        help='name of the instance to which to connect')
+    connection_flags(parser)
+
+def connection_flags(parser):
+    """Add flags common to every connection-establishing subcommand.
+
+    Args:
+      parser: The argparse parser to which to add the flags.
+    """
+    parser.add_argument(
+        '--quiet',
+        dest='quiet',
+        action='store_true',
+        help='do not issue any interactive prompts')
+    parser.add_argument(
+        '--port',
+        dest='port',
+        type=int,
+        default=8081,
+        help='local port from which to forward traffic to Datalab')
+    parser.add_argument(
+        '--max-reconnects',
+        dest='max_reconnects',
+        type=int,
+        default=-1,
+        help=(
+            'maximum number of times to reconnect.'
+            '\n\n'
+            'A negative value means no limit.'))
+
+    browser_group = parser.add_mutually_exclusive_group()
+    browser_group.add_argument(
+        '--no-launch-browser',
+        dest='launch_browser',
+        action='store_false',
+        help='do not open a browser connected to Datalab')
+    browser_group.add_argument(
+        '--launch-browser',
+        dest='launch_browser',
+        action='store_true',
+        default=True,
+        help='open a browser connected to Datalab')
+
+    return
+
+
+def connect(args, gcloud_compute):
+    """Create a persistent connection to a Datalab instance.
+
+    Args:
+      args: The Namespace object constructed by argparse
+      gcloud_compute: A function that can be called to invoke `gcloud compute`
+    """
+    instance = args.instance
+    print('Connecting to {0}'.format(instance))
+
+    datalab_address = 'http://localhost:{0}/'.format(str(args.port))
+
+    def create_tunnel():
+        """Create an SSH tunnel to the Datalab instance.
+
+        This method blocks for as long as the connection is open.
+
+        Raises:
+          KeyboardInterrupt: When the end user kills the connection
+          subprocess.CalledProcessError: If the connection dies on its own
+        """
+        cmd = ['ssh']
+        if args.quiet:
+            cmd.append('--quiet')
+        if args.zone:
+            cmd.extend(['--zone', args.zone])
+        port_mapping = 'localhost:' + str(args.port) + ':localhost:8080'
+        cmd.extend([
+            '--ssh-flag=-4',
+            '--ssh-flag=-o',
+            '--ssh-flag=LogLevel=error',
+            '--ssh-flag=-N',
+            '--ssh-flag=-L',
+            '--ssh-flag=' + port_mapping])
+        cmd.append('datalab@{0}'.format(instance))
+        with tempfile.TemporaryFile() as tf:
+            gcloud_compute(args, cmd, stdout=tf, stderr=tf)
+        return
+
+    def on_ready():
+        """Callback that handles a successful connection."""
+        print('You can now connect to Datalab at ' + datalab_address)
+        if args.launch_browser:
+            try:
+                webbrowser.open(datalab_address)
+            except webbrowser.Error as e:
+                print('Unable to open the webbrowser: ' + str(e))
+        return
+
+    def health_check(cancelled_event):
+        """Check if the Datalab instance is reachable via the connection.
+
+        After the instance is reachable, the `on_ready` method is called.
+
+        This method is meant to be suitable for running in a separate thread,
+        and takes an event argument to indicate when that thread should exit.
+
+        Args:
+          cancelled_event: A threading.Event instance that indicates we should
+            give up on the instance becoming reachable.
+        """
+        health_url = '{0}_info/'.format(datalab_address)
+        healthy = False
+        print('Waiting for Datalab to be reachable at ' + datalab_address)
+        while not cancelled_event.is_set():
+            try:
+                health_resp = urllib2.urlopen(health_url)
+                if health_resp.getcode() == 200:
+                    healthy = True
+                    break
+            except:
+                continue
+
+        if healthy:
+            on_ready()
+        return
+
+    def connect_and_check():
+        """Create a connection to Datalab and notify the user when ready.
+
+        This method blocks for as long as the connection is open.
+
+        Raises:
+          KeyboardInterrupt: If the user kills the connection.
+        """
+        cancelled_event = threading.Event()
+        health_check_thread = threading.Thread(
+            target=health_check,
+            args=[cancelled_event])
+        health_check_thread.start()
+        try:
+            create_tunnel()
+        except subprocess.CalledProcessError as e:
+            print('Connection broken')
+        finally:
+            cancelled_event.set()
+            health_check_thread.join()
+        return
+
+    remaining_reconnects = args.max_reconnects
+    while True:
+        try:
+            connect_and_check()
+        except KeyboardInterrupt as e:
+            return
+        if remaining_reconnects == 0:
+            return
+        print('Attempting to reconnect...')
+        remaining_reconnects -= 1
+        # Don't launch the browser on reconnect...
+        args.launch_browser = False
+    return
+
+
+def maybe_start(args, gcloud_compute, instance):
+    """Start the given Google Compute Engine VM if it is not running.
+
+    Args:
+      args: The Namespace instance returned by argparse
+      gcloud_compute: Function that can be used to invoke `gcloud compute`
+      instance: The name of the instance to check and (possibly) start
+    Raises:
+      subprocess.CalledProcessError: If one of the `gcloud` calls fails
+    """
+    get_cmd = ['instances', 'describe']
+    start_cmd = ['instances', 'start']
+    if args.zone:
+        get_cmd.extend(['--zone', args.zone])
+        start_cmd.extend(['--zone', args.zone])
+    status = 'UNKNOWN'
+    with tempfile.TemporaryFile() as tf:
+        gcloud_compute(args, get_cmd + ['--format', 'value(status)', instance], stdout=tf)
+        tf.seek(0)
+        status = tf.read().strip()
+    if status != 'RUNNING':
+        print('Restarting the instance {0} with status {1}'.format(instance, status))
+        gcloud_compute(args, start_cmd + [instance])
+    return
+
+
+def run(args, gcloud_compute):
+    """Implementation of the `datalab connect` subcommand.
+
+    Args:
+      args: The Namespace instance returned by argparse
+      gcloud_compute: Function that can be used to invoke `gcloud compute`
+    Raises:
+      subprocess.CalledProcessError: If a nested `gcloud` calls fails
+    """
+    instance = args.instance
+    maybe_start(args, gcloud_compute, instance)
+    connect(args, gcloud_compute)
+    return

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -72,7 +72,7 @@ metadata:
 spec:
   containers:
     - name: datalab
-      image: gcr.io/cloud-datalab/datalab:local
+      image: {0}
       command: ['/datalab/run.sh']
       imagePullPolicy: IfNotPresent
       ports:
@@ -120,7 +120,16 @@ def flags(parser):
         metavar='NAME',
         help='a name for the newly created instance')
     parser.add_argument(
-        '--disk_name',
+        '--image-name',
+        dest='image_name',
+        default='gcr.io/cloud-datalab/datalab:local',
+        help=(
+            'name of the Datalab image to run.'
+            '\n\n'
+            'If not specified, this defaults to the most recently\n'
+            'published image.'))
+    parser.add_argument(
+        '--disk-name',
         dest='disk_name',
         default=None,
         help=(
@@ -129,7 +138,7 @@ def flags(parser):
             'If not specified, this defaults to having a name based\n'
             'on the instance name.'))
     parser.add_argument(
-        '--disk_size_gb',
+        '--disk-size-gb',
         type=int,
         dest='disk_size_gb',
         default=_DATALAB_DEFAULT_DISK_SIZE_GB,
@@ -353,7 +362,8 @@ def run(args, gcloud_compute):
         cmd.extend(['--zone', args.zone])
     metadata = format_metadata({
         'startup-script': _DATALAB_STARTUP_SCRIPT,
-        'google-container-manifest': _DATALAB_CONTAINER_SPEC,
+        'google-container-manifest': (
+            _DATALAB_CONTAINER_SPEC.format(args.image_name)),
     })
     disk_cfg = (
         'auto-delete=no,boot=no,device-name=datalab-pd,mode=rw,name=' +

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -1,0 +1,375 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Methods for implementing the `datalab create` command."""
+
+import argparse
+import subprocess
+import tempfile
+
+import connect
+
+
+description=(
+"""{0} {1} creates a new Datalab instances running in a Google
+Compute Engine VM.
+
+This command also creates the 'datalab-network' network if necessary.
+
+By default, the command creates a persistent connection to the newly
+created instance. You can disable that behavior by passing in the
+'--no-connect' flag."""
+)
+
+
+_DATALAB_NETWORK = 'datalab-network'
+_DATALAB_NETWORK_DESCRIPTION = 'Network for Google Cloud Datalab instances'
+
+_DATALAB_FIREWALL_RULE = 'datalab-network-allow-ssh'
+_DATALAB_FIREWALL_RULE_DESCRIPTION = 'Allow SSH access to Datalab instances'
+
+_DATALAB_DEFAULT_DISK_SIZE_GB = 200
+_DATALAB_DISK_DESCRIPTION = (
+    'Persistent disk for a Google Cloud Datalab instance')
+
+_DATALAB_STARTUP_SCRIPT = """#!/bin/bash
+
+PERSISTENT_DISK_DEV="/dev/disk/by-id/google-datalab-pd"
+MOUNT_DIR="/mnt/disks/datalab-pd"
+MOUNT_CMD="mount -o discard,defaults ${PERSISTENT_DISK_DEV} ${MOUNT_DIR}"
+
+format_disk() {
+  mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0,discard ${PERSISTENT_DISK_DEV}
+  ${MOUNT_CMD}
+}
+
+mount_disk() {
+  mkdir -p "${MOUNT_DIR}"
+  ${MOUNT_CMD} || format_disk
+  mount -o discard,defaults /dev/disk/by-id/google-datalab-pd /mnt/disks/datalab-pd || format_disk
+  chmod a+w "${MOUNT_DIR}"
+}
+
+mount_disk
+"""
+
+_DATALAB_CONTAINER_SPEC = """
+apiVersion: v1
+kind: Pod
+metadata:
+  name: 'datalab-server'
+spec:
+  containers:
+    - name: datalab
+      image: gcr.io/cloud-datalab/datalab:local
+      command: ['/datalab/run.sh']
+      imagePullPolicy: IfNotPresent
+      ports:
+        - containerPort: 8080
+          hostPort: 8080
+          hostIP: 127.0.0.1
+      env:
+        - name: DATALAB_ENV
+          value: GCE
+      volumeMounts:
+        - name: home
+          mountPath: /content
+    - name: logger
+      image: gcr.io/google_containers/fluentd-gcp:1.18
+      env:
+        - name: FLUENTD_ARGS
+          value: -q
+      volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+  volumes:
+    - name: home
+      hostPath:
+        path: /mnt/disks/datalab-pd
+    - name: varlog
+      hostPath:
+        path: /var/log
+    - name: varlibdockercontainers
+      hostPath:
+        path: /var/lib/docker/containers
+"""
+
+
+def flags(parser):
+    """Add command line flags for the `create` subcommand.
+
+    Args:
+      parser: The argparse parser to which to add the flags.
+    """
+    parser.add_argument(
+        'instance',
+        metavar='INSTANCE',
+        help='a name for the newly created instance')
+    parser.add_argument(
+        '--disk_name',
+        dest='disk_name',
+        default=None,
+        help=(
+            'name of the persistent disk used to store notebooks.'
+            '\n\n'
+            'If not specified, this defaults to having a name based\n'
+            'on the instance name.'))
+    parser.add_argument(
+        '--disk_size_gb',
+        type=int,
+        dest='disk_size_gb',
+        default=_DATALAB_DEFAULT_DISK_SIZE_GB,
+        help='size of the persistent disk in GB.')
+
+    connect_group = parser.add_mutually_exclusive_group()
+    connect_group.add_argument(
+        '--no-connect',
+        dest='connect',
+        action='store_false',
+        help='do not connect to the newly created instance')
+    connect_group.add_argument(
+        '--connect',
+        dest='connect',
+        default=True,
+        action='store_true',
+        help='connect to the newly created instance')
+
+    connect.connection_flags(parser)
+    return
+
+
+def call_gcloud_quietly(args, gcloud_compute, cmd):
+    """Call `gcloud` and silence any output unless it fails.
+
+    Normally, the `gcloud` command line tool can output a lot of
+    messages that are relevant to users in general, but may not
+    be relevant to the way a Datalab instance is created.
+
+    For example, creating a persistent disk will result in a
+    message that the disk needs to be formatted before it can
+    be used. However, the instance we create formats the disk
+    if necessary, so that message is erroneous in our case.
+
+    These messages are output regardless of the `--quiet` flag.
+
+    This method allows us to avoid any confusion from those
+    messages by redirecting them to a temporary file.
+
+    In the case of an error in the `gcloud` invocation, we
+    still print the messages by reading from the temporary
+    file and printing its contents.
+
+    Args:
+      args: The Namespace returned by argparse
+      gcloud_compute: Function that can be used for invoking `gcloud compute`
+      cmd: The subcommand to run
+    Raises:
+      subprocess.CalledProcessError: If the `gcloud` command fails
+    """
+    with tempfile.TemporaryFile() as tf:
+        try:
+            gcloud_compute(args, cmd, stdout=tf, stderr=tf)
+        except subprocess.CalledProcessError:
+            tf.seek(0)
+            print(tf.read())
+            raise
+    return
+
+
+def create_network(args, gcloud_compute):
+    """Create the `datalab-network` network.
+
+    Args:
+      args: The Namespace returned by argparse
+      gcloud_compute: Function that can be used for invoking `gcloud compute`
+    Raises:
+      subprocess.CalledProcessError: If the `gcloud` command fails
+    """
+    print('Creating the network {0}'.format(_DATALAB_NETWORK))
+    create_cmd = [
+        'networks', 'create', '--quiet', _DATALAB_NETWORK,
+        '--description', _DATALAB_NETWORK_DESCRIPTION]
+    call_gcloud_quietly(args, gcloud_compute, create_cmd)
+    return
+
+
+def ensure_network_exists(args, gcloud_compute):
+    """Create the `datalab-network` network if it does not already exist.
+
+    Args:
+      args: The Namespace returned by argparse
+      gcloud_compute: Function that can be used for invoking `gcloud compute`
+    Raises:
+      subprocess.CalledProcessError: If the `gcloud` command fails
+    """
+    get_cmd = ['networks', 'describe', '--format', 'value(name)', _DATALAB_NETWORK]
+    try:
+        with tempfile.TemporaryFile() as tf:
+            gcloud_compute(args, get_cmd, stdout=tf, stderr=tf)
+            return
+    except subprocess.CalledProcessError:
+        create_network(args, gcloud_compute)
+    return
+
+
+def create_firewall_rule(args, gcloud_compute):
+    """Create the `datalab-network-allow-ssh` firewall rule.
+
+    Args:
+      args: The Namespace returned by argparse
+      gcloud_compute: Function that can be used for invoking `gcloud compute`
+    Raises:
+      subprocess.CalledProcessError: If the `gcloud` command fails
+    """
+    print('Creating the firewall rule {0}'.format(_DATALAB_FIREWALL_RULE))
+    create_cmd = [
+        'firewall-rules', 'create', '--quiet', _DATALAB_FIREWALL_RULE,
+        '--allow', 'tcp:22',
+        '--network', _DATALAB_NETWORK,
+        '--description', _DATALAB_FIREWALL_RULE_DESCRIPTION]
+    call_gcloud_quietly(args, gcloud_compute, create_cmd)
+    return
+
+
+def ensure_firewall_rule_exists(args, gcloud_compute):
+    """Create the `datalab-network-allow-ssh` firewall rule if it necessary.
+
+    Args:
+      args: The Namespace returned by argparse
+      gcloud_compute: Function that can be used for invoking `gcloud compute`
+    Raises:
+      subprocess.CalledProcessError: If the `gcloud` command fails
+    """
+    get_cmd = [
+        'firewall-rules', 'describe', _DATALAB_FIREWALL_RULE,
+        '--format', 'value(name)']
+    try:
+        with tempfile.TemporaryFile() as tf:
+            gcloud_compute(args, get_cmd, stdout=tf, stderr=tf)
+            return
+    except subprocess.CalledProcessError:
+        create_firewall_rule(args, gcloud_compute)
+    return
+
+
+def create_disk(args, gcloud_compute, disk_name):
+    """Create the user's persistent disk.
+
+    Args:
+      args: The Namespace returned by argparse
+      gcloud_compute: Function that can be used for invoking `gcloud compute`
+      disk_name: The name of the persistent disk to create
+    Raises:
+      subprocess.CalledProcessError: If the `gcloud` command fails
+    """
+    print('Creating the disk {0}'.format(disk_name))
+    create_cmd = ['disks', 'create', '--quiet']
+    if args.zone:
+        create_cmd.extend(['--zone', args.zone])
+    create_cmd.extend([
+        '--size', str(args.disk_size_gb) + 'GB',
+        '--description', _DATALAB_DISK_DESCRIPTION,
+        disk_name])
+    call_gcloud_quietly(args, gcloud_compute, create_cmd)
+    return
+
+
+def ensure_disk_exists(args, gcloud_compute, disk_name):
+    """Create the given persistent disk if it does not already exist.
+
+    Args:
+      args: The Namespace returned by argparse
+      gcloud_compute: Function that can be used for invoking `gcloud compute`
+      disk_name: The name of the persistent disk
+    Raises:
+      subprocess.CalledProcessError: If the `gcloud` command fails
+    """
+    get_cmd = [
+        'disks', 'describe', disk_name, '--format', 'value(name)']
+    try:
+        with tempfile.TemporaryFile() as tf:
+            gcloud_compute(args, get_cmd, stdout=tf, stderr=tf)
+            return
+    except subprocess.CalledProcessError as e:
+        create_disk(args, gcloud_compute, disk_name)
+    return
+
+
+def format_metadata(metadata_dict):
+    """Format a dictionary of metadata values for use on a command line.
+
+    The `gcloud` command line tool requires that all metadata values for
+    a VM to be provided in a signle flag.
+
+    That, in turn, means the separator used to distinguish multiple entries
+    can not occur in any of the given metadata values.
+
+    The default separator used is '=', which does occur in our metadata
+    values, so we have to override the default separator with a different
+    one.
+
+    In this case, we chose '~~~' as the separator.
+
+    Args:
+      metadata_dict: A dictionay mapping metadata keys to values
+    Returns:
+      A string suitable to passing to `gcloud` on the command line
+    """
+    separator = '~~~'
+    metadata_pairs = [
+        '{0}={1}'.format(k, metadata_dict[k]) for k in metadata_dict]
+    metadata_str = separator.join(metadata_pairs)
+    return '^{0}^{1}'.format(separator, metadata_str)
+
+
+def run(args, gcloud_compute):
+    """Implementation of the `datalab create` subcommand.
+
+    Args:
+      args: The Namespace instance returned by argparse
+      gcloud_compute: Function that can be used to invoke `gcloud compute`
+    Raises:
+      subprocess.CalledProcessError: If a nested `gcloud` calls fails
+    """
+    ensure_network_exists(args, gcloud_compute)
+    ensure_firewall_rule_exists(args, gcloud_compute)
+
+    instance = args.instance
+    disk_name = args.disk_name or '{0}-pd'.format(instance)
+    ensure_disk_exists(args, gcloud_compute, disk_name)
+
+    print('Creating the instance {0}'.format(instance))
+    cmd = ['instances', 'create']
+    if args.zone:
+        cmd.extend(['--zone', args.zone])
+    metadata = format_metadata({
+        'startup-script': _DATALAB_STARTUP_SCRIPT,
+        'google-container-manifest': _DATALAB_CONTAINER_SPEC,
+    })
+    cmd.extend([
+        '--network', _DATALAB_NETWORK,
+        '--image-family', 'container-vm',
+        '--image-project', 'google-containers',
+        '--metadata', metadata,
+        '--tags', 'datalab',
+        '--disk', 'auto-delete=no,boot=no,device-name=datalab-pd,mode=rw,name=' + disk_name,
+        instance])
+    gcloud_compute(args, cmd)
+
+    if args.connect:
+        connect.connect(args, gcloud_compute)
+    return

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -117,7 +117,7 @@ def flags(parser):
     """
     parser.add_argument(
         'instance',
-        metavar='INSTANCE',
+        metavar='NAME',
         help='a name for the newly created instance')
     parser.add_argument(
         '--disk_name',

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -135,18 +135,12 @@ def flags(parser):
         default=_DATALAB_DEFAULT_DISK_SIZE_GB,
         help='size of the persistent disk in GB.')
 
-    connect_group = parser.add_mutually_exclusive_group()
-    connect_group.add_argument(
+    parser.add_argument(
         '--no-connect',
-        dest='connect',
-        action='store_false',
-        help='do not connect to the newly created instance')
-    connect_group.add_argument(
-        '--connect',
-        dest='connect',
-        default=True,
+        dest='no_connect',
         action='store_true',
-        help='connect to the newly created instance')
+        default=False,
+        help='do not connect to the newly created instance')
 
     connect.connection_flags(parser)
     return
@@ -375,6 +369,6 @@ def run(args, gcloud_compute):
         instance])
     gcloud_compute(args, cmd)
 
-    if args.connect:
+    if not args.no_connect:
         connect.connect(args, gcloud_compute)
     return

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -371,6 +371,7 @@ def run(args, gcloud_compute):
         '--metadata', metadata,
         '--tags', 'datalab',
         '--disk', disk_cfg,
+        '--scopes', 'cloud-platform',
         instance])
     gcloud_compute(args, cmd)
 

--- a/tools/cli/commands/delete.py
+++ b/tools/cli/commands/delete.py
@@ -14,11 +14,8 @@
 
 """Methods for implementing the `datalab delete` command."""
 
-import argparse
 
-
-description=(
-"""{0} {1} deletes the given Datalab instance's
+description = ("""{0} {1} deletes the given Datalab instance's
 Google Compute Engine VM.
 
 By default, the persistent disk's auto-delete configuration determines
@@ -29,20 +26,15 @@ If you wish to override that setting, you can pass in one of either the
 
 For more information on disk auto-deletion, see
 https://cloud.google.com/compute/docs/disks/persistent-disks#updateautodelete
-"""
-)
+""")
 
 
-_DELETE_DISK_HELP=(
-"""Whether or not to delete the instance's persistent disk
-regardless of the disks' auto-delete configuration."""
-)
+_DELETE_DISK_HELP = ("""Whether or not to delete the instance's persistent disk
+regardless of the disks' auto-delete configuration.""")
 
 
-_KEEP_DISK_HELP=(
-"""Whether or not to keep the instance's persistent disk
-regardless of the disks' auto-delete configuration."""
-)
+_KEEP_DISK_HELP = ("""Whether or not to keep the instance's persistent disk
+regardless of the disks' auto-delete configuration.""")
 
 
 def flags(parser):

--- a/tools/cli/commands/delete.py
+++ b/tools/cli/commands/delete.py
@@ -45,7 +45,7 @@ def flags(parser):
     """
     parser.add_argument(
         'instance',
-        metavar='INSTANCE',
+        metavar='NAME',
         help='name of the instance to delete')
 
     auto_delete_override = parser.add_mutually_exclusive_group()

--- a/tools/cli/commands/delete.py
+++ b/tools/cli/commands/delete.py
@@ -1,0 +1,92 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Methods for implementing the `datalab delete` command."""
+
+import argparse
+
+
+description=(
+"""{0} {1} deletes the given Datalab instance's
+Google Compute Engine VM.
+
+By default, the persistent disk's auto-delete configuration determines
+whether or not that disk is also deleted.
+
+If you wish to override that setting, you can pass in one of either the
+`--delete-disk` flag or the `--keep-disk` flag.
+
+For more information on disk auto-deletion, see
+https://cloud.google.com/compute/docs/disks/persistent-disks#updateautodelete
+"""
+)
+
+
+_DELETE_DISK_HELP=(
+"""Whether or not to delete the instance's persistent disk
+regardless of the disks' auto-delete configuration."""
+)
+
+
+_KEEP_DISK_HELP=(
+"""Whether or not to keep the instance's persistent disk
+regardless of the disks' auto-delete configuration."""
+)
+
+
+def flags(parser):
+    """Add command line flags for the `delete` subcommand.
+
+    Args:
+      parser: The argparse parser to which to add the flags.
+    """
+    parser.add_argument(
+        'instance',
+        metavar='INSTANCE',
+        help='name of the instance to delete')
+
+    auto_delete_override = parser.add_mutually_exclusive_group()
+    auto_delete_override.add_argument(
+        '--delete-disk',
+        dest='delete_disk',
+        action='store_true',
+        help=_DELETE_DISK_HELP)
+    auto_delete_override.add_argument(
+        '--keep-disk',
+        dest='keep_disk',
+        action='store_true',
+        help=_KEEP_DISK_HELP)
+    return
+
+
+def run(args, gcloud_compute):
+    """Implementation of the `datalab delete` subcommand.
+
+    Args:
+      args: The Namespace instance returned by argparse
+      gcloud_compute: Function that can be used to invoke `gcloud compute`
+    Raises:
+      subprocess.CalledProcessError: If a nested `gcloud` calls fails
+    """
+    instance = args.instance
+    print('Deleting {0}'.format(instance))
+    base_cmd = ['instances', 'delete']
+    if args.zone:
+        base_cmd.extend(['--zone', args.zone])
+    if args.delete_disk:
+        base_cmd.extend(['--delete-disks', 'data'])
+    elif args.keep_disk:
+        base_cmd.extend(['--keep-disks', 'data'])
+    gcloud_compute(args, base_cmd + [instance])
+    return

--- a/tools/cli/commands/list.py
+++ b/tools/cli/commands/list.py
@@ -1,0 +1,111 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Methods for implementing the `datalab list` command."""
+
+import argparse
+
+
+_FILTER_HELP=(
+"""Apply a Boolean filter EXPRESSION to each resource item
+to be listed.
+
+If the expression evaluates True then that item is listed.
+For more details run `gcloud topic filters`."""
+)
+
+
+_ZONES_HELP=(
+"""List of zones to which to limit the resulting list."""
+)
+
+
+description=(
+"""{0} {1} displays the Datalab instances running in Google
+Compute Engine VM's in a project.
+
+By default, instances from all zones are listed. The results
+can be narrowed down by providing the --zones flag."""
+)
+
+
+examples=("""
+To list all of the available Datalab instances in a project:
+
+    $ {0} {1}
+
+To only list the Datalab instances in the zones
+'us-central1-a' and  'us-central1-b':
+
+    $ {0} {1} --zones us-central1-a,us-central1-b
+
+To only list the Datalab instances that are currently running:
+
+    $ {0} {1} --filter 'status=RUNNING'
+"""
+)
+
+
+def flags(parser):
+    """Add command line flags for the `list` subcommand.
+
+    Args:
+      parser: The argparse parser to which to add the flags.
+    """
+    parser.add_argument(
+        '--filter',
+        dest='filter',
+        default=None,
+        help=_FILTER_HELP)
+    parser.add_argument(
+        '--zones',
+        dest='zones',
+        nargs='*',
+        default=[],
+        help=_ZONES_HELP)
+    return
+
+
+def _filter(args):
+    """Construct the value for the '--filter' flag to gcloud.
+
+    Args:
+      args: The Namespace instance returned by argparse
+    Returns:
+      A string suitable for passing to the `gcloud` command
+    """
+    base_expr = 'labels.{0}=\'\''.format('datalab')
+    if args.filter:
+      return '({0}) ({1})'.format(base_expr, args.filter)
+    else:
+      return base_expr
+
+
+def run(args, gcloud_compute):
+    """Implementation of the `datalab list` subcommand.
+
+    Args:
+      args: The Namespace instance returned by argparse
+      gcloud_compute: Function that can be used to invoke `gcloud compute`
+    Raises:
+      subprocess.CalledProcessError: If a nested `gcloud` calls fails
+    """
+    filter_expr = _filter(args)
+    base_cmd = ['instances', 'list']
+    zones = args.zones if args.zones else []
+    if args.zone:
+        zones.append(args.zone)
+    if zones:
+        base_cmd.extend(['--zones'] + zones)
+    gcloud_compute(args, base_cmd + ['--filter', filter_expr], api='beta')

--- a/tools/cli/commands/list.py
+++ b/tools/cli/commands/list.py
@@ -14,33 +14,25 @@
 
 """Methods for implementing the `datalab list` command."""
 
-import argparse
 
-
-_FILTER_HELP=(
-"""Apply a Boolean filter EXPRESSION to each resource item
+_FILTER_HELP = ("""Apply a Boolean filter EXPRESSION to each resource item
 to be listed.
 
 If the expression evaluates True then that item is listed.
-For more details run `gcloud topic filters`."""
-)
+For more details run `gcloud topic filters`.""")
 
 
-_ZONES_HELP=(
-"""List of zones to which to limit the resulting list."""
-)
+_ZONES_HELP = """List of zones to which to limit the resulting list."""
 
 
-description=(
-"""{0} {1} displays the Datalab instances running in Google
+description = ("""{0} {1} displays the Datalab instances running in Google
 Compute Engine VM's in a project.
 
 By default, instances from all zones are listed. The results
-can be narrowed down by providing the --zones flag."""
-)
+can be narrowed down by providing the --zones flag.""")
 
 
-examples=("""
+examples = ("""
 To list all of the available Datalab instances in a project:
 
     $ {0} {1}
@@ -53,8 +45,7 @@ To only list the Datalab instances in the zones
 To only list the Datalab instances that are currently running:
 
     $ {0} {1} --filter 'status=RUNNING'
-"""
-)
+""")
 
 
 def flags(parser):
@@ -87,9 +78,9 @@ def _filter(args):
     """
     base_expr = 'labels.{0}=\'\''.format('datalab')
     if args.filter:
-      return '({0}) ({1})'.format(base_expr, args.filter)
+        return '({0}) ({1})'.format(base_expr, args.filter)
     else:
-      return base_expr
+        return base_expr
 
 
 def run(args, gcloud_compute):

--- a/tools/cli/commands/stop.py
+++ b/tools/cli/commands/stop.py
@@ -14,13 +14,9 @@
 
 """Methods for implementing the `datalab stop` command."""
 
-import argparse
 
-
-description=(
-"""{0} {1} stops the given Datalab instance's
-Google Compute Engine VM."""
-)
+description = ("""{0} {1} stops the given Datalab instance's
+Google Compute Engine VM.""")
 
 
 def flags(parser):

--- a/tools/cli/commands/stop.py
+++ b/tools/cli/commands/stop.py
@@ -27,7 +27,7 @@ def flags(parser):
     """
     parser.add_argument(
         'instance',
-        metavar='INSTANCE',
+        metavar='NAME',
         help='name of the instance to stop')
     return
 

--- a/tools/cli/commands/stop.py
+++ b/tools/cli/commands/stop.py
@@ -1,0 +1,54 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Methods for implementing the `datalab stop` command."""
+
+import argparse
+
+
+description=(
+"""{0} {1} stops the given Datalab instance's
+Google Compute Engine VM."""
+)
+
+
+def flags(parser):
+    """Add command line flags for the `stop` subcommand.
+
+    Args:
+      parser: The argparse parser to which to add the flags.
+    """
+    parser.add_argument(
+        'instance',
+        metavar='INSTANCE',
+        help='name of the instance to stop')
+    return
+
+
+def run(args, gcloud_compute):
+    """Implementation of the `datalab stop` subcommand.
+
+    Args:
+      args: The Namespace instance returned by argparse
+      gcloud_compute: Function that can be used to invoke `gcloud compute`
+    Raises:
+      subprocess.CalledProcessError: If a nested `gcloud` calls fails
+    """
+    instance = args.instance
+    print('Stopping {0}'.format(instance))
+    base_cmd = ['instances', 'stop']
+    if args.zone:
+        base_cmd.extend(['--zone', args.zone])
+    gcloud_compute(args, base_cmd + [instance])
+    return

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python
+
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Command line tool for administering instances of Datalab
+
+This tool is specific to the use case of running in the Google Cloud Platform.
+"""
+
+from commands import create, connect, list, stop, delete
+
+import argparse
+import subprocess
+import sys
+
+
+_SUBCOMMANDS = {
+    'create': {
+        'help': 'Create and connect to a new Datalab instance',
+        'description': create.description,
+        'flags': create.flags,
+        'run': create.run,
+        'require-zone': True,
+    },
+    'connect': {
+        'help': 'Connect to an existing Datalab instance',
+        'description': connect.description,
+        'flags': connect.flags,
+        'run': connect.run,
+        'require-zone': True,
+    },
+    'list': {
+        'help': 'List the existing Datalab instances in a project',
+        'description': list.description,
+        'examples': list.examples,
+        'flags': list.flags,
+        'run': list.run,
+        'require-zone': False,
+    },
+    'stop': {
+        'help': 'Stop an existing Datalab instance',
+        'description': stop.description,
+        'flags': stop.flags,
+        'run': stop.run,
+        'require-zone': True,
+    },
+    'delete': {
+        'help': 'Delete an existing Datalab instance',
+        'description': delete.description,
+        'flags': delete.flags,
+        'run': delete.run,
+        'require-zone': True,
+    },
+}
+
+
+_PROJECT_HELP = (
+"""The Google Cloud Platform project name to use
+for this invocation.
+
+If omitted then the current project is assumed.""")
+
+
+_ZONE_HELP = (
+"""The zone containing the instance. If not specified,
+you may be prompted to select a zone.
+
+To avoid prompting when this flag is omitted, you can
+set the compute/zone property:
+
+    $ gcloud config set compute/zone ZONE
+
+A list of zones can be fetched by running:
+
+    $ gcloud compute zones list
+
+To unset the property, run:
+
+    $ gcloud config unset compute/zone
+
+Alternatively, the zone can be stored in the
+environment variable CLOUDSDK_COMPUTE_ZONE.
+""")
+
+
+def gcloud_compute(args, cmd, api='', stdin=None, stdout=None, stderr=None):
+    """Run the given subcommand of `gcloud compute`
+
+    Args:
+      args: The Namespace instance returned by argparse
+      cmd: The subcommand of `gcloud compute` to run
+      api: The optional API version to use (e.g. 'alpha', 'beta', etc)
+      stdin: The 'stdin' argument for the subprocess call
+      stdout: The 'stdout' argument for the subprocess call
+      stderr: The 'stderr' argument for the subprocess call
+    Raises:
+      KeyboardInterrupt: If the user kills the command
+      subprocess.CalledProcessError: If the command dies on its own
+    """
+    base_cmd = ['gcloud']
+    if api:
+        base_cmd.append(api)
+    base_cmd.append('compute')
+    if args.project:
+        base_cmd.extend(['--project', args.project])
+    cmd = base_cmd + cmd
+    return subprocess.check_call(cmd, stdin=stdin, stdout=stdout, stderr=stderr)
+
+
+def run():
+    """Run the command line tool."""
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument(
+        '--project',
+        dest='project',
+        default=None,
+        help=_PROJECT_HELP)
+    parser.add_argument(
+        '--zone',
+        dest='zone',
+        default=None,
+        help=_ZONE_HELP)
+
+    subparsers = parser.add_subparsers(dest='subcommand')
+    for subcommand in _SUBCOMMANDS:
+        command_config = _SUBCOMMANDS[subcommand]
+        description_template = command_config.get('description')
+        prog = sys.argv[0]
+        command_description = (
+            description_template.format(prog, subcommand))
+        examples = command_config.get('examples', '').format(prog, subcommand)
+        epilog = 'examples:{0}'.format(examples) if examples else ''
+        subcommand_parser = subparsers.add_parser(
+            subcommand,
+            formatter_class=argparse.RawTextHelpFormatter,
+            description=command_description,
+            epilog=epilog,
+            help=command_config['help'])
+        command_config['flags'](subcommand_parser)
+        subcommand_parser.add_argument(
+            '--project',
+            dest='project',
+            default=None,
+            help=_PROJECT_HELP)
+        if command_config['require-zone']:
+            subcommand_parser.add_argument(
+                '--zone',
+                dest='zone',
+                default=None,
+                help=_ZONE_HELP)
+
+    args = parser.parse_args()
+    try:
+        _SUBCOMMANDS[args.subcommand]['run'](args, gcloud_compute)
+    except subprocess.CalledProcessError:
+        print('A nested call to gcloud failed.')
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
This is meant to automate and simplify the manual steps currently documented
[here](https://cloud.google.com/datalab/docs/quickstarts/quickstart-gce-frontend).

This relies on the `gcloud` tool being installed on the same machine,
and the user already being authenticated.