### PR TITLE
Fix the conflict between the socket.io proxying and ungit

### DIFF
--- a/sources/web/datalab/reverseProxy.ts
+++ b/sources/web/datalab/reverseProxy.ts
@@ -44,6 +44,11 @@ function getPort(url: string) {
  */
 export function getRequestPort(request: http.ServerRequest, path: string): string {
   var port: string = getPort(path) || getPort(request.headers.referer);
+  if (!port) {
+    if (path.indexOf('/socket.io/') == 0) {
+      port = '8084';
+    }
+  }
   return port;
 }
 
@@ -52,7 +57,8 @@ export function getRequestPort(request: http.ServerRequest, path: string): strin
  */
 function shouldProxyPort(port: String) {
   // Do not proxy 8083 to gateway, it's open for ungit
-  return !!process.env.KG_URL && port !== '8083';
+  // Do not proxy 8084 to gateway, it's open for socket.io wrapping
+  return !!process.env.KG_URL && port !== '8083' && port !== '8084';
 }
 
 /**

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -282,6 +282,7 @@ export function run(settings: common.Settings): void {
   auth.init(settings);
   noCacheContent.init(settings);
   reverseProxy.init();
+  sockets.init();
 
   healthHandler = health.createHandler(settings);
   infoHandler = info.createHandler(settings);
@@ -290,7 +291,6 @@ export function run(settings: common.Settings): void {
 
   server = http.createServer(requestHandler);
   server.on('upgrade', socketHandler);
-  sockets.wrapServer(server);
 
   if (settings.allowHttpOverWebsocket) {
     new wsHttpProxy.WsHttpProxy(server, httpOverWebSocketPath, settings.allowOriginOverrides);

--- a/sources/web/datalab/sockets.ts
+++ b/sources/web/datalab/sockets.ts
@@ -163,8 +163,8 @@ function socketHandler(socket: SocketIO.Socket) {
   });
 }
 
-export function wrapServer(server: http.Server): void {
-  var io = socketio.listen(server, {
+export function init(): void {
+  var io = socketio('8084', {
     transports: [ 'polling' ],
     allowUpgrades: false
   });


### PR DESCRIPTION
This commit changes socket.io proxying so that it is done
by a separate server listening to port 8084.

That fixes a bug where the socket.io logic on the main server
was interferring with ungit's usage of socket.io.

The reason this fixes that bug is because the socket.io wrapped
server is only invoked after the reverse proxy has determined that
the request should not be proxied to ungit.

This fixes #1125