### PR TITLE
Remove a duplicate mount command from the startup script

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -58,8 +58,6 @@ format_disk() {
 mount_disk() {
   mkdir -p "${MOUNT_DIR}"
   ${MOUNT_CMD} || format_disk
-  mount -o discard,defaults \
-    /dev/disk/by-id/google-datalab-pd /mnt/disks/datalab-pd || format_disk
   chmod a+w "${MOUNT_DIR}"
 }
 


### PR DESCRIPTION
This change fixes a bug in the startup script used by Datalab
instances where the command to mount the persistent disk was
being duplicated.