### PR TITLE
Detect when the CLI is run from Google Cloud Shell 

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -240,8 +240,8 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
 
     def on_ready():
         """Callback that handles a successful connection."""
-        print('The connection to Datalab is now open and will '
-              'remain until this command is killed.\n\n')
+        print('\nThe connection to Datalab is now open and will '
+              'remain until this command is killed.')
         if in_cloud_shell:
             print(web_preview_message.format(datalab_port))
         else:

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -481,7 +481,8 @@ def ensure_repo_exists(args, gcloud_repos, repo_name):
             create_repo(args, gcloud_repos, repo_name)
 
 
-def run(args, gcloud_compute, gcloud_repos, email='', **kwargs):
+def run(args, gcloud_compute, gcloud_repos,
+        email='', in_cloud_shell=False, **kwargs):
     """Implementation of the `datalab create` subcommand.
 
     Args:
@@ -490,6 +491,8 @@ def run(args, gcloud_compute, gcloud_repos, email='', **kwargs):
       gcloud_repos: Function that can be used to invoke
         `gcloud alpha source repos`
       email: The user's email address
+      in_cloud_shell: Whether or not the command is being run in the
+        Google Cloud Shell
     Raises:
       subprocess.CalledProcessError: If a nested `gcloud` calls fails
     """
@@ -563,5 +566,5 @@ def run(args, gcloud_compute, gcloud_repos, email='', **kwargs):
             os.remove(for_user_file.name)
 
     if (not args.no_connect) and (not args.for_user):
-        connect.connect(args, gcloud_compute, email)
+        connect.connect(args, gcloud_compute, email, in_cloud_shell)
     return

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -224,7 +224,8 @@ def run():
         _SUBCOMMANDS[args.subcommand]['run'](
             args, gcloud_compute,
             gcloud_repos=gcloud_repos,
-            email=get_email_address())
+            email=get_email_address(),
+            in_cloud_shell=('DEVSHELL_CLIENT_PORT' in os.environ))
     except subprocess.CalledProcessError:
         print('A nested call to gcloud failed.')
 


### PR DESCRIPTION
This change teaches the CLI to detect when it is running inside
of the Google Cloud Shell, and then handle successful connections
differently for that case.

The purpose of this is that the user cannot connect to the 'local'
port in Cloud Shell via the 'localhost' domain name, but rather
must use the 'Web Preview' feature of Cloud Shell to connect to
their Datalab instance. As such, the tool should tell the user
to connect using the 'Web Preview' feature.

This fixes #1139