### PR TITLE
Add access-control-allow-credentials when access-control-allow-origin is used.

### DIFF
--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -424,6 +424,7 @@ function responseHandler(proxyResponse: http.ClientResponse,
   if (appSettings.allowOriginOverrides.length &&
       appSettings.allowOriginOverrides.indexOf(request.headers['origin']) != -1) {
       proxyResponse.headers['access-control-allow-origin'] = request.headers['origin'];
+      proxyResponse.headers['access-control-allow-credentials'] = 'true';
   } else if (proxyResponse.headers['access-control-allow-origin'] !== undefined) {
     // Delete the allow-origin = * header that is sent (likely as a result of a workaround
     // notebook configuration to allow server-side websocket connections that are


### PR DESCRIPTION
This is required to allow datalab kernels to be used cross-origin when they live
behind a credentials-requiring proxy, such as Cloud Shell's Web Preview mode.

This fixes #1169