### PR TITLE
Add empty login token to disable jupyter notebook auth

### DIFF
--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -24,6 +24,7 @@
     "--debug",
     "--NotebookApp.allow_origin=\"*\"",
     "--NotebookApp.log_format=\"%(message)s\"",
+    "--NotebookApp.token=",
     "--Session.key=\"\"",
     "--Session.keyfile=\"\"",
     "--ContentsManager.untitled_directory=\"Untitled Folder\"",


### PR DESCRIPTION
Fixes #1073

Jupyter notebook recently made a change requiring a login token to be passed, empty to disable auth.