### PR TITLE
UI refresh - use material icons

### DIFF
--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -18,42 +18,42 @@
       </button>
     </div>
     <div class="btn-group">
+      <a href="/sessions" target="_blank" id="sessionsButton">
+        <button title="Running Sessions" class="toolbar-btn">
+          <i class="material-icons">playlist_play</i>
+        </button>
+      </a>
+    </div>
+    <div class="btn-group">
       <button class="toolbar-btn" data-toggle="dropdown" title="Help Links">
-        <span class="fa fa-question-circle"></span>
+        <i class="material-icons">open_in_new</i>
       </button>
       <ul class="dropdown-menu dropdown-menu-right" style="width: 200px">
         <li><a id="keyboardHelpLink" style="display:none" href="#">Keyboard Shortcuts</a></li>
         <li><a id="markdownHelpLink" style="display:none" href="#">Markdown Syntax</a></li>
         <li id="notebookHelpDivider" class="divider" style="display:none"></li>
-        <li><a href="https://cloud.google.com/bigquery/what-is-bigquery" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>BigQuery&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></a></li>
-        <li><a href="https://cloud.google.com/storage/docs/overview" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Cloud Storage&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></a></li>
+        <li><a href="https://cloud.google.com/bigquery/what-is-bigquery" target="_blank"><span>BigQuery&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></a></li>
+        <li><a href="https://cloud.google.com/storage/docs/overview" target="_blank"><span>Cloud Storage&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></a></li>
         <li class="divider"></li>
-        <li><a href="https://developers.google.com/chart/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Google Charts</span></a></li>
-        <li><a href="http://matplotlib.org/contents.html" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Matplotlib</span></a></li>
-        <li><a href="http://pandas.pydata.org/pandas-docs/stable/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Pandas</span></a></li>
-        <li><a href="http://scikit-learn.org/stable/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>SciKit-Learn</span></a></li>
+        <li><a href="https://developers.google.com/chart/" target="_blank"><span>Google Charts</span></a></li>
+        <li><a href="http://matplotlib.org/contents.html" target="_blank"><span>Matplotlib</span></a></li>
+        <li><a href="http://pandas.pydata.org/pandas-docs/stable/" target="_blank"><span>Pandas</span></a></li>
+        <li><a href="http://scikit-learn.org/stable/" target="_blank"><span>SciKit-Learn</span></a></li>
         <li class="divider"></li>
-        <li><a href="/tree/datalab/docs" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Samples and Tutorials</span></a></li>
-        <li><a href="http://googledatalab.github.io/pydatalab/" target="_blank"><i class="fa fa-external-link pull-right menu-icon"></i><span>Datalab API</span></a></li>
+        <li><a href="/tree/datalab/docs" target="_blank"><span>Samples and Tutorials</span></a></li>
+        <li><a href="http://googledatalab.github.io/pydatalab/" target="_blank"><span>Datalab API</span></a></li>
       </ul>
     </div>
     <div class="btn-group">
       <button id="aboutButton" title="About Google Cloud Datalab" class="toolbar-btn">
-        <span class="fa fa-info-circle"></span>
+        <i class="material-icons">info_outline</i>
       </button>
-    </div>
-    <div class="btn-group">
-      <a href="/sessions" target="_blank" id="sessionsButton">
-        <button title="Running Sessions" class="toolbar-btn">
-          <span class="fa fa-tasks"></span>
-        </button>
-      </a>
     </div>
     <div id="accountDropdown" class="btn-group">
       <button id="accountDropdownButton" title="Account" class="toolbar-btn">
-        <span class="fa fa-user"></span>
+        <i class="material-icons">account_circle</i>
       </button>
-      <div class="dropdown-menu dropdown-menu-right">
+      <div class="dropdown-menu dropdown-menu-right" style="min-width: 250px;">
         <div id="signInButton" style="display:none">
           <button title="Sign In" class="btn btn-success" style="width: 100%; float: none">Sign In</button>
         </div>
@@ -81,9 +81,11 @@
             <label><input type="radio" id="darkThemeRadioOption" checked="">Dark Theme</label>
           </div>
         </div>
-        <div id="feedbackButton" title="Provide feedback" class="btn">
-          <span class="fa fa-comment" id="feedbackButton"></span>
-          <span>Feedback</span>
+        <div>
+          <div id="feedbackButton" title="Provide feedback" class="btn btn-default">
+            <i class="material-icons" id="feedbackButton">feedback</i>
+            <span>Feedback</span>
+          </div>
         </div>
       </div>
     </div>

--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -37,8 +37,10 @@
         <li class="divider"></li>
         <li><a href="https://developers.google.com/chart/" target="_blank"><span>Google Charts</span></a></li>
         <li><a href="http://matplotlib.org/contents.html" target="_blank"><span>Matplotlib</span></a></li>
+        <li><a href="http://docs.scipy.org/doc/numpy/reference/" target="_blank"><span>Numpy</span></a></li>
         <li><a href="http://pandas.pydata.org/pandas-docs/stable/" target="_blank"><span>Pandas</span></a></li>
         <li><a href="http://scikit-learn.org/stable/" target="_blank"><span>SciKit-Learn</span></a></li>
+        <li><a href="http://tensorflow.org" target="_blank"><span>TensorFlow</span></a></li>
         <li class="divider"></li>
         <li><a href="/tree/datalab/docs" target="_blank"><span>Samples and Tutorials</span></a></li>
         <li><a href="http://googledatalab.github.io/pydatalab/" target="_blank"><span>Datalab API</span></a></li>

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -13,7 +13,7 @@
  */
 
 /* Font Imports */
-@import url(https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700|Open+Sans:400,700);
+@import url(https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700|Open+Sans:400,700|Material+Icons);
 
 * {
   padding: 0px;
@@ -24,7 +24,7 @@
 body {
   font-family: 'Open Sans', Helvetica, sans-serif;
   font-size: 14px;
-  min-width: 650px;
+  min-width: 710px;
 }
 
 /* Layout */
@@ -247,6 +247,10 @@ div.btn-toolbar .toolbar-btn.active {
   font-weight: bold;
   border: none;
   box-shadow: none;
+}
+i.material-icons {
+  font-size: 18px !important;
+  vertical-align: sub !important;
 }
 #toggleSidebarButton {
   margin-bottom: 8px;
@@ -523,7 +527,7 @@ div.modal-dialog pre, div.modal-dialog code, #help code, #help pre {
 }
 
 /* Responsive Design */
-@media screen and (max-width: 1170px) {
+@media screen and (max-width: 1230px) {
   span.toolbar-text {
     display: none;
   }

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -131,7 +131,8 @@ function reportEvent(event) {
 function toggleSidebar() {
   var d = document.getElementById('sidebarArea');
   d.style.display = (d.style.display == 'none') ? 'block' : 'none';
-  document.getElementById('hideSidebarButton').classList.toggle('fa-flip-vertical');
+  rotated = $('#hideSidebarButton>.material-icons').css('transform').indexOf('matrix') > -1;
+  $('#hideSidebarButton>.material-icons').css('transform', rotated ? '' : 'rotate(180deg)')
   this.blur();
   // Chrome at least seems to render the notebook poorly after this for a little
   // while. If you scroll new content into view it is messed up until you click
@@ -236,12 +237,12 @@ function initializePage(dialog, saveFn) {
       '<p>Explore, transform, visualize and process data using BigQuery and Google Cloud Storage.</p><br />' +
       '<pre>Version: ' + version  + '\nBased on Jupyter (formerly IPython) 4</pre>' +
       '<h5><b>More Information</b></h5>' +
-      '<span class="fa fa-external-link-square">&nbsp;</span><a href="https://cloud.google.com" target="_blank">Product information</a><br />' +
-      '<span class="fa fa-external-link-square">&nbsp;</span><a href="https://github.com/googledatalab/datalab" target="_blank">Project on GitHub</a><br />' +
-      '<span class="fa fa-external-link-square">&nbsp;</span><a href="/static/about.txt" target="_blank">License and software information</a><br />' +
-      '<span class="fa fa-external-link-square">&nbsp;</span><a href="https://cloud.google.com/terms/" target="_blank">Terms of Service</a><br />' +
-      '<span class="fa fa-external-link-square">&nbsp;</span><a href="http://www.google.com/intl/en/policies/" target="_blank">Privacy Policy</a><br />' +
-      '<span class="fa fa-recycle">&nbsp;</span><a href="javascript:restartDatalab()">Restart Server</a><br />';
+      '<i class="material-icons">open_in_new</i><a href="https://cloud.google.com" target="_blank">Product information</a><br />' +
+      '<i class="material-icons">open_in_new</i><a href="https://github.com/googledatalab/datalab" target="_blank">Project on GitHub</a><br />' +
+      '<i class="material-icons">open_in_new</i><a href="/static/about.txt" target="_blank">License and software information</a><br />' +
+      '<i class="material-icons">open_in_new</i><a href="https://cloud.google.com/terms/" target="_blank">Terms of Service</a><br />' +
+      '<i class="material-icons">open_in_new</i><a href="http://www.google.com/intl/en/policies/" target="_blank">Privacy Policy</a><br />' +
+      '<i class="material-icons">open_in_new</i><a href="javascript:restartDatalab()">Restart Server</a><br />';
 
     var dialogOptions = {
       title: 'About Google Cloud Datalab',
@@ -360,13 +361,12 @@ function initializePage(dialog, saveFn) {
 
 // constants for minitoolbar operations
 const CELL_METADATA_COLLAPSED = 'hiddenCell';
-const COLLAPSE_BUTTON_CLASS = 'fa-compress';
-const UNCOLLAPSE_BUTTON_CLASS = 'fa-expand';
+const COLLAPSE_BUTTON_CLASS = 'vertical_align_top';
+const UNCOLLAPSE_BUTTON_CLASS = 'vertical_align_bottom';
 const CELL_METADATA_CODE_COLLAPSED = 'codeCollapsed';
-const COLLAPSE_CODE_BUTTON_CLASS = 'fa-code';
-const UNCOLLAPSE_CODE_BUTTON_CLASS = 'fa-code';
-const RUN_CELL_BUTTON_CLASS = 'fa-play';
-const CLEAR_CELL_BUTTON_CLASS = 'fa-minus-square-o';
+const COLLAPSE_CODE_BUTTON_CLASS = 'code';
+const RUN_CELL_BUTTON_CLASS = 'play_arrow';
+const CLEAR_CELL_BUTTON_CLASS = 'check_box_outline_blank';
 
 function toggleCollapseCell(cell) {
   isCollapsed = cell.metadata[CELL_METADATA_COLLAPSED] || false;
@@ -398,9 +398,8 @@ function collapseCell(cell) {
 
   cell.element.find('div.widget-area').hide();
   cell.element.find('div.cellPlaceholder')[0].innerHTML = getCollapsedCellHeader(cell);
-  collapseSpan = cell.element.find('span.glyph-collapse-cell').removeClass(COLLAPSE_BUTTON_CLASS);
-  collapseSpan = cell.element.find('span.glyph-collapse-cell').addClass(UNCOLLAPSE_BUTTON_CLASS);
-  collapseSpan = cell.element.find('span.title-collapse-cell')[0].innerText = 'Expand';
+  collapseSpan = cell.element.find('.glyph-collapse-cell')[0].innerText = UNCOLLAPSE_BUTTON_CLASS;
+  collapseSpan = cell.element.find('.title-collapse-cell')[0].innerText = 'Expand';
 
   cell.metadata[CELL_METADATA_COLLAPSED] = true;
 }
@@ -416,9 +415,8 @@ function uncollapseCell(cell) {
   if (widgetSubarea.children.length > 0)
     cell.element.find('div.widget-area').show();
   cell.element.find('div.cellPlaceholder')[0].innerHTML = '';
-  collapseSpan = cell.element.find('span.glyph-collapse-cell').removeClass(UNCOLLAPSE_BUTTON_CLASS);
-  collapseSpan = cell.element.find('span.glyph-collapse-cell').addClass(COLLAPSE_BUTTON_CLASS);
-  collapseSpan = cell.element.find('span.title-collapse-cell')[0].innerText = 'Collapse';
+  collapseSpan = cell.element.find('.glyph-collapse-cell')[0].innerText = COLLAPSE_BUTTON_CLASS;
+  collapseSpan = cell.element.find('.title-collapse-cell')[0].innerText = 'Collapse';
 
   cell.metadata[CELL_METADATA_COLLAPSED] = false;
 
@@ -471,10 +469,11 @@ function createCellMiniToolbarButton(description) {
   anchor.href = "#";
 
   // span for button icon
-  let glyphSpan = document.createElement('span');
-  glyphSpan.className = description.className + ' glyph-' + description.id;
-  glyphSpan.style.width = '20px';
-  anchor.appendChild(glyphSpan);
+  let glyphElement = document.createElement('i');
+  glyphElement.className = 'material-icons' + ' glyph-' + description.id;
+  glyphElement.innerText = description.className;
+  glyphElement.style.paddingRight = '10px';
+  anchor.appendChild(glyphElement);
 
   // span for button title
   let titleSpan = document.createElement('span');
@@ -498,7 +497,7 @@ function addCellMiniToolbar(cell) {
   let toolbarToggle = document.createElement('button');
   toolbarToggle.className = 'btn btn-default dropdown-toggle minitoolbar-toggle';
   toolbarToggle.setAttribute('data-toggle', 'dropdown');
-  toolbarToggle.innerHTML = '<span class="fa fa-bars"></span>';
+  toolbarToggle.innerHTML = '<i class="material-icons">menu</i>';
   toolbarDiv.appendChild(toolbarToggle);
 
   let toolbarButtonList = document.createElement('ul');
@@ -535,7 +534,7 @@ function addCellMiniToolbar(cell) {
     {
       id: 'run-cell',
       title: 'Run',
-      className: 'fa ' + RUN_CELL_BUTTON_CLASS,
+      className: RUN_CELL_BUTTON_CLASS,
       clickHandler: function() {
         cell.execute();
       }
@@ -544,7 +543,7 @@ function addCellMiniToolbar(cell) {
     {
       id: 'clear-cell',
       title: 'Clear',
-      className: 'fa ' + CLEAR_CELL_BUTTON_CLASS,
+      className: CLEAR_CELL_BUTTON_CLASS,
       clickHandler: function() {
         cell.clear_output();
       }
@@ -553,7 +552,7 @@ function addCellMiniToolbar(cell) {
     {
       id: 'collapse-cell',
       title: 'Collapse',
-      className: 'fa ' + COLLAPSE_BUTTON_CLASS,
+      className: COLLAPSE_BUTTON_CLASS,
       clickHandler: function() {
         toggleCollapseCell(cell);
       }
@@ -562,7 +561,7 @@ function addCellMiniToolbar(cell) {
     {
       id: 'collapse-code',
       title: 'Hide Code',
-      className: 'fa ' + COLLAPSE_CODE_BUTTON_CLASS,
+      className: COLLAPSE_CODE_BUTTON_CLASS,
       clickHandler: function() {
         toggleCollapseCode(cell);
       }
@@ -1117,7 +1116,8 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
 
   $('#toggleSidebarButton').click(function() {
     document.getElementById('sidebarArea').classList.toggle('larger');
-    document.getElementById('toggleSidebarButton').classList.toggle('fa-flip-horizontal');
+    rotated = $('#toggleSidebarButton').css('transform').indexOf('matrix') > -1;
+    $('#toggleSidebarButton').css('transform', rotated ? '' : 'rotate(180deg)');
     this.blur();
   });
 
@@ -1361,7 +1361,7 @@ function initializeNotebookList(ipy, notebookList, newNotebook, events, dialog, 
 
     var html = [];
     html.push('<ul class="breadcrumb">');
-    html.push('<li><a href="/tree"><i class="fa fa-home"></i></a></li>');
+    html.push('<li><a href="/tree"><i class="material-icons">home</i></a></li>');
 
     var segments = [];
 

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -237,12 +237,12 @@ function initializePage(dialog, saveFn) {
       '<p>Explore, transform, visualize and process data using BigQuery and Google Cloud Storage.</p><br />' +
       '<pre>Version: ' + version  + '\nBased on Jupyter (formerly IPython) 4</pre>' +
       '<h5><b>More Information</b></h5>' +
-      '<i class="material-icons">open_in_new</i><a href="https://cloud.google.com" target="_blank">Product information</a><br />' +
-      '<i class="material-icons">open_in_new</i><a href="https://github.com/googledatalab/datalab" target="_blank">Project on GitHub</a><br />' +
-      '<i class="material-icons">open_in_new</i><a href="/static/about.txt" target="_blank">License and software information</a><br />' +
-      '<i class="material-icons">open_in_new</i><a href="https://cloud.google.com/terms/" target="_blank">Terms of Service</a><br />' +
-      '<i class="material-icons">open_in_new</i><a href="http://www.google.com/intl/en/policies/" target="_blank">Privacy Policy</a><br />' +
-      '<i class="material-icons">open_in_new</i><a href="javascript:restartDatalab()">Restart Server</a><br />';
+      '<i class="material-icons">open_in_new</i><a href="https://cloud.google.com" target="_blank"> Product information</a><br />' +
+      '<i class="material-icons">open_in_new</i><a href="https://github.com/googledatalab/datalab" target="_blank"> Project on GitHub</a><br />' +
+      '<i class="material-icons">open_in_new</i><a href="/static/about.txt" target="_blank"> License and software information</a><br />' +
+      '<i class="material-icons">open_in_new</i><a href="https://cloud.google.com/terms/" target="_blank"> Terms of Service</a><br />' +
+      '<i class="material-icons">open_in_new</i><a href="http://www.google.com/intl/en/policies/" target="_blank"> Privacy Policy</a><br />' +
+      '<i class="material-icons">open_in_new</i><a href="javascript:restartDatalab()"> Restart Server</a><br />';
 
     var dialogOptions = {
       title: 'About Google Cloud Datalab',

--- a/sources/web/datalab/templates/edit.html
+++ b/sources/web/datalab/templates/edit.html
@@ -34,7 +34,7 @@
           <div class="btn-toolbar pull-left">
             <div class="btn-group">
               <button type="button" class="toolbar-btn" data-toggle="dropdown" title="File commands">
-                <i class="material-icons">insert_drive_file</i>
+                <i class="material-icons">insert_drive_file</i> File
               </button>
               <ul class="dropdown-menu">
                 <li id="saveButton"><a href="#">Save</a></li>

--- a/sources/web/datalab/templates/edit.html
+++ b/sources/web/datalab/templates/edit.html
@@ -34,7 +34,7 @@
           <div class="btn-toolbar pull-left">
             <div class="btn-group">
               <button type="button" class="toolbar-btn" data-toggle="dropdown" title="File commands">
-                <span class="fa fa-book"></span> File <span class="caret"></span>
+                <i class="material-icons">insert_drive_file</i>
               </button>
               <ul class="dropdown-menu">
                 <li id="saveButton"><a href="#">Save</a></li>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -103,7 +103,7 @@
           <div class="btn-toolbar pull-left">
             <div class="btn-group">
               <button type="button" class="toolbar-btn" data-toggle="dropdown" title="Notebook commands">
-                <span class="fa fa-book"></span> Notebook <span class="caret"></span>
+                <i class="material-icons">book</i> Notebook
               </button>
               <ul class="dropdown-menu">
                 <li id="saveButton"><a href="#">Save and Checkpoint</a></li>
@@ -130,31 +130,31 @@
           <div class="btn-toolbar pull-left">
             <div class="btn-group">
               <button id="addCodeCellButton" type="button" class="toolbar-btn" title="Append a new code cell">
-                <span class="fa fa-plus-square">
-                  <span class="fa fa-code"></span>
-                </span>
+                <i class="material-icons">add_box</i>
+                <i class="material-icons">code</i>
                 <span class="toolbar-text">Add Code</span>
               </button>
               <button id="addMarkdownCellButton" type="button" class="toolbar-btn" title="Append a new markdown cell">
-                <span class="fa fa-plus-square"> T</span>
+                <i class="material-icons">add_box</i>
+                <i class="material-icons">text_fields</i>
                 <span class="toolbar-text">Add Markdown</span>
               </button>
               <button id="deleteCellButton" type="button" class="toolbar-btn" title="Delete the selected cell">
-                <span class="fa fa-times"></span>
+                <i class="material-icons">clear</i>
                 <span class="toolbar-text">Delete</span>
               </button>
               <button id="moveCellUpButton" type="button" class="toolbar-btn" title="Move the selected cell up">
-                <span class="fa fa-chevron-up"></span>
+                <i class="material-icons">arrow_upward</i>
                 <span class="toolbar-text">Move Up</span>
               </button>
               <button id="moveCellDownButton" type="button" class="toolbar-btn" title="Move the selected cell down">
-                <span class="fa fa-chevron-down"></span>
+                <i class="material-icons">arrow_downward</i>
                 <span class="toolbar-text">Move Down</span>
               </button>
             </div>
             <div class="btn-group">
               <button id="runButton" type="button" class="toolbar-btn" title="Run the selected cell">
-                <span class="fa fa-play"></span> Run
+                <i class="material-icons">play_arrow</i> Run
               </button>
               <button type="button" class="toolbar-btn dropdown-toggle" data-toggle="dropdown">
                 <span class="caret"></span>
@@ -167,7 +167,7 @@
             </div>
             <div class="btn-group">
               <button id="clearButton" type="button" class="toolbar-btn" title="Clear outputs of the selected cell">
-                <span class="fa fa-minus-square-o"></span> Clear
+                <i class="material-icons">check_box_outline_blank</i> Clear
               </button>
               <button type="button" class="toolbar-btn dropdown-toggle" data-toggle="dropdown">
                 <span class="caret"></span>
@@ -195,17 +195,17 @@
           <div class="btn-toolbar pull-right">
             <div class="btn-group">
               <button id="navigationButton" type="button" class="toolbar-btn" title="Notebook Navigation">
-                <span class="fa fa-bookmark-o"></span>
+                <i class="material-icons">bookmark</i>
                 <span class="toolbar-text">Navigation</span>
               </button>
               <button id="helpButton" type="button" class="toolbar-btn active" title="Help">
-                <span class="fa fa-question"></span>
+                <i class="material-icons">help</i>
                 <span class="toolbar-text">Help</span>
               </button>
             </div>
             <div class="btn-group">
               <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Toggle sidebar on/off">
-                <span class="fa fa-chevron-down"></span>
+                <i class="material-icons">keyboard_arrow_down</i>
               </button>
             </div>
           </div>
@@ -226,7 +226,7 @@
           <div id="sidebarContent">
             <div class="btn-group">
               <button id="toggleSidebarButton" type="button" class="toolbar-btn" title="Toggle the size of the sidebar">
-                <span class="fa fa-chevron-right fa-flip-horizontal"></span>
+                <i class="material-icons">chevron_left</i>
               </button>
             </div>
             <div>

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -72,27 +72,27 @@
                       <div class="btn-toolbar pull-left">
                         <div class="btn-group">
                           <button id="addNotebookButton" type="button" class="toolbar-btn" title="Add a new notebook">
-                            <span class="fa fa-plus-square"></span> Notebook
+                            <i class="material-icons">add_box</i> Notebook
                           </button>
                           <button id="addFolderButton" type="button" class="toolbar-btn" title="Add a new folder">
-                            <span class="fa fa-plus-square"></span> Folder
+                            <i class="material-icons">add_box</i> Folder
                           </button>
                           <button id="uploadButton" type="button" class="toolbar-btn" title="Upload notebook(s)">
-                            <span class="fa fa-upload"></span>
+                            <i class="material-icons">file_upload</i>
                             <input type="file" name="datafile" class="fileinput" multiple="multiple" value="Upload" style="cursor: pointer" />
                             Upload
                           </button>
                           <button id="duplicateButton" type="button" class="toolbar-btn duplicate-button" title="Create a copy of the selected item(s)">
-                            <span class="fa fa-files-o"></span> Copy
+                            <i class="material-icons">content_copy</i> Copy
                           </button>
                           <button id="renameButton" type="button" class="toolbar-btn rename-button" title="Rename selected item(s)">
-                            <span class="fa fa-edit"></span> Rename
+                            <i class="material-icons">border_color</i> Rename
                           </button>
                           <button id="deleteButton" type="button" class="toolbar-btn delete-button" title="Deleted selected item(s)">
-                            <span class="fa fa-trash-o"></span> Delete
+                            <i class="material-icons">clear</i> Delete
                           </button>
                           <button id="editorButton" type="button" class="toolbar-btn editor-button" title="Open selected file in editor">
-                            <span class="fa fa-file-text-o"></span> Open as Text
+                            <i class="material-icons">format_align_left</i> Open as Text
                           </button>
                         </div>
                       </div>
@@ -107,7 +107,11 @@
                       </div>
                       <div id="project_name">
                         <ul class="breadcrumb">
-                          <li><a href="/tree"><i class="fa fa-home"></i></a></li>
+                          <li>
+                            <a href="/tree">
+                              <i class="material-icons">home</i>
+                            </a>
+                          </li>
                         </ul>
                       </div>
                     </div>


### PR DESCRIPTION
Used Google material design icons for everything, except for git, which I kept the fontawesome icon (we load fontawesome anyway as part of Jupyter).

![image](https://cloud.githubusercontent.com/assets/1424661/23575702/5460e34c-0046-11e7-8641-0e01f481b67d.png)

![image](https://cloud.githubusercontent.com/assets/1424661/23575825/c1ae1076-0048-11e7-8cec-29973de50c76.png)
