### PR TITLE
Check light theme radio button by default

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -467,9 +467,8 @@ div.selected .CodeMirror-linenumber, div#texteditor-container .CodeMirror-linenu
   visibility: visible;
 }
 .CodeMirror-matchingbracket {
-  color: #800000 !important;
-  text-decoration: none !important;
-  font-weight: bold !important;
+  color: inherit !important;
+  outline: solid 1px #888;
 }
 .cm-keyword {
   font-weight: normal !important;

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -321,6 +321,11 @@ function initializePage(dialog, saveFn) {
   // Prepare the theme selector radio boxes
   lightThemeRadioOption = document.getElementById("lightThemeRadioOption")
   darkThemeRadioOption = document.getElementById("darkThemeRadioOption")
+
+  // By default, check the light theme radio button
+  // TODO: When we have support for default settings on server side, remove this
+  lightThemeRadioOption.checked = true;
+  darkThemeRadioOption.checked = false;
   xhr(getSettingKeyAddress("theme"), function() {
     lightThemeRadioOption.checked = this.responseText === "\"light\"";
     darkThemeRadioOption.checked = this.responseText === "\"dark\"";


### PR DESCRIPTION
- Check light theme radio button by default before getting configured theme
- Make matchingbracket more visible