### PR TITLE
Report errors when creating a disk to the user if the error is terminal.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -388,21 +388,21 @@ def ensure_disk_exists(args, gcloud_compute, disk_name, report_errors=False):
         try:
             create_disk(args, gcloud_compute, disk_name, report_errors)
         except:
-            if args.zone or args.quiet:
-                if report_errors:
-                    raise
-                # We know the command failed (and will almost certainly
-                # fail again), but we did not forward the errors that
-                # it reported to the user. To work around this, we
-                # re-run the command with 'report_errors' set to True
-                create_disk(args, gcloud_compute, disk_name, True)
-            else:
+            if (not args.zone) and (not args.quiet):
                 # We take this failure as a sign that gcloud might need
                 # to prompt for a zone. As such, we do that prompting
                 # for it, and then try again.
                 args.zone = utils.prompt_for_zone(args, gcloud_compute)
                 ensure_disk_exists(args, gcloud_compute, disk_name,
                                    report_errors=True)
+            elif not report_errors:
+                # We know the command failed (and will almost certainly
+                # fail again), but we did not forward the errors that
+                # it reported to the user. To work around this, we
+                # re-run the command with 'report_errors' set to True
+                create_disk(args, gcloud_compute, disk_name, True)
+            else:
+                raise
     return
 
 

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -389,7 +389,13 @@ def ensure_disk_exists(args, gcloud_compute, disk_name, report_errors=False):
             create_disk(args, gcloud_compute, disk_name, report_errors)
         except:
             if args.zone or args.quiet:
-                raise
+                if report_errors:
+                    raise
+                # We know the command failed (and will almost certainly
+                # fail again), but we did not forward the errors that
+                # it reported to the user. To work around this, we
+                # re-run the command with 'report_errors' set to True
+                create_disk(args, gcloud_compute, disk_name, True)
             else:
                 # We take this failure as a sign that gcloud might need
                 # to prompt for a zone. As such, we do that prompting


### PR DESCRIPTION
This fixes a bug where the errors reported by gcloud when creating
a disk were sometimes discarded without being shown to the user if
the command failed the first time it is run, but will not be retried
(either because the zone has been explicitly set, or the --quiet
flag has been specified, causing us to not prompt for a zone).