### PR TITLE
Fix load errors, colors for markdown file

### DIFF
--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -182,7 +182,9 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
     if (datalabFileExists(newPath)) {
       sendDataLabFile(newPath, response);
     } else {
-      sendJupyterFile(path.substr(1), response);
+      // load codemirror modes from proper path
+      path = path.substr(1).replace('static/codemirror', 'static/components/codemirror');
+      sendJupyterFile(path, response);
     }
   }
   else if (path.lastIndexOf('/custom.js') >= 0) {

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -24,7 +24,7 @@
 body {
   font-family: 'Open Sans', Helvetica, sans-serif;
   font-size: 14px;
-  min-width: 710px;
+  min-width: 720px;
 }
 
 /* Layout */

--- a/sources/web/datalab/templates/edit.html
+++ b/sources/web/datalab/templates/edit.html
@@ -35,6 +35,7 @@
             <div class="btn-group">
               <button type="button" class="toolbar-btn" data-toggle="dropdown" title="File commands">
                 <i class="material-icons">insert_drive_file</i> File
+                <span class="caret"></span>
               </button>
               <ul class="dropdown-menu">
                 <li id="saveButton"><a href="#">Save</a></li>


### PR DESCRIPTION
When trying to open a markdown file, console shows some errors trying to load codemirror modes `markdown` and `xml`, we just need to reroute those to the right path.

I also added a missing chevron for the File menu, and updated the minimum width to account for the missing chevron that was added to Notebook menu.