### PR TITLE
Add a Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+  - flake8 tools/cli/
+  - cd containers/datalab
+  - ./build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 sudo: required
+language: python
+python:
+  - "2.7"
+
+before_install:
+  - npm install -g typescript
+  - pip install -U pip
+  - pip install flake8
 
 services:
   - docker

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -66,15 +66,13 @@ _SUBCOMMANDS = {
 }
 
 
-_PROJECT_HELP = (
-"""The Google Cloud Platform project name to use
+_PROJECT_HELP = ("""The Google Cloud Platform project name to use
 for this invocation.
 
 If omitted then the current project is assumed.""")
 
 
-_ZONE_HELP = (
-"""The zone containing the instance. If not specified,
+_ZONE_HELP = ("""The zone containing the instance. If not specified,
 you may be prompted to select a zone.
 
 To avoid prompting when this flag is omitted, you can
@@ -116,7 +114,8 @@ def gcloud_compute(args, cmd, api='', stdin=None, stdout=None, stderr=None):
     if args.project:
         base_cmd.extend(['--project', args.project])
     cmd = base_cmd + cmd
-    return subprocess.check_call(cmd, stdin=stdin, stdout=stdout, stderr=stderr)
+    return subprocess.check_call(
+        cmd, stdin=stdin, stdout=stdout, stderr=stderr)
 
 
 def run():


### PR DESCRIPTION
This does two things:

1. Ensures that the 'datalab' container can be built
2. Looks for lint errors in the CLI

This change also includes two fixes to lint errors in the CLI that
were not caught earlier (when we did not have this check).