### PR TITLE
Switch the default image tag to be "latest" instead of "local".

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -206,7 +206,7 @@ def flags(parser):
     parser.add_argument(
         '--image-name',
         dest='image_name',
-        default='gcr.io/cloud-datalab/datalab:local',
+        default='gcr.io/cloud-datalab/datalab:latest',
         help=(
             'name of the Datalab image to run.'
             '\n\n'

--- a/tools/release/publish.sh
+++ b/tools/release/publish.sh
@@ -62,6 +62,8 @@ gcloud docker -- push gcr.io/${PROJECT_ID}/datalab-gateway:latest
 echo "Releasing the Datalab image: ${DATALAB_IMAGE}"
 docker tag -f ${DATALAB_IMAGE} gcr.io/${PROJECT_ID}/datalab:local
 gcloud docker -- push gcr.io/${PROJECT_ID}/datalab:local
+docker tag -f ${DATALAB_IMAGE} gcr.io/${PROJECT_ID}/datalab:latest
+gcloud docker -- push gcr.io/${PROJECT_ID}/datalab:latest
 
 gsutil cp gs://${PROJECT_ID}/deploy/config_local.js ./config_local.js
 OLD_VERSION=`cat ./config_local.js | grep previous | cut -d ':' -f 2`


### PR DESCRIPTION
We were previously not using the "latest" tag because that had
been used by oure beta1 release, which ran in App Engine.

However, that has been deprecated for so long that we can now
take back the "latest" tag.

This change updates the default for the CLI and the release
script.

The release script will continue to also update the "local" tag,
so that anyone using it can still get updates.