### PR TITLE
Add a config setting for the console log level.

### DIFF
--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -34,6 +34,10 @@ fi
 
 # Use this flag to map in web server content during development
 #  -v $REPO_DIR/sources/web:/sources \
+#
+# To turn on debug logs, add the following:
+#  -e 'DATALAB_SETTINGS_OVERRIDES={"consoleLogLevel": "debug" }' \
+
 docker run -it --entrypoint=$ENTRYPOINT \
   -p 127.0.0.1:8081:8080 \
   -v "$CONTENT:/content" \

--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -16,7 +16,18 @@ declare module common {
 
   interface Settings {
 
+    /**
+     * Whether or not to write log statements to stderr
+     */
     consoleLogging: boolean;
+
+    /**
+     * The minimum threshold for log statements to be written to stderr.
+     * Values should be one of 'trace', 'debug', 'info',
+     * 'warn', 'error', or 'fatal'.
+     */
+    consoleLogLevel: string;
+
     logFilePath: string;
     logFilePeriod: string;
     logFileCount: number;

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -1,5 +1,6 @@
 {
   "consoleLogging": true,
+  "consoleLogLevel": "warn",
   "release": "beta",
   "logFilePath": "/var/log/app_engine/custom_logs/app.log",
   "logFilePeriod": "300000ms",

--- a/sources/web/datalab/logging.ts
+++ b/sources/web/datalab/logging.ts
@@ -73,7 +73,7 @@ export function initializeLoggers(settings: common.Settings): void {
       path: logFilePath, period: settings.logFilePeriod, count: settings.logFileCount }
   ];
   if (settings.consoleLogging) {
-    streams.push({ level: 'info', type: 'stream', stream: process.stderr });
+    streams.push({ level: settings.consoleLogLevel, type: 'stream', stream: process.stderr });
   }
 
   logger = bunyan.createLogger({ name: 'app', streams: streams });


### PR DESCRIPTION
Previously, if console logging was enabled, then the log threshold
level was hard-coded to 'info'.

This change both makes that configurable, and changes the default
from 'info' (which is very noisy) to 'warn' (which should only
include things the user really needs to know).

This is part of the work to address #1157