### PR TITLE
Restart the SSH tunnel if it dies

### DIFF
--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -81,6 +81,15 @@ setup_tunnel() {
     exit "${ERR_GATEWAY_FAILED}"
   fi
   echo "Successfully established SSH tunnel to ${instance}"
+
+  watch_and_restart_tunnel &
+}
+
+watch_and_restart_tunnel() {
+  while ps --ppid $$ -C ssh 2>&1 > /dev/null; do
+    sleep 1
+  done
+  setup_tunnel > /dev/null
 }
 
 source /datalab/setup-env.sh

--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -109,7 +109,7 @@ watch_and_restart_tunnel() {
   ssh_user=$4
   
   while [ "$(ps --ppid $$ -o comm= | grep ssh)" != "" ]; do
-    sleep 1
+    sleep 5
   done
   echo "Restarting SSH tunnel"
   setup_tunnel "${project_id}" "${zone}" "${instance}" "${ssh_user}"


### PR DESCRIPTION
This change spins up a background process that continuously watches the SSH process to see if it is still running.

If it finds that it is not, it tries to recreate the SSH tunnel.

This change also includes a fix for an issue where Datalab would not start if it could not communicate with a metadata server (e.g. if it was running locally). That has been sent in a separate PR, and once it is merged I will rebase this PR.