### PR TITLE
Use VM's zone and name in the GCS backup path

### DIFF
--- a/sources/web/datalab/backupUtility.ts
+++ b/sources/web/datalab/backupUtility.ts
@@ -78,14 +78,14 @@ export function startBackup(settings: common.Settings) {
       // test hourly backup
       if (!log_history.lastHourlyRun || (Date.now()-log_history.lastHourlyRun)/1000 > 60*60) {
         runBackup('hourly', () => {
-          writeBackupLog(log_history);
           log_history.lastHourlyRun = Date.now();
+          writeBackupLog(log_history);
         });
       }
       if (!log_history.lastDailyRun || (Date.now()-log_history.lastDailyRun)/1000 > 60*60*24) {
         runBackup('daily', () => {
-          writeBackupLog(log_history);
           log_history.lastDailyRun = Date.now();
+          writeBackupLog(log_history);
         });
       }
       if (!log_history.lastWeeklyRun || (Date.now()-log_history.lastWeeklyRun)/1000 > 60*60*24*7) {


### PR DESCRIPTION
This PR uses the VM's zone and name instead of its numeric ID in the GCS backup path to make it easy for the user to find and restore backups. It uses the environment variables added inside the Datalab container for `VM_PROJECT`, `VM_ZONE`, and `VM_NAME`.

It also fixes a minor bug with the backup log where it was written prematurely.