### PR TITLE
Add syntax coloring for `%bq query`

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -159,17 +159,21 @@ RUN ipython profile create default && \
     cd /datalab/lib/pydatalab && \
     /tools/node/bin/npm install -g typescript && \
     tsc --module amd --noImplicitAny --outdir datalab/notebook/static datalab/notebook/static/*.ts && \
+    tsc --module amd --noImplicitAny --outdir google/datalab/notebook/static google/datalab/notebook/static/*.ts && \
     /tools/node/bin/npm uninstall -g typescript && \
     pip install --upgrade-strategy only-if-needed --no-cache-dir . && \
     pip install --upgrade-strategy only-if-needed /datalab/lib/pydatalab/solutionbox/image_classification/. && \
     pip install --upgrade-strategy only-if-needed /datalab/lib/pydatalab/solutionbox/structured_data/. && \
     jupyter nbextension install --py datalab.notebook && \
+    jupyter nbextension install --py google.datalab.notebook && \
     jupyter nbextension enable --py widgetsnbextension && \
-    rm datalab/notebook/static/*.js && \
+    rm datalab/notebook/static/*.js google/datalab/notebook/static/*.js && \
     mkdir -p /datalab/nbconvert && \
     cp -R /usr/local/share/jupyter/nbextensions/gcpdatalab/* /datalab/nbconvert && \
     ln -s /usr/local/lib/python2.7/dist-packages/notebook/static/custom/custom.css /datalab/nbconvert/custom.css && \
     mkdir -p /usr/local/lib/python2.7/dist-packages/notebook/static/components/codemirror/mode/text/sql/text && \
     ln -s /usr/local/share/jupyter/nbextensions/gcpdatalab/codemirror/mode/sql.js /usr/local/lib/python2.7/dist-packages/notebook/static/components/codemirror/mode/text/sql/text/sql.js && \
+    mkdir -p /usr/local/lib/python2.7/dist-packages/notebook/static/components/codemirror/mode/text/bigquery/text && \
+    ln -s /usr/local/share/jupyter/nbextensions/gcpdatalab/codemirror/mode/bigquery.js /usr/local/lib/python2.7/dist-packages/notebook/static/components/codemirror/mode/text/bigquery/text/bigquery.js && \
     cd /
 

--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -231,19 +231,25 @@ table.bqsv th, table.bqsv td {
   color: #ae81ff;
 }
 .cm-s-ipython span.cm-number {
-  color: #ae81ff;
+  color: white;
 }
 .cm-s-ipython span.cm-property, .cm-s-ipython span.cm-attribute {
   color: #a6e22e;
 }
 .cm-s-ipython span.cm-keyword {
-  color: #f92672;
+  color: #48c34e;
+}
+.cm-s-ipython span.cm-function {
+  color: #ff4056;
 }
 .cm-s-ipython span.cm-string {
   color: #e6db74;
 }
 .cm-s-ipython span.cm-operator {
-  color: #ae81ff;
+  color: #ff7878;
+}
+.cm-s-ipython span.cm-type {
+  color: #d67135;
 }
 .cm-s-ipython span.cm-variable {
   color: #f8f8f2;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -487,15 +487,11 @@ div.selected .CodeMirror-linenumber, div#texteditor-container .CodeMirror-linenu
   color: inherit !important;
   outline: solid 1px #888;
 }
-.cm-keyword {
+.cm-keyword, .cm-operator {
   font-weight: normal !important;
 }
 .cm-comment {
-  color: #008000 !important;
   font-style: normal !important;
-}
-.cm-error {
-  color: red !important;
 }
 .cm-header-1, .cm-header-2, .cm-header-3, .cm-header-4, .cm-header-5, .cm-header-6 {
   font-family: inherit !important;

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -839,7 +839,10 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
     ];
 
     codeCell.config_defaults.highlight_modes['magic_text/sql'] = {
-      reg: [ /^%%sql/ ]
+      reg: [ /%%?sql\b/ ]
+    };
+    codeCell.config_defaults.highlight_modes['magic_text/bigquery'] = {
+      reg: [ /%%?bq\s+query\b/ ]
     };
   });
 

--- a/sources/web/datalab/static/light.css
+++ b/sources/web/datalab/static/light.css
@@ -75,6 +75,20 @@ code {
   background-color: #eee;
 }
 
+/* Code theme */
+.cm-comment {
+  color: #008000 !important;
+}
+.cm-error {
+  color: red !important;
+}
+.cm-function {
+  color: #ff4056;
+}
+.cm-type {
+  color: #d67135;
+}
+
 /* Scrollbars */
 ::-webkit-scrollbar {
 	width: 12px;


### PR DESCRIPTION
(This PR is functionally dependent on https://github.com/googledatalab/pydatalab/pull/272, tests will not pass until that PR is merged)

Installs `google.datalab.notebook` as a separate Jupyter extension in order to allow it to define its own CodeMirror modes. It's also good to make the separation now so it's easier to deprecate the old namespace `datalab`.

The PR also fixes CSS colors to make things more consistent between light and dark themes.

![image](https://cloud.githubusercontent.com/assets/1424661/23586389/9a785a7e-0148-11e7-9081-554e6b29d1d1.png)

![image](https://cloud.githubusercontent.com/assets/1424661/23586399/c395cb76-0148-11e7-8dba-bb3321f4d575.png)