### PR TITLE
Update node to v6.9.2

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -80,7 +80,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
 
 # Setup Node.js
     mkdir -p /tools/node && \
-    wget -nv https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-x64.tar.gz -O node.tar.gz && \
+    wget -nv https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-x64.tar.gz -O node.tar.gz && \
     tar xzf node.tar.gz -C /tools/node --strip-components=1 && \
     rm node.tar.gz && \
 

--- a/tools/release/build.sh
+++ b/tools/release/build.sh
@@ -39,7 +39,7 @@ function install_node() {
   echo "Installing NodeJS"
 
   mkdir -p /tools/node
-  wget -nv https://nodejs.org/dist/v4.3.2/node-v4.3.2-linux-x64.tar.gz -O node.tar.gz
+  wget -nv https://nodejs.org/dist/v6.9.2/node-v6.9.2-linux-x64.tar.gz -O node.tar.gz
   tar xzf node.tar.gz -C /tools/node --strip-components=1
   rm node.tar.gz
   export "PATH=${PATH}:/tools/node/bin"


### PR DESCRIPTION
It's good to bring our packages up to date, but this is needed now to fix `npm install` issues in Docker on MacOS, where it hangs forever or throws errors with older node versions. This happens if `npm install` is run in a mounted directory.

Context:
https://forums.docker.com/t/unable-to-perform-any-npm-install-inside-a-osxfs-mounted-directory/12590/17
https://forums.docker.com/t/npm-install-doesnt-complete-inside-docker-container/12640
https://github.com/npm/npm/issues/9863