### PR TITLE
Allow EULA to be suppressed

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -103,7 +103,7 @@ declare module common {
      * If true, allow HTTP requests via websockets.
      */
     allowHttpOverWebsocket: boolean;
-    
+
     /**
      * Whether to automatically back up user's contents dir to GCS
      */
@@ -123,6 +123,12 @@ declare module common {
      * Number of weekly GCS backups of the user's content dir to keep
      */
     numWeeklyBackups: number;
+
+    /**
+     * False if the EULA checks can be skipped because they have been enforced
+     * at a higher level.
+     */
+    eulaAccepted: boolean;
   }
 
   interface Map<T> {

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -23,6 +23,7 @@
   "numHourlyBackups": 10,
   "numDailyBackups": 7,
   "numWeeklyBackups": 20,
+  "eulaAccepted": false,
   "jupyterArgs": [
     "notebook",
     "-y",

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -241,7 +241,7 @@ function uncheckedRequestHandler(request: http.ServerRequest, response: http.Ser
     // We serve these even if the EULA has not been accepted, so that the
     // EULA page can include static resources.
     staticHandler(request, response);
-  } else if (!fs.existsSync(eulaDir())) {
+  } else if (!appSettings.eulaAccepted && !fs.existsSync(eulaDir())) {
     logging.getLogger().info('No Datalab config; redirect to EULA page');
     var eula = path.join(appSettings.datalabRoot, '/datalab/web/static/eula.html');
     fs.readFile(eula, function(error, content) {


### PR DESCRIPTION
This adds a setting to not show the EULA prompt, to be used if the
environment will be enforcing the EULA at a higher level.