### PR TITLE
Add an option for relaying HTTP requests over websockets.

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -81,7 +81,12 @@ declare module common {
      * The value for the access-control-allow-origin header. This
      * allows another frontend to connect to Datalab.
      */
-    allowOriginOverride: string;
+    allowOriginOverrides: Array<string>;
+
+    /**
+     * If true, allow HTTP requests via websockets.
+     */
+    allowHttpOverWebsocket: boolean;
   }
 
   interface Map<T> {

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -15,7 +15,8 @@
   "supportUserOverride": false,
   "configUrl": "https://storage.googleapis.com/cloud-datalab/deploy/config_local.js",
   "docsGcsPath": "gs://cloud-datalab/deploy/docs/",
-  "allowOriginOverride": "",
+  "allowOriginOverrides": [],
+  "allowHttpOverWebsocket": false,
   "jupyterArgs": [
     "notebook",
     "-y",

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -426,8 +426,9 @@ function sendTemplate(key: string, data: common.Map<string>, response: http.Serv
 
 function responseHandler(proxyResponse: http.ClientResponse,
                          request: http.ServerRequest, response: http.ServerResponse) {
-  if (appSettings.allowOriginOverride) {
-    proxyResponse.headers['access-control-allow-origin'] = appSettings.allowOriginOverride;
+  if (appSettings.allowOriginOverrides.length &&
+      appSettings.allowOriginOverrides.indexOf(request.headers['origin']) != -1) {
+      proxyResponse.headers['access-control-allow-origin'] = request.headers['origin'];
   } else if (proxyResponse.headers['access-control-allow-origin'] !== undefined) {
     // Delete the allow-origin = * header that is sent (likely as a result of a workaround
     // notebook configuration to allow server-side websocket connections that are

--- a/sources/web/datalab/wsHttpProxy.ts
+++ b/sources/web/datalab/wsHttpProxy.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ /// <reference path="../../../externs/ts/node/node-ws.d.ts" />
+ /// <reference path="../../../externs/ts/node/node.d.ts" />
+
+import * as WebSocket from 'ws';
+import * as http from 'http';
+import * as logging from './logging';
+
+/**
+ * Proxies HTTP requests over websockets.
+ *
+ * This is used to allow connections to the local server from whitelisted https: origins since
+ * ws: connections can be established when the browser would otherwise block http: connections
+ * because of mixed content restrictions.
+ *
+ * Basic protocol is a JSON message with the following fields:
+ *
+ * - method: HTTP method (such as GET or POST)
+ * - path: Path on this server which is being requested.
+ * - message_id: Unique ID specified by client which is included in the response for pairing
+ *     request/response pairs.
+ * - data: Optional data to be included in POST requests.
+ */
+export class WsHttpProxy {
+  constructor(server: http.Server, path: string, allowedOrigins: Array<string>) {
+    this.run(server, path, allowedOrigins);
+  }
+
+  private run(server: http.Server, path: string, allowedOrigins: Array<string>): void {
+    const wss = new WebSocket.Server({
+      server,
+      path,
+    });
+    wss.on('connection', (client: WebSocket) => {
+      // Since web sockets are allowed cross-origin and cross protocol (http/https), need to be
+      // strict about only allowing whitelisted origins.
+      const origin = client.upgradeReq.headers.origin;
+      if (allowedOrigins.indexOf(origin) == -1) {
+        logging.getLogger().error('WebSocket origin not in allowedOrigins "%s"', origin);
+        client.close();
+      }
+
+      client.on('message', (data: string) => {
+        try {
+          const request: any = JSON.parse(data);
+
+          const options: any = {
+            method: request.method,
+            // Only support connections to this server.
+            hostname: 'localhost',
+            port: server.address().port,
+            path: request.path,
+          };
+          // Requests have a unique message ID which is used by the client to differentiate
+          // responses.
+          const wsResponse: any = {
+            message_id: request.message_id,
+          };
+
+          const httpRequest = http.request(options, (httpResponse: http.ClientResponse) => {
+            wsResponse.status = httpResponse.statusCode;
+            // Accumulate the full response and send as a single message over the websocket.
+            wsResponse.data = '';
+            httpResponse.on('data', (chunk: string) => {
+              wsResponse.data += chunk;
+            });
+            httpResponse.on('end', () => {
+              // Ensure that the socket hasn't been closed while the request was being processed.
+              if (client.readyState === client.OPEN) {
+                client.send(JSON.stringify(wsResponse));
+              }
+            });
+          });
+          // Optional POST data.
+          if (request.body) {
+            httpRequest.write(request.body);
+          }
+          httpRequest.end();
+        } catch(error) {
+          logging.getLogger().error('Uncaught error processing http over websocket "%s": %s',
+              data, error);
+        }
+      });
+    });
+  }
+}


### PR DESCRIPTION
This is used to allow creating and connecting to local kernels cross-protocol (such as from an HTTPS page).

This allows an app to host the frontend UI on an HTTPS server and still interact with local kernels. The HTTP requests are only available from whitelisted origins and may only make requests to the local server.