### PR TITLE
Upgrade to ungit 1.1.0, use the new --ungitVersionCheckOverride option

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -25,7 +25,7 @@ RUN ln -s /datalab/web/static/datalab.css /datalab/nbconvert/datalab.css && \
     cd / && \
 
 # Install ungit
-    /tools/node/bin/npm install -g ungit@1.0.0 && \
+    /tools/node/bin/npm install -g ungit@1.1.0 && \
 
 # Install the support for connecting to a kernel gateway
     wget https://github.com/jupyter/kernel_gateway_demos/archive/e653b2bd3ca91ef1af2a13c397766484dcb7b76d.zip && \

--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -254,7 +254,7 @@ then
 fi
 
 # Start the ungit server
-ungit --port=8083 --no-launchBrowser --forcedLaunchPath=/content/datalab 1> /dev/null &
+ungit --port=8083 --no-launchBrowser --forcedLaunchPath=/content/datalab --ungitVersionCheckOverride 1> /dev/null &
 
 # Start the DataLab server
 FOREVER_CMD="forever --minUptime 1000 --spinSleepTime 1000"


### PR DESCRIPTION
This removes the version update notification from ungit's UI.