### PR TITLE
Fix visuals for ipywidgets Widgets menu.

### DIFF
--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -34,6 +34,12 @@ button:hover {
   background-color: #333;
   color: #ddd;
 }
+#help_menu_container li.dropdown a {
+  color: #ddd;
+}
+#help_menu_container li.dropdown a:hover {
+  color: #fff;
+}
 .btn-default:hover, .btn-default:focus {
   background-color: #222;
   color: #ddd;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -215,14 +215,14 @@ div.btn-group a {
 div.btn-toolbar {
   margin: 0px;
 }
-div.btn-toolbar .toolbar-btn {
+div.btn-toolbar .toolbar-btn, #help_menu_container .dropdown-toggle {
   background-color: transparent;
   border: none;
   font-family: 'Open Sans', Helvetica, sans-serif;
   font-weight: normal;
   font-size: 14px;
   outline: solid 1px transparent !important;
-  height: 46px;
+  /* height: 46px; */
   margin-left: 0px;
   padding: 0px 8px;
   cursor: pointer;
@@ -252,6 +252,12 @@ div.btn-toolbar .toolbar-btn.active {
 }
 #toggleSidebarButton {
   margin-bottom: 8px;
+}
+#help_menu_container li.dropdown {
+  list-style: none;
+}
+#help_menu_container li.dropdown a {
+  text-decoration: none;
 }
 
 #logo {

--- a/sources/web/datalab/static/light.css
+++ b/sources/web/datalab/static/light.css
@@ -32,6 +32,12 @@ div.btn-toolbar .toolbar-btn {
   color: #666;
   background-color: transparent;
 }
+#help_menu_container li.dropdown a {
+  color: #666;
+}
+#help_menu_container li.dropdown a:hover {
+  color: #000;
+}
 div.btn-toolbar .toolbar-btn:hover, div.btn-toolbar .btn:focus {
   color: #000;
 }

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -175,7 +175,7 @@
               </button>
             </div>
             <!-- The next div and its contents are for ipywidgets. They insert their own menu before #help_menu -->
-            <div class="btn-group">
+            <div class="btn-group" id="help_menu_container">
               <div>
                 <div id="help_menu">
                 </div>


### PR DESCRIPTION
Commenting out the height line makes the Widgets menu vertically aligned with the other menus. Probably not the best solution, but seems to work.