### PR TITLE
Allow overriding individual config settings from outside docker container

### DIFF
--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -63,6 +63,14 @@ export function loadSettings(): common.Settings {
     if (process.env['DATALAB_CONFIG_URL']) {
       settings.configUrl = process.env['DATALAB_CONFIG_URL'];
     }
+    const settingsOverrides = process.env['DATALAB_SETTINGS_OVERRIDES'];
+    if (settingsOverrides) {
+      // Allow overriding individual settings via JSON provided as an environment variable.
+      const overrides = JSON.parse(settingsOverrides);
+      for (const key of Object.keys(overrides)) {
+        (<any>settings)[key] = overrides[key];
+      }
+    }
     return settings;
   }
   catch (e) {


### PR DESCRIPTION
This allows patching specific config settings from the environment so the settings can be tweaked without modifying the docker container.