### PR TITLE
Support specifying the zone via the CLI when creating an instance

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -316,9 +316,11 @@ def ensure_disk_exists(args, gcloud_compute, disk_name):
     """
     get_cmd = [
         'disks', 'describe', disk_name, '--format', 'value(name)']
+    if args.zone:
+        get_cmd.extend(['--zone', args.zone])
     try:
         with tempfile.TemporaryFile() as tf:
-            gcloud_compute(args, get_cmd, stdout=tf, stderr=tf)
+            gcloud_compute(args, get_cmd, stdout=tf)
             return
     except subprocess.CalledProcessError:
         create_disk(args, gcloud_compute, disk_name)


### PR DESCRIPTION
This fixes #1106 where the `datalab create` command only works if
the `compute/zone` gcloud config is set prior to running the command.

With this fix, either the following will work:

1. Setting the zone via the `--zone` argument to the datalab command
2. Setting the zone via the interactive prompt issued by gcloud

However, if using the second option, the user must make sure that
they select the same zone for both the instance and creating the
disk. That issue will be fixed by a subsequent change to come later.