### PR TITLE
Explicitly configure gcloud to use the test project in release validation.

### DIFF
--- a/tools/release/publish.sh
+++ b/tools/release/publish.sh
@@ -49,7 +49,7 @@ git clone https://github.com/googledatalab/notebooks tests/notebooks
 docker run \
   --net host \
   -v "$(pwd)/tests:/content/datalab" \
-  -e "PROJECT_ID=${TEST_PROJECT_ID}" \
+  -e "CLOUDSDK_CORE_PROJECT=${TEST_PROJECT_ID}" \
   --entrypoint /content/datalab/notebooks/.test.sh \
   --workdir /content/datalab/notebooks \
   ${DATALAB_IMAGE}


### PR DESCRIPTION
This change switches the release script from specifying the test project
via the 'PROJECT_ID' environment variable to instead setting the project
via the 'CLOUDSDK_CORE_PROJECT' environment varialbe.

This is necessary because https://github.com/googledatalab/pydatalab/pull/136
changed the pydatalab library so that the gcloud config overrides the 'PROJECT_ID'
environment variable. This means that in a GCE VM, we don't use that variable,
as gcloud will pick up the project name from the metadata server.

However, gcloud itself will use the 'CLOUDSDK_CORE_PROJECT' variable, so we
use that one for setting the test project.