### PR TITLE
Fix potential issues with interactive prompts being hidden.

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -77,9 +77,6 @@ unsupported_browsers = [
 ]
 
 
-max_ssh_attempts = 10
-
-
 def flags(parser):
     """Add command line flags for the `connect` subcommand.
 
@@ -190,12 +187,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
             '--ssh-flag=LogLevel=' + args.ssh_log_level])
         cmd.append('datalab@{0}'.format(instance))
         cmd.extend(['--', 'true'])
-        for attempt in range(max_ssh_attempts):
-            try:
-                gcloud_compute(args, cmd)
-                return
-            except subprocess.CalledProcessError:
-                pass
+        gcloud_compute(args, cmd)
         return
 
     def create_tunnel():


### PR DESCRIPTION
This change is in response to an interactive prompt accidentally
being hidden when connecting to a VM (asking whether or not it
should create the "~/.ssh" directory). However, rather than just
fixing that one issue, this tries to eliminate that entire class
of errors.

The way we do this is by adopting the following design:

1. If a call to gcloud needs to silence the output of gcloud, then
   it calls the call_gcloud_quietly method, which always includes
   the `--quiet` flag in the call to gcloud.
2. The only other time a call to gcloud has the stdout or stderr
   redirected is when the tool needs to process the output of the
   call, and in those cases the tool always adds the `--quiet` flag
   to the call to gcloud.
3. For all remaining calls to gcloud (including the one that caused
   the issue), we do not redirect either the stdout or the stderr,
   but instead use the `--verbosity` flag to control how much output
   gcloud produces.

This change also cleans up some duplicated checks of the `args.quiet`
flag (which is also checked in the underlying `gcloud_compute` method),
and removes the retry loop from the initial check of whether or not a VM
is SSH-able.