### PR TITLE
Fix console output max width

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -426,6 +426,9 @@ div.output_area {
 div.output_area div.prompt {
   display: none;
 }
+div.output_subarea {
+  max-width: inherit;
+}
 div.output_scroll {
   border-radius: 0;
   -webkit-box-shadow: none;


### PR DESCRIPTION
This lets cell output use the entire width of the cell.

Fixes https://github.com/googledatalab/datalab/issues/1240.