### PR TITLE
Fix pip install build break

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -163,7 +163,8 @@ RUN ipython profile create default && \
     /tools/node/bin/npm install -g typescript && \
     tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts && \
     /tools/node/bin/npm uninstall -g typescript && \
-    pip install --upgrade-strategy only-if-needed --no-cache-dir . && \
+    pip install -U pip"<9" && \
+    pip install --no-cache-dir . && \
     jupyter nbextension install --py datalab.notebook && \
     jupyter nbextension enable --py widgetsnbextension && \
     rm datalab/notebook/static/*.js && \

--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -32,7 +32,7 @@ RUN ln -s /datalab/web/static/datalab.css /datalab/nbconvert/datalab.css && \
     unzip -qq e653b2bd3ca91ef1af2a13c397766484dcb7b76d.zip -d kernel_gateway_demos && \
     rm e653b2bd3ca91ef1af2a13c397766484dcb7b76d.zip && \
     cd ./kernel_gateway_demos/kernel_gateway_demos-e653b2bd3ca91ef1af2a13c397766484dcb7b76d && \
-    pip install --upgrade-strategy only-if-needed ./nb2kg/
+    pip install ./nb2kg/
 
 ENV EXPERIMENTAL_KERNEL_GATEWAY_URL=""
 

--- a/containers/gateway/Dockerfile.in
+++ b/containers/gateway/Dockerfile.in
@@ -19,7 +19,7 @@ ADD build/web/kernelproxy /datalab/web
 ADD content/ /datalab
 
 # Install the support for running a kernel gateway
-RUN pip install --upgrade-strategy only-if-needed jupyter_kernel_gateway
+RUN pip install jupyter_kernel_gateway
 
 # Startup
 ENV DATALAB_VERSION _version_


### PR DESCRIPTION
With the latest release of CloudML Python SDK, installing it inside the Datalab container fails for the newest pip. This PR downgrades pip as a workaround, until the bug on the CloudML SDK is fixed.