### PR TITLE
Upgrade the version of the 'six' library to 1.10.0

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -66,7 +66,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir seaborn==0.7.0 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir notebook==4.2.3 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir PyYAML==3.11 && \
-    pip install -U --upgrade-strategy only-if-needed --no-cache-dir six==1.9.0 && \
+    pip install -U --upgrade-strategy only-if-needed --no-cache-dir six==1.10.0 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir ipywidgets==5.2.2 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir future==0.15.2 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir psutil==4.3.0 && \


### PR DESCRIPTION
This fixes a build breakage that just showed up today (builds
were working this morning, and failing now).

I was not able to isolate exactly what changed, but it seems that
our earlier builds were installing 1.10.0 as a dependency of
something else, and then the explicit install of 1.9.0 was skipped
since the existing 1.10.0 install satisified that dependency.

The failing builds seem to not have the 1.10.0 install, so the
1.9.0 install actually goes through, and later on the 'future'
library fails because it requires 1.10.0.

This change fixes that build breakage by switching our explicit
dependency to be the one that we were implicitly depending on.