### PR TITLE
Set the root path for ungit

### DIFF
--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -205,7 +205,7 @@ then
 fi
 
 # Start the ungit server
-ungit --port=8083 --no-launchBrowser --forcedLaunchPath=/content/datalab 1> /dev/null &
+ungit --port=8083 --no-launchBrowser --forcedLaunchPath=/content/datalab --rootPath=/_proxy/8083/ 1> /dev/null &
 
 # Start the DataLab server
 FOREVER_CMD="forever --minUptime 1000 --spinSleepTime 1000"


### PR DESCRIPTION
The reverse proxy logic will route requests correctly if either:

1. Their path specifies a resource behind the reverse proxy, or...
2. The referrer specifies a path behind the reverse proxy.

However, for the ungit UI sometimes neither of these were true.

This change attempts to fix that by making the URLs used by ungit always specify a reverse-proxy path.