### PR TITLE
Fix the enableAutoGCSBackups setting to be a boolean rather than a string

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -85,7 +85,7 @@ spec:
         - name: DATALAB_ENV
           value: GCE
         - name: DATALAB_SETTINGS_OVERRIDES
-          value: '{{"enableAutoGCSBackups": "{1}"}}'
+          value: '{{"enableAutoGCSBackups": {1} }}'
       volumeMounts:
         - name: home
           mountPath: /content


### PR DESCRIPTION
This fixes a bug where turning off backups did not work because the value
was set to "false" (which is truthy) instead of false.