### PR TITLE
Make the login server initialze the auth module.

### DIFF
--- a/sources/web/datalab/login.ts
+++ b/sources/web/datalab/login.ts
@@ -77,6 +77,7 @@ appSettings = settings.loadSettings();
 if (appSettings != null) {
   appSettings.consoleLogging = false;
   logging.initializeLoggers(appSettings);
+  auth.init(appSettings);
 
   server = http.createServer(requestHandler);
   server.listen(appSettings.serverPort);


### PR DESCRIPTION
PR #1046 changed the auth module to include an 'appSettings' variable
that must be initialized before the auth flow will work. The login
server was using the auth module to perform that flow, but was not
initializing that variable. This caused the server to abruptly exit
in the middle of that flow.

This fixes #1092