### PR TITLE
Remove the ensure_sshable method.

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -14,8 +14,6 @@
 
 """Methods for implementing the `datalab connect` command."""
 
-import os
-import os.path
 import subprocess
 import threading
 import urllib2


### PR DESCRIPTION
Previously, the `datalab connect` command was calling `gcloud compute ssh`
twice, once with output forwarded to the user, and once with output
written to a log file.

That was causing issues when a user has a passphrase on their SSH key,
because they would be prompted for the passphrase repeatedly.

This also didn't seem to save anything in terms of the actual verbosity
of the `connect` command output.

This fixes #1214 (at least as much as we can).