### PR TITLE
Cleanups for GET request handlers:

### DIFF
--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -175,6 +175,9 @@ function handleRequest(request: http.ServerRequest,
   //       this into a real feature, that involves a confirmation prompt, as
   //       well validation to require a POST request.
   if (path.indexOf('/_restart') == 0) {
+    if ('POST' != request.method) {
+      return;
+    }
     setTimeout(function() { process.exit(0); }, 0);
     response.statusCode = 200;
     response.end();

--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -219,7 +219,6 @@ function postSettingsHandler(userId: string, request: http.ServerRequest, respon
     }
     formHandler(userId, formData, request, response);
   });
-  request.resume();
 }
 
 /**

--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -229,6 +229,8 @@ function postSettingsHandler(userId: string, request: http.ServerRequest, respon
  */
 function formHandler(userId: string, formData: any, request: http.ServerRequest, response: http.ServerResponse): void {
   if (!(('key' in formData) && ('value' in formData))) {
+    response.writeHead(400, { 'Content-Type': 'text/plain' });
+    response.end('Missing one or more required fields');
     return;
   }
   var key = formData['key'];

--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -21,6 +21,7 @@ import fs = require('fs');
 import http = require('http');
 import uuid = require('node-uuid');
 import path = require('path');
+import querystring = require('querystring');
 import url = require('url');
 import util = require('util');
 import userManager = require('./userManager');
@@ -168,39 +169,82 @@ export function updateUserSetting(userId: string, key: string, value: string, as
  */
 function requestHandler(request: http.ServerRequest, response: http.ServerResponse): void {
   var userId = userManager.getUserId(request);
+  if ('POST' == request.method) {
+    postSettingsHandler(userId, request, response);
+  } else {
+    getSettingsHandler(userId, request, response);
+  }
+}
+
+/**
+ * Handles 'GET' requests to the settings handler.
+ * @param request the incoming http request.
+ * @param response the outgoing http response.
+ */
+function getSettingsHandler(userId: string, request: http.ServerRequest, response: http.ServerResponse): void {
+  var userSettings = loadUserSettings(userId);
   var parsedUrl = url.parse(request.url, true);
-  if (('key' in parsedUrl.query) && ('value' in parsedUrl.query)) {
+  if ('key' in parsedUrl.query) {
     var key = parsedUrl.query['key'];
-    var value = parsedUrl.query['value'];
-    if (updateUserSetting(userId, key, value)) {
-      if ('redirect' in parsedUrl.query) {
-        response.writeHead(302, { 'Location': parsedUrl.query['redirect'] });
-      } else {
-        response.writeHead(200, { 'Content-Type': 'text/plain' });
-      }
+    if (key in userSettings) {
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify(userSettings[key]));
     } else {
-      response.writeHead(500, { 'Content-Type': 'text/plain' });
+      response.writeHead(404, { 'Content-Type': 'text/plain' });
+      response.end();
     }
-    response.end();
     return;
   } else {
-    var userSettings = loadUserSettings(userId);
-    if ('key' in parsedUrl.query) {
-      var key = parsedUrl.query['key'];
-      if (key in userSettings) {
-        response.writeHead(200, { 'Content-Type': 'application/json' });
-        response.end(JSON.stringify(userSettings[key]));
-      } else {
-        response.writeHead(404, { 'Content-Type': 'text/plain' });
-        response.end();
-      }
-      return;
-    } else {
-      response.writeHead(200, { 'Content-Type': 'application/json' });
-      response.end(JSON.stringify(userSettings));
-      return;
-    }
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.end(JSON.stringify(userSettings));
+    return;
   }
+}
+
+/**
+ * Handles 'POST' requests to the settings handler.
+ * @param request the incoming http request.
+ * @param response the outgoing http response.
+ */
+function postSettingsHandler(userId: string, request: http.ServerRequest, response: http.ServerResponse): void {
+  var formData : any;
+  var body : string = "";
+  request.on('data', function(chunk: string) { body += chunk; });
+  request.on('end', function() {
+    if (body) {
+      formData = querystring.parse(body);
+    } else {
+      var parsedUrl = url.parse(request.url, true);
+      formData = parsedUrl.query;  
+    }
+    formHandler(userId, formData, request, response);
+  });
+  request.resume();
+}
+
+/**
+ * Handles updating a setting given the parsed form contents.
+ * @param formData the form data parsed from the incoming http request.
+ * @param request the incoming http request.
+ * @param response the outgoing http response.
+ */
+function formHandler(userId: string, formData: any, request: http.ServerRequest, response: http.ServerResponse): void {
+  if (!(('key' in formData) && ('value' in formData))) {
+    return;
+  }
+  var key = formData['key'];
+  var value = formData['value'];
+  if (updateUserSetting(userId, key, value)) {
+    if ('redirect' in formData) {
+      response.writeHead(302, { 'Location': formData['redirect'] });
+    } else {
+      response.writeHead(200, { 'Content-Type': 'text/plain' });
+    }
+  } else {
+    response.writeHead(500, { 'Content-Type': 'text/plain' });
+  }
+  response.end();
+  return;
 }
 
 /**

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -154,10 +154,12 @@ function showHelp(markup) {
   }
 }
 
-function xhr(url, callback) {
+function xhr(url, callback, method) {
+  method = method || "GET";
+
   let request = new XMLHttpRequest();
   request.onreadystatechange = callback.bind(request);
-  request.open("POST", url);
+  request.open(method, url);
   request.send();
 }
 
@@ -176,7 +178,7 @@ function restartDatalab() {
     // We redirect to signal to the user that the restart did something.
     // However, we have to delay that a bit to give Datalab time to restart.  
     window.setTimeout(redirect, 500);
-  });
+  }, "POST");
 }
 
 function initializePage(dialog, saveFn) {
@@ -269,7 +271,7 @@ function initializePage(dialog, saveFn) {
   xhr(getSettingKeyAddress("theme"), function() {
     lightThemeRadioOption.checked = this.responseText === "\"light\"";
     darkThemeRadioOption.checked = this.responseText === "\"dark\"";
-  })
+  });
   lightThemeRadioOption.onclick = function() {
     setTheme("light");
     darkThemeRadioOption.checked = false;
@@ -284,7 +286,7 @@ function initializePage(dialog, saveFn) {
       // Reload the stylesheet by resetting its address with a random (time) version querystring
       sheetAddress = document.getElementById("themeStylesheet").href + "?v=" + Date.now()
       document.getElementById("themeStylesheet").setAttribute('href', sheetAddress);
-    })
+    }, "POST");
   }
 
   // If inside a notebook, prepare notebook-specific help link inside the sidebar

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -157,7 +157,7 @@ function showHelp(markup) {
 function xhr(url, callback) {
   let request = new XMLHttpRequest();
   request.onreadystatechange = callback.bind(request);
-  request.open("GET", url);
+  request.open("POST", url);
   request.send();
 }
 

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -165,6 +165,20 @@ function getSettingKeyAddress(setting) {
   return window.location.protocol + "//" + window.location.host + "/_settings?key=" + setting;
 }
 
+function restartDatalab() {
+  var restartUrl = window.location.protocol + "//" + window.location.host + "/_restart";
+
+  function redirect() {
+    window.location = '/';
+  }
+
+  xhr(restartUrl, function(){
+    // We redirect to signal to the user that the restart did something.
+    // However, we have to delay that a bit to give Datalab time to restart.  
+    window.setTimeout(redirect, 500);
+  });
+}
+
 function initializePage(dialog, saveFn) {
 
   function showAbout() {
@@ -180,7 +194,8 @@ function initializePage(dialog, saveFn) {
       '<span class="fa fa-external-link-square">&nbsp;</span><a href="/static/about.txt" target="_blank">License and software information</a><br />' +
       '<span class="fa fa-external-link-square">&nbsp;</span><a href="https://cloud.google.com/terms/" target="_blank">Terms of Service</a><br />' +
       '<span class="fa fa-external-link-square">&nbsp;</span><a href="http://www.google.com/intl/en/policies/" target="_blank">Privacy Policy</a><br />' +
-      '<span class="fa fa-external-link-square">&nbsp;</span><a href="/static/reporting.html?enabled=' + reportingEnabled + '" target="_blank">Usage Statistics</a><br />';
+      '<span class="fa fa-external-link-square">&nbsp;</span><a href="/static/reporting.html?enabled=' + reportingEnabled + '" target="_blank">Usage Statistics</a><br />' +
+      '<span class="fa fa-recycle">&nbsp;</span><a href="javascript:restartDatalab()">Restart Server</a><br />';
 
     var dialogOptions = {
       title: 'About Google Cloud Datalab',

--- a/sources/web/datalab/static/reporting.html
+++ b/sources/web/datalab/static/reporting.html
@@ -90,7 +90,7 @@ body {
     </div>
 
     <div class="buttonarea">
-      <form action="/_setting">
+      <form action="/_setting" method="post">
         <input type="hidden" name="redirect" value="/">
         <input type="hidden" name="key" value="enableUsageReporting">
         <input id="unchecked" type="hidden" name="value" value="false">


### PR DESCRIPTION
1. Make the '_restart' handler require a 'POST' request to do anything.
2. Make the '_setting' handler require a 'POST' request in order to
   update a setting. This also meant it should support reading the
   form data from either the URL query or from the request body.

Similarly, the various places where we update settings were changed
to use 'POST' requests instead of 'GET' requests.