### PR TITLE
Remove output indent by disabling unused output prompt.

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -410,6 +410,9 @@ div.output_area {
   margin-top: 4px;
   margin-left: 38px;
 }
+div.output_area div.prompt {
+  display: none;
+}
 div.output_scroll {
   border-radius: 0;
   -webkit-box-shadow: none;


### PR DESCRIPTION
Datalab already has css to hide the input indent. This change does a similar thing for the output indent.