### PR TITLE
Do not try to launch the browser if it may not support Datalab.

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -52,6 +52,15 @@ To connect to 'example-instance' in zone 'us-central1-a', run:
     $ {0} {1} example-instance --zone us-central1-a""")
 
 
+# The list of web browsers that we don't want to automatically open.
+#
+# This is a subset of the canonical list of python browser types
+# defined here: https://docs.python.org/2/library/webbrowser.html
+unsupported_browsers = [
+    'BackgroundBrowser', 'Elinks', 'GenericBrowser', 'Grail'
+]
+
+
 def flags(parser):
     """Add command line flags for the `connect` subcommand.
 
@@ -191,14 +200,22 @@ def connect(args, gcloud_compute):
             gcloud_compute(args, cmd, stdout=lf, stderr=lf)
         return
 
+    def maybe_open_browser(address):
+        """Try to open a browser if we reasonably can."""
+        browser_context = webbrowser.get()
+        browser_name = type(browser_context).__name__
+        if browser_name in unsupported_browsers:
+            return
+        try:
+            webbrowser.open(datalab_address)
+        except webbrowser.Error as e:
+            print('Unable to open the webbrowser: ' + str(e))
+
     def on_ready():
         """Callback that handles a successful connection."""
         print('You can now connect to Datalab at ' + datalab_address)
         if not args.no_launch_browser:
-            try:
-                webbrowser.open(datalab_address)
-            except webbrowser.Error as e:
-                print('Unable to open the webbrowser: ' + str(e))
+            maybe_open_browser(datalab_address)
         return
 
     def health_check(cancelled_event):


### PR DESCRIPTION
This change stops the CLI from automatically launching the browser
if the type of browser launched is one that may not work with the
Datalab UI.

In particular, this detects a large class of text-only browsers,
including the one that is provided in Google Cloud Shell.

This mitigates iessue #1139, but does not completely fix it, as
we still do not tell the user to launch the web-preview feature.

However, even though this approach still leaves room for improving
the usage under Cloud Shell, it also greatly improves the experience
when running under other environments where a text-only browser
would be opened instead of a browser with a GUI.