### PR TITLE
Add a flag to the CLI to proxy websocket connections.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -84,6 +84,8 @@ spec:
       env:
         - name: DATALAB_ENV
           value: GCE
+        - name: PROXY_WEB_SOCKETS
+          value: '{1}'
       volumeMounts:
         - name: home
           mountPath: /content
@@ -163,6 +165,13 @@ def flags(parser):
         action='store_true',
         default=False,
         help='do not connect to the newly created instance')
+
+    parser.add_argument(
+        '--proxy-websockets',
+        dest='proxy_websockets',
+        action='store_true',
+        default=False,
+        help='(Experiemental!) proxy websocket connections over HTTP')
 
     connect.connection_flags(parser)
     return
@@ -370,8 +379,11 @@ def run(args, gcloud_compute):
             try:
                 startup_script_file.write(_DATALAB_STARTUP_SCRIPT)
                 startup_script_file.close()
+                proxy_websockets = "true" if args.proxy_websockets else "false"
                 manifest_file.write(
-                    _DATALAB_CONTAINER_SPEC.format(args.image_name))
+                    _DATALAB_CONTAINER_SPEC.format(
+                        args.image_name,
+                        proxy_websockets))
                 manifest_file.close()
                 metadata_from_file = (
                     'startup-script={0},google-container-manifest={1}'.format(


### PR DESCRIPTION
This is needed for users who want to connect to their
Datalab instances from the Cloud Shell, since the Cloud
Shell's "web preview" feature does not support websockets.