### PR TITLE
Silence a noisy warning from gcloud

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -499,6 +499,7 @@ def run(args, gcloud_compute, gcloud_repos, email='', **kwargs):
                             manifest_file.name))
                     cmd.extend([
                         '--boot-disk-size=20GB',
+                        '--verbosity=error',
                         '--network', _DATALAB_NETWORK,
                         '--image-family', 'gci-stable',
                         '--image-project', 'google-containers',


### PR DESCRIPTION
This fixes an issue with the larger boot-disk size where gcloud would always log a noisy warning about the boot disk being smaller than 200GB.