### PR TITLE
Use dot:mega progress meter option for wget

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -35,7 +35,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     mkdir -p /srcs && \
     cd /srcs && \
     apt-get source -d wget git python-zmq ca-certificates pkg-config libpng-dev && \
-    wget https://mirrors.kernel.org/gnu/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2 && \
+    wget --progress=dot:mega https://mirrors.kernel.org/gnu/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2 && \
     cd / && \
 
 # Setup Python packages. Rebuilding numpy/scipy is expensive so we move this early

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -125,7 +125,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
 
 # Install ProtoBuf, TensorFlow
 RUN pip install --no-cache-dir protobuf==3.0.0b2.post2 && \
-    wget https://storage.googleapis.com/cloud-datalab/deploy/tf/tensorflow-0.11.0rc0-cp27-none-linux_x86_64.whl && \
+    wget --progress=dot:mega https://storage.googleapis.com/cloud-datalab/deploy/tf/tensorflow-0.11.0rc0-cp27-none-linux_x86_64.whl && \
     pip install --no-cache-dir tensorflow-0.11.0rc0-cp27-none-linux_x86_64.whl && \
     rm tensorflow-0.11.0rc0-cp27-none-linux_x86_64.whl
 


### PR DESCRIPTION
In the Dockerfile, the default `--progress=dot` style used when wget has non-TTY output uses 1K per dot, 50 dots (50K) per line. This ends up being quite noisy when downloading the 86MB gcc source file, so I've added the `--progress=mega` option which uses 64K per dot instead, which is 3M per line. This allows the progress to fit onto a single screen, instead of many screens.

I also considered using `--progress=giga`, but on slower connections it might be unacceptably long before the first indication of download speed appears.