### PR TITLE
Automatically detect if websockets need to be proxied.

### DIFF
--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -373,10 +373,6 @@ export function handleRequest(request: http.ServerRequest, response: http.Server
 
 function getBaseTemplateData(request: http.ServerRequest): common.Map<string> {
   var userId: string = userManager.getUserId(request);
-  var proxyWebSockets: string = process.env.PROXY_WEB_SOCKETS;
-  if (proxyWebSockets != 'true') {
-    proxyWebSockets = 'false';
-  }
   var reportingEnabled: string = process.env.ENABLE_USAGE_REPORTING;
   if (reportingEnabled) {
     var userSettings: common.Map<string> = settings.loadUserSettings(userId);
@@ -390,8 +386,7 @@ function getBaseTemplateData(request: http.ServerRequest): common.Map<string> {
     userId: userId,
     configUrl: appSettings.configUrl,
     baseUrl: '/',
-    reportingEnabled: reportingEnabled,
-    proxyWebSockets: proxyWebSockets
+    reportingEnabled: reportingEnabled
   };
   var signedIn = auth.isSignedIn();
   templateData['isSignedIn'] = signedIn.toString();

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -289,12 +289,8 @@ export function run(settings: common.Settings): void {
   staticHandler = static_.createHandler(settings);
 
   server = http.createServer(requestHandler);
-  var proxyWebSockets: string = process.env.PROXY_WEB_SOCKETS;
-  if (proxyWebSockets == 'true') {
-    sockets.wrapServer(server);
-  } else {
-    server.on('upgrade', socketHandler);
-  }
+  server.on('upgrade', socketHandler);
+  sockets.wrapServer(server);
 
   if (settings.allowHttpOverWebsocket) {
     new wsHttpProxy.WsHttpProxy(server, httpOverWebSocketPath, settings.allowOriginOverrides);

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -18,7 +18,7 @@ var debug = {
 };
 
 function shouldShimWebsockets() {
-    return location.host.substr(-12) === '.appspot.com';
+    return location.host.toLowerCase().substr(-12) === '.appspot.com';
 }
 
 // Override WebSocket
@@ -106,7 +106,7 @@ function shouldShimWebsockets() {
 
     if (shouldShimWebsockets()) {
         debug.log('Replacing native websockets with socket.io');
-        var nativeWebSocket = window.WebSocket;
+        window.nativeWebSocket = window.WebSocket;
         window.WebSocket = WebSocketShim;
     }
 })();

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -12,13 +12,17 @@
  * the License.
  */
 
+var debug = {
+  enabled: true,
+  log: function() { console.log.apply(console, arguments); }
+};
+
+function shimWebSockets() {
+    return location.host.substr(-12) === '.appspot.com';
+}
+
 // Override WebSocket
 (function() {
-    var proxyWebSockets = (document.body.getAttribute('data-proxy-web-sockets') == 'true');
-    if (!proxyWebSockets) {
-	return;
-    }
-
     if (!window.io) {
 	// If socket.io was not loaded into the page, then do not override the existing
 	// WebSocket functionality.
@@ -100,14 +104,12 @@
     WebSocketShim.CLOSED = 0;
     WebSocketShim.OPEN = 1;
 
-    var nativeWebSocket = window.WebSocket;
-    window.WebSocket = WebSocketShim;
+    if (shimWebSockets()) {
+        debug.log('Replacing native websockets with socket.io');
+        var nativeWebSocket = window.WebSocket;
+        window.WebSocket = WebSocketShim;
+    }
 })();
-
-var debug = {
-  enabled: true,
-  log: function() { console.log.apply(console, arguments); }
-};
 
 function placeHolder() {}
 

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -17,7 +17,7 @@ var debug = {
   log: function() { console.log.apply(console, arguments); }
 };
 
-function shimWebSockets() {
+function shouldShimWebsockets() {
     return location.host.substr(-12) === '.appspot.com';
 }
 
@@ -104,7 +104,7 @@ function shimWebSockets() {
     WebSocketShim.CLOSED = 0;
     WebSocketShim.OPEN = 1;
 
-    if (shimWebSockets()) {
+    if (shouldShimWebsockets()) {
         debug.log('Replacing native websockets with socket.io');
         var nativeWebSocket = window.WebSocket;
         window.WebSocket = WebSocketShim;

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -27,8 +27,7 @@
   data-user-id="<%userId%>"
   data-account="<%account%>"
   data-reporting-enabled="<%reportingEnabled%>"
-  data-project-hash="<%projectHash%>"
-  data-proxy-web-sockets="<%proxyWebSockets%>">
+  data-project-hash="<%projectHash%>">
 
   <script>
      window.datalab = {};


### PR DESCRIPTION
This change removes the previously used 'PROXY_WEB_SOCKETS' environment
variable, and instead detects on the client whether or not that client
needs to proxy websocket connections via socket.io.

This gives us the benefits that:

1. The user no longer needs to decide ahead of time whether or not
   their instance will rely on websockets.
2. A single instance can both rely on websockets for some clients
   and proxy them for others (e.g. depending on whether an SSH
   tunnel is coming from a Cloud Shell instance or from something else).

For now the logic for this decision is based on whether or not the
hostname ends in '.appspot.com' (indicating that it is hosted by
App Engine which does not support websockets).

However, in the future we may want to make the logic more sophisticated
by first trying to create a websocket connection, and then proxying
them if that fails.