### PR TITLE
Prevent users from accidentally sharing a Datalab instance.

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -57,10 +57,10 @@ wrong_user_message = (
     'are attempting to connect to it as {1}.'
     '\n\n'
     'Datalab instances are single-user environments, and trying '
-    'to share one will cause problems.'
+    'to share one is not supported.'
     '\n\n'
-    'If you are sure you want to do this, then re-run the command '
-    'with the `--no-user-checking` flag.')
+    'To override this behavior, re-run the command with the '
+    '--no-user-checking flag.')
 
 
 def flags(parser):

--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -52,6 +52,17 @@ To connect to 'example-instance' in zone 'us-central1-a', run:
     $ {0} {1} example-instance --zone us-central1-a""")
 
 
+wrong_user_message = (
+    'The specified Datalab instance was created for {0}, but you '
+    'are attempting to connect to it as {1}.'
+    '\n\n'
+    'Datalab instances are single-user environments, and trying '
+    'to share one will cause problems.'
+    '\n\n'
+    'If you are sure you want to do this, then re-run the command '
+    'with the `--no-user-checking` flag.')
+
+
 def flags(parser):
     """Add command line flags for the `connect` subcommand.
 
@@ -62,6 +73,13 @@ def flags(parser):
         'instance',
         metavar='NAME',
         help='name of the instance to which to connect')
+    parser.add_argument(
+        '--no-user-checking',
+        dest='no_user_checking',
+        action='store_true',
+        default=False,
+        help='do not check if the current user matches the Datalab instance')
+
     connection_flags(parser)
     return
 
@@ -117,12 +135,13 @@ def connection_flags(parser):
     return
 
 
-def connect(args, gcloud_compute):
+def connect(args, gcloud_compute, email):
     """Create a persistent connection to a Datalab instance.
 
     Args:
       args: The Namespace object constructed by argparse
       gcloud_compute: A function that can be called to invoke `gcloud compute`
+      email: The user's email address
     """
     instance = args.instance
     print('Connecting to {0}'.format(instance))
@@ -267,17 +286,17 @@ def connect(args, gcloud_compute):
     return
 
 
-def maybe_start(args, gcloud_compute, instance):
+def maybe_start(args, gcloud_compute, instance, status):
     """Start the given Google Compute Engine VM if it is not running.
 
     Args:
       args: The Namespace instance returned by argparse
       gcloud_compute: Function that can be used to invoke `gcloud compute`
       instance: The name of the instance to check and (possibly) start
+      status: The string describing the status of the instance
     Raises:
       subprocess.CalledProcessError: If one of the `gcloud` calls fail
     """
-    status = utils.get_instance_status(args, gcloud_compute, instance)
     if status != 'RUNNING':
         print('Restarting the instance {0} with status {1}'.format(
             instance, status))
@@ -289,16 +308,24 @@ def maybe_start(args, gcloud_compute, instance):
     return
 
 
-def run(args, gcloud_compute, **unused_kwargs):
+def run(args, gcloud_compute, email='', **unused_kwargs):
     """Implementation of the `datalab connect` subcommand.
 
     Args:
       args: The Namespace instance returned by argparse
       gcloud_compute: Function that can be used to invoke `gcloud compute`
+      email: The user's email address
     Raises:
       subprocess.CalledProcessError: If a nested `gcloud` calls fails
     """
     instance = args.instance
-    maybe_start(args, gcloud_compute, instance)
-    connect(args, gcloud_compute)
+    status, metadata_items = utils.describe_instance(
+        args, gcloud_compute, instance)
+    for_user = metadata_items.get('for-user', '')
+    if (not args.no_user_checking) and for_user and (for_user != email):
+        print(wrong_user_message.format(for_user, email))
+        return
+
+    maybe_start(args, gcloud_compute, instance, status)
+    connect(args, gcloud_compute, email)
     return

--- a/tools/cli/commands/utils.py
+++ b/tools/cli/commands/utils.py
@@ -14,6 +14,7 @@
 
 """Utility methods common to multiple commands."""
 
+import json
 import tempfile
 
 
@@ -49,8 +50,39 @@ def prompt_for_zone(args, gcloud_compute, instance=None):
     return raw_input('Your selected zone: ')
 
 
-def get_instance_status(args, gcloud_compute, instance):
-    """Get the status of the given Google Compute Engine VM.
+def flatten_metadata(metadata):
+    """Flatten the given API-style dictionary into a Python dictionary.
+
+    This takes a mapping of key-value pairs as returned by the Google
+    Compute Engine API, and converts it to a Python dictionary.
+
+    The `metadata` argument is an object that has an `items` field
+    containing a list of key->value mappings. Each key->value mapping
+    is an object with a `key` field and a `value` field.
+
+    Example:
+       Given the following input:
+          { "items": [
+              { "key": "a",
+                "value": 1
+              },
+              { "key": "b",
+                "value": 2
+              },
+            ],
+            "fingerprint": "<something>"
+          }
+       ... this will return {"a": 1, "b": 2}
+    """
+    items = metadata.get('items', [])
+    result = {}
+    for mapping in items:
+        result[mapping.get('key', '')] = mapping.get('value', '')
+    return result
+
+
+def describe_instance(args, gcloud_compute, instance):
+    """Get the status and metadata of the given Google Compute Engine VM.
 
     This will prompt the user to select a zone if necessary.
 
@@ -59,28 +91,34 @@ def get_instance_status(args, gcloud_compute, instance):
       gcloud_compute: Function that can be used to invoke `gcloud compute`
       instance: The name of the instance to check
     Returns:
-      A string describing the status of the instance
-      (e.g. 'RUNNING' or 'TERMINATED')
+      A tupe of the string describing the status of the instance
+      (e.g. 'RUNNING' or 'TERMINATED'), and the list of metadata items.
     Raises:
       subprocess.CalledProcessError: If the `gcloud` call fails
+      ValueError: If the result returned by gcloud is not valid JSON
     """
     get_cmd = ['instances', 'describe', '--quiet']
     if args.zone:
         get_cmd.extend(['--zone', args.zone])
-    get_cmd.extend(['--format', 'value(status)', instance])
+    get_cmd.extend(['--format', 'json(status,metadata.items)', instance])
     try:
         with tempfile.TemporaryFile() as tf:
             gcloud_compute(args, get_cmd, stdout=tf, stderr=tf)
             tf.seek(0)
-            return tf.read().strip()
+            json_result = tf.read().strip()
+            status_and_metadata = json.loads(json_result)
+            status = status_and_metadata.get('status', 'UNKNOWN')
+            metadata = status_and_metadata.get('metadata', {})
+            return (status, flatten_metadata(metadata))
     except:
         if args.zone:
             raise
         else:
             args.zone = prompt_for_zone(
                 args, gcloud_compute, instance=instance)
-            return get_instance_status(args, gcloud_compute, instance)
-    return 'UNKNOWN'
+            return describe_instance(
+                args, gcloud_compute, instance)
+    return ('UNKNOWN', [])
 
 
 def maybe_prompt_for_zone(args, gcloud_compute, instance):
@@ -96,4 +134,4 @@ def maybe_prompt_for_zone(args, gcloud_compute, instance):
       subprocess.CalledProcessError: If the `gcloud` call fails
     """
     if not args.quiet:
-        get_instance_status(args, gcloud_compute, instance)
+        describe_instance(args, gcloud_compute, instance)

--- a/tools/cli/commands/utils.py
+++ b/tools/cli/commands/utils.py
@@ -91,7 +91,7 @@ def describe_instance(args, gcloud_compute, instance):
       gcloud_compute: Function that can be used to invoke `gcloud compute`
       instance: The name of the instance to check
     Returns:
-      A tupe of the string describing the status of the instance
+      A tuple of the string describing the status of the instance
       (e.g. 'RUNNING' or 'TERMINATED'), and the list of metadata items.
     Raises:
       subprocess.CalledProcessError: If the `gcloud` call fails


### PR DESCRIPTION
The overall goal of this change is to make it clear to users that
the Datalab instances they create should be tied to a single user.

We do this by recording for which user the Datalab instance was
created, and then checking that when a user tries to connect to
the instance.

By default, the Datalab instance is created for the user who runs
the `datalab create` command, but there is a new `--for-user` flag
that can be used to override that.

When a user tries to connect to a Datalab instance that was created
for someone else, the code prints out an error message explaining
the user mismatch.

The user still has the option of disabling that check by passing
in the new `--no-user-checking` flag, but this should prevent
users from accidentally stomping on each others' toes.

This fixes #1165