### PR TITLE
Add magics defined under google.datalab from pydatalab extension

### DIFF
--- a/containers/base/config/ipython.py
+++ b/containers/base/config/ipython.py
@@ -18,6 +18,7 @@ c = get_config()
 
 # Implicitly imported packages.
 c.InteractiveShellApp.extensions = [
+  'google.datalab.kernel',
   'datalab.kernel',
   'matplotlib',
   'seaborn',


### PR DESCRIPTION
This imports and readies the new magics defined under google.datalab, which was recently committed to master in pydatalab (https://github.com/googledatalab/pydatalab/pull/241).