### PR TITLE
Don't remove .install folder from cloud sdk root

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -119,7 +119,6 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     rm -rf /var/lib/dpkg/info/* && \
     rm -rf /tmp/* && \
     rm -rf /root/.cache/* && \
-    rm -rf /tools/google-cloud-sdk/.install && \
     rm -rf /usr/share/locale/* && \
     rm -rf /usr/share/i18n/locales/* && \
     cd /


### PR DESCRIPTION
.install folder needed for `gcloud components update` command.

Fixes #1081 