### PR TITLE
Three fixes for running the CLI on Windows:

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -157,7 +157,7 @@ def connect(args, gcloud_compute):
             '--ssh-flag=LogLevel=' + args.log_level])
         cmd.append('datalab@{0}'.format(instance))
         cmd.extend(['--', 'true'])
-        with open(os.devnull, "a") as dn:
+        with open(os.devnull, 'w') as dn:
             while True:
                 try:
                     gcloud_compute(args, cmd, stderr=dn)

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -22,6 +22,7 @@ This tool is specific to the use case of running in the Google Cloud Platform.
 from commands import create, connect, list, stop, delete
 
 import argparse
+import os
 import subprocess
 import sys
 
@@ -93,12 +94,21 @@ environment variable CLOUDSDK_COMPUTE_ZONE.
 """)
 
 
-def gcloud_compute(args, cmd, api='', stdin=None, stdout=None, stderr=None):
+try:
+    with open(os.devnull, 'w') as dn:
+        subprocess.call(['gcloud', '--version'], stderr=dn, stdout=dn)
+    gcloud_cmd = 'gcloud'
+except:
+    gcloud_cmd = 'gcloud.cmd'
+
+
+def gcloud_compute(
+        args, compute_cmd, api='', stdin=None, stdout=None, stderr=None):
     """Run the given subcommand of `gcloud compute`
 
     Args:
       args: The Namespace instance returned by argparse
-      cmd: The subcommand of `gcloud compute` to run
+      compute_cmd: The subcommand of `gcloud compute` to run
       api: The optional API version to use (e.g. 'alpha', 'beta', etc)
       stdin: The 'stdin' argument for the subprocess call
       stdout: The 'stdout' argument for the subprocess call
@@ -107,13 +117,13 @@ def gcloud_compute(args, cmd, api='', stdin=None, stdout=None, stderr=None):
       KeyboardInterrupt: If the user kills the command
       subprocess.CalledProcessError: If the command dies on its own
     """
-    base_cmd = ['gcloud']
+    base_cmd = [gcloud_cmd]
     if api:
         base_cmd.append(api)
     base_cmd.append('compute')
     if args.project:
         base_cmd.extend(['--project', args.project])
-    cmd = base_cmd + cmd
+    cmd = base_cmd + compute_cmd
     return subprocess.check_call(
         cmd, stdin=stdin, stdout=stdout, stderr=stderr)
 


### PR DESCRIPTION
1. The name of the gcloud binary on Windows is actually 'gcloud.cmd'
   rather than 'gcloud'. We detect this by trying to invoke 'gcloud',
   and if it fails failling back to 'gcloud.cmd'.
2. Passing the contents of the startup script and container manifest
   metadata values via the command line on Windows is not feasible
   due to the complexities of escaping their values. Instead, we
   write them to named temporary files, and then use the
   '--metadata-from-file' arg instead of the '--metadata' one.
3. The devnull file in Windows cannot be opened in 'a' mode.