### PR TITLE
Make the `datalab ... --help` output more readable

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -24,7 +24,7 @@ import webbrowser
 import utils
 
 
-description = ("""{0} {1} creates a persistent connection to a
+description = ("""`{0} {1}` creates a persistent connection to a
 Datalab instance running in a Google Compute Engine VM.
 
 This is a thin wrapper around the *ssh(1)* command that takes care

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -22,7 +22,7 @@ import connect
 import utils
 
 
-description = ("""{0} {1} creates a new Datalab instances running in a Google
+description = ("""`{0} {1}` creates a new Datalab instances running in a Google
 Compute Engine VM.
 
 This command also creates the 'datalab-network' network if necessary.

--- a/tools/cli/commands/delete.py
+++ b/tools/cli/commands/delete.py
@@ -17,7 +17,7 @@
 import utils
 
 
-description = ("""{0} {1} deletes the given Datalab instance's
+description = ("""`{0} {1}` deletes the given Datalab instance's
 Google Compute Engine VM.
 
 By default, the persistent disk's auto-delete configuration determines

--- a/tools/cli/commands/list.py
+++ b/tools/cli/commands/list.py
@@ -25,7 +25,7 @@ For more details run `gcloud topic filters`.""")
 _ZONES_HELP = """List of zones to which to limit the resulting list."""
 
 
-description = ("""{0} {1} displays the Datalab instances running in Google
+description = ("""`{0} {1}` displays the Datalab instances running in Google
 Compute Engine VM's in a project.
 
 By default, instances from all zones are listed. The results

--- a/tools/cli/commands/stop.py
+++ b/tools/cli/commands/stop.py
@@ -17,7 +17,7 @@
 import utils
 
 
-description = ("""{0} {1} stops the given Datalab instance's
+description = ("""`{0} {1}` stops the given Datalab instance's
 Google Compute Engine VM.""")
 
 

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -24,7 +24,6 @@ from commands import create, connect, list, stop, delete
 import argparse
 import os
 import subprocess
-import sys
 
 
 _SUBCOMMANDS = {
@@ -168,8 +167,9 @@ def get_email_address():
 
 def run():
     """Run the command line tool."""
+    prog = 'datalab'
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter)
+        prog=prog, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument(
         '--project',
         dest='project',
@@ -190,7 +190,6 @@ def run():
     for subcommand in _SUBCOMMANDS:
         command_config = _SUBCOMMANDS[subcommand]
         description_template = command_config.get('description')
-        prog = sys.argv[0]
         command_description = (
             description_template.format(prog, subcommand))
         examples = command_config.get('examples', '').format(prog, subcommand)


### PR DESCRIPTION
This fixes two readability issues with help output:

1. References to command invocations are now quoted so that it is easier to tell what is a reference to a command and what is text describing that command.
2. The program name is now hard-coded to `datalab`, as the argv[0] value was being set to the fully qualified path to the 'datalab.py' python file.