### PR TITLE
responsive design, fix scrollbars

### DIFF
--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -11,7 +11,7 @@
     <button class="toolbar-btn" title="Rename notebook"><span id="notebook_name" class="filename"></span></button>
     <span class="autosave_status"></span>
   </span>
-  <div class="btn-toolbar pull-right">
+  <div class="btn-toolbar pull-right right-toolbar">
     <div class="btn-group">
       <button id="ungitButton" title="Open ungit on the notebooks repository" class="toolbar-btn">
         <span class="fa fa-code-fork"></span>

--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -277,7 +277,6 @@ table.bqsv th, table.bqsv td {
 }
 
 .cm-s-ipython .CodeMirror-matchingbracket {
-  text-decoration: underline;
   color: white !important;
 }
 

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -24,7 +24,7 @@
 body {
   font-family: 'Open Sans', Helvetica, sans-serif;
   font-size: 14px;
-  min-width: 1250px;
+  min-width: 700px;
 }
 
 /* Layout */
@@ -141,6 +141,7 @@ body {
   position: relative;
   padding-top: 10px;
   min-width: 100px;
+  overflow: auto;
 }
 #sidebarToolbar.larger {
   -webkit-flex-grow: 3;
@@ -163,7 +164,6 @@ body {
   left: 0px;
   right: 0px;
   bottom: 0px;
-  overflow: auto;
 }
 .fileMainContent {
   overflow: auto;
@@ -508,5 +508,12 @@ div.modal-dialog pre, div.modal-dialog code, #help code, #help pre {
   div.cell.selected {
     border: none !important;
     box-shadow: none !important;
+  }
+}
+
+/* Responsive Design */
+@media screen and (max-width: 1150px) {
+  span.toolbar-text {
+    display: none;
   }
 }

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -24,7 +24,7 @@
 body {
   font-family: 'Open Sans', Helvetica, sans-serif;
   font-size: 14px;
-  min-width: 700px;
+  min-width: 650px;
 }
 
 /* Layout */
@@ -62,6 +62,8 @@ body {
   padding-right: 10px;
   position: relative;
   z-index: 10;
+  display: flex;
+  justify-content: space-between;
 }
 #site {
   -webkit-order: 2;
@@ -258,6 +260,7 @@ div.btn-toolbar .toolbar-btn.active {
 
 #logo {
   margin-left: 12px;
+  flex: 0 0 auto;
 }
 #logo, #logo img {
   height: 32px;
@@ -315,6 +318,14 @@ span.save_widget span.filename {
   border: none;
   padding: 0px;
   margin: 0px;
+}
+span.save_widget {
+  overflow: hidden;
+  white-space: nowrap;
+  flex: 1 1 auto;
+}
+div.right-toolbar {
+  flex: 0 0 auto;
 }
 span.autosave_status {
   font-size: 13px;
@@ -512,7 +523,7 @@ div.modal-dialog pre, div.modal-dialog code, #help code, #help pre {
 }
 
 /* Responsive Design */
-@media screen and (max-width: 1150px) {
+@media screen and (max-width: 1170px) {
   span.toolbar-text {
     display: none;
   }

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -130,24 +130,32 @@
           <div class="btn-toolbar pull-left">
             <div class="btn-group">
               <button id="addCodeCellButton" type="button" class="toolbar-btn" title="Append a new code cell">
-                <span class="fa fa-plus-square"></span> Add Code
+                <span class="fa fa-plus-square">
+                  <span class="fa fa-code"></span>
+                </span>
+                <span class="toolbar-text">Add Code</span>
               </button>
               <button id="addMarkdownCellButton" type="button" class="toolbar-btn" title="Append a new markdown cell">
-                <span class="fa fa-plus-square"></span> Add Markdown
+                <span class="fa fa-plus-square"> T</span>
+                <span class="toolbar-text">Add Markdown</span>
               </button>
               <button id="deleteCellButton" type="button" class="toolbar-btn" title="Delete the selected cell">
-                <span class="fa fa-minus-square"></span> Delete
+                <span class="fa fa-minus-square"></span>
+                <span class="toolbar-text">Delete</span>
               </button>
               <button id="moveCellUpButton" type="button" class="toolbar-btn" title="Move the selected cell up">
-                <span class="fa fa-chevron-up"></span> Move Up
+                <span class="fa fa-chevron-up"></span>
+                <span class="toolbar-text">Move Up</span>
               </button>
               <button id="moveCellDownButton" type="button" class="toolbar-btn" title="Move the selected cell down">
-                <span class="fa fa-chevron-down"></span> Move Down
+                <span class="fa fa-chevron-down"></span>
+                <span class="toolbar-text">Move Down</span>
               </button>
             </div>
             <div class="btn-group">
               <button id="runButton" type="button" class="toolbar-btn" title="Run the selected cell">
-                <span class="fa fa-play"></span> Run
+                <span class="fa fa-play"></span>
+                <span class="toolbar-text">Run</span>
               </button>
               <button type="button" class="toolbar-btn dropdown-toggle" data-toggle="dropdown">
                 <span class="caret"></span>
@@ -160,7 +168,8 @@
             </div>
             <div class="btn-group">
               <button id="clearButton" type="button" class="toolbar-btn" title="Clear outputs of the selected cell">
-                <span class="fa fa-minus-square-o"></span> Clear
+                <span class="fa fa-minus-square-o"></span>
+                <span class="toolbar-text">Clear</span>
               </button>
               <button type="button" class="toolbar-btn dropdown-toggle" data-toggle="dropdown">
                 <span class="caret"></span>
@@ -171,7 +180,8 @@
             </div>
             <div class="btn-group">
               <button id="resetSessionButton" type="button" class="toolbar-btn" title="Restart the current notebook session">
-                <i id="kernel_indicator_icon"></i> Reset Session
+                <i id="kernel_indicator_icon"></i>
+                <span class="toolbar-text">Reset Session</span>
               </button>
             </div>
             <!-- The next div and its contents are for ipywidgets. They insert their own menu before #help_menu -->

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -140,7 +140,7 @@
                 <span class="toolbar-text">Add Markdown</span>
               </button>
               <button id="deleteCellButton" type="button" class="toolbar-btn" title="Delete the selected cell">
-                <span class="fa fa-minus-square"></span>
+                <span class="fa fa-times"></span>
                 <span class="toolbar-text">Delete</span>
               </button>
               <button id="moveCellUpButton" type="button" class="toolbar-btn" title="Move the selected cell up">
@@ -154,8 +154,7 @@
             </div>
             <div class="btn-group">
               <button id="runButton" type="button" class="toolbar-btn" title="Run the selected cell">
-                <span class="fa fa-play"></span>
-                <span class="toolbar-text">Run</span>
+                <span class="fa fa-play"></span> Run
               </button>
               <button type="button" class="toolbar-btn dropdown-toggle" data-toggle="dropdown">
                 <span class="caret"></span>
@@ -168,8 +167,7 @@
             </div>
             <div class="btn-group">
               <button id="clearButton" type="button" class="toolbar-btn" title="Clear outputs of the selected cell">
-                <span class="fa fa-minus-square-o"></span>
-                <span class="toolbar-text">Clear</span>
+                <span class="fa fa-minus-square-o"></span> Clear
               </button>
               <button type="button" class="toolbar-btn dropdown-toggle" data-toggle="dropdown">
                 <span class="caret"></span>
@@ -180,8 +178,8 @@
             </div>
             <div class="btn-group">
               <button id="resetSessionButton" type="button" class="toolbar-btn" title="Restart the current notebook session">
-                <i id="kernel_indicator_icon"></i>
-                <span class="toolbar-text">Reset Session</span>
+                <i id="kernel_indicator_icon"></i> Reset
+                <span class="toolbar-text">Session</span>
               </button>
             </div>
             <!-- The next div and its contents are for ipywidgets. They insert their own menu before #help_menu -->
@@ -196,8 +194,14 @@
         <div id="sidebarToolbar">
           <div class="btn-toolbar pull-right">
             <div class="btn-group">
-              <button id="navigationButton" type="button" class="toolbar-btn">Navigation</button>
-              <button id="helpButton" type="button" class="toolbar-btn active">Help</button>
+              <button id="navigationButton" type="button" class="toolbar-btn" title="Notebook Navigation">
+                <span class="fa fa-bookmark-o"></span>
+                <span class="toolbar-text">Navigation</span>
+              </button>
+              <button id="helpButton" type="button" class="toolbar-btn active" title="Help">
+                <span class="fa fa-question"></span>
+                <span class="toolbar-text">Help</span>
+              </button>
             </div>
             <div class="btn-group">
               <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Toggle sidebar on/off">


### PR DESCRIPTION
Fixes #1223 and #889 

- Fix scrolling issues across main content area and sidebar
- Make page more responsive by collapsing toolbar button texts to show only the button icons. For that I had to also add some more icons to distinguish the Add Code and Add Markdown buttons, image below.

![image](https://cloud.githubusercontent.com/assets/1424661/23570574/a055adb4-0019-11e7-91b9-df7b4fbecf06.png)

![image](https://cloud.githubusercontent.com/assets/1424661/23570558/8e222884-0019-11e7-9a49-ae4eb3829a6b.png)