### PR TITLE
Replace 127.0.0.1's with localhost to support IPv6-only machines.

### DIFF
--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -69,7 +69,7 @@ function getNextJupyterPort(attempts: number, resolved: (port: number)=>void, fa
    var port = nextJupyterPort;
    nextJupyterPort++;
 
-   tcp.check(port, null).then(
+   tcp.check(port, "localhost").then(
      function(inUse: boolean) {
        if (inUse) {
          getNextJupyterPort(attempts - 1, resolved, failed);
@@ -166,14 +166,14 @@ function createJupyterServerAtPort(port: number, userId: string, userDir: string
 
   // Create the proxy.
   var proxyOptions: httpProxy.ProxyServerOptions = {
-    target: 'http://127.0.0.1:' + port
+    target: 'http://localhost:' + port
   };
 
   server.proxy = httpProxy.createProxyServer(proxyOptions);
   server.proxy.on('proxyRes', responseHandler);
   server.proxy.on('error', errorHandler);
 
-  tcp.waitUntilUsed(server.port, 100, 15000).then(
+  tcp.waitUntilUsedOnHost(server.port, "localhost", 100, 15000).then(
     function() {
       jupyterServers[userId] = server;
       logging.getLogger().info('Jupyter server started for %s.', userId);

--- a/sources/web/datalab/reverseProxy.ts
+++ b/sources/web/datalab/reverseProxy.ts
@@ -74,7 +74,7 @@ export function handleRequest(request: http.ServerRequest,
   }
   else {
     request.url = request.url.replace(regex, '/');
-    proxy.web(request, response, { target: 'http://127.0.0.1:' + port });
+    proxy.web(request, response, { target: 'http://localhost:' + port });
   }
 }
 

--- a/sources/web/datalab/sockets.ts
+++ b/sources/web/datalab/sockets.ts
@@ -47,7 +47,7 @@ var sessionCounter = 0;
  * Creates a WebSocket connected to the Jupyter server for the URL in the specified session.
  */
 function createWebSocket(port: number, session: Session): WebSocket {
-  var socketUrl = 'ws://127.0.0.1:' + port + url.parse(session.url).path;
+  var socketUrl = 'ws://localhost:' + port + url.parse(session.url).path;
   logging.getLogger().debug('Creating WebSocket to %s for session %d', socketUrl, session.id);
 
   var ws = new WebSocket(socketUrl);

--- a/third_party/externs/ts/node/tcp-port-used.d.ts
+++ b/third_party/externs/ts/node/tcp-port-used.d.ts
@@ -25,4 +25,6 @@ declare module 'tcp-port-used' {
   export function check(port: number, host: any): BooleanPromise;
 
   export function waitUntilUsed(port: number, retryMs: number, timeOutMs: number): SimplePromise;
+
+  export function waitUntilUsedOnHost(port: number, host: string, retryTimeMs: number, timeOutMs: number): SimplePromise;
 }


### PR DESCRIPTION
When running on machines with no IPv4 interface, 127.0.0.1 is not a useful IP or
interface name.  localhost on the other hand is ~universally useful for the same
concept, and works equally well on each of IPv4-only, IPv6-only, and dual-stack
machines.

This change replaces 3 explicit usages of "127.0.0.1" and two implicit ones
(hiding behind the default or null arguments to tcp-port-used's functions.

b/35224793