### PR TITLE
Fix an issue where the Docker images could not fit in the boot disk

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -54,7 +54,7 @@ clone_repo() {{
   echo "Creating the datalab directory"
   mkdir -p ${{MOUNT_DIR}}/datalab
   echo "Cloning the repo {0}"
-  docker run -v "${{MOUNT_DIR}}:/content" \
+  docker run -v --rm "${{MOUNT_DIR}}:/content" \
     --entrypoint "/bin/bash" {0} \
     gcloud source repos clone {1} /content/datalab/notebooks
 }}
@@ -481,6 +481,7 @@ def run(args, gcloud_compute, gcloud_repos, email='', **kwargs):
                             user_data_file.name,
                             manifest_file.name))
                     cmd.extend([
+                        '--boot-disk-size=20GB',
                         '--network', _DATALAB_NETWORK,
                         '--image-family', 'gci-stable',
                         '--image-project', 'google-containers',


### PR DESCRIPTION
This change fixes two issues with disk space for Docker images and
containers.

1. Make the container used for formatting the notebooks disk clean
   itself up when it exits. This wasn't actually causing any issues,
   but it is good hygiene.
2. Double the size of the boot disk for instances. The default size
   of 10GB turns out to be just barely too small to fit both the
   Datalab image and the fluentd image. This caused issues where
   only the first image pulled would be pulled successfully.