### PR TITLE
Improve the error message when a user does not have permission to create the repository.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -181,6 +181,18 @@ spec:
 """
 
 
+class RepositoryException(Exception):
+
+    _MESSAGE = (
+        'Failed to find or create the repository {}.'
+        '\n\n'
+        'Ask a project owner to create it for you.')
+
+    def __init__(self, repo_name):
+        super(RepositoryException, self).__init__(
+            RepositoryException._MESSAGE.format(repo_name))
+
+
 def flags(parser):
     """Add command line flags for the `create` subcommand.
 
@@ -504,7 +516,10 @@ def ensure_repo_exists(args, gcloud_repos, repo_name):
         tf.seek(0)
         matching_repos = tf.read().strip()
         if not matching_repos:
-            create_repo(args, gcloud_repos, repo_name)
+            try:
+                create_repo(args, gcloud_repos, repo_name)
+            except:
+                raise RepositoryException(repo_name)
 
 
 def run(args, gcloud_compute, gcloud_repos,


### PR DESCRIPTION
Only project owners can create a repository, so project editors who
create a Datalab instance for the first time might hit a permission
denied error when running that step.

The current error message only tells you that you don't have permission,
so this changes it to instead tell you who you need to ask to fix
the issue (i.e. a project owner).