### PR TITLE
Don't convert line to cell magics

### DIFF
--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -847,27 +847,6 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
     };
   });
 
-  require(["services/kernels/kernel"], function(ipy) {
-    var kernel = ipy.Kernel;
-
-    var originalExecute = kernel.prototype.execute;
-    kernel.prototype.execute = function (code, callbacks, options) {
-      // If this is a line magic but has a non-empty cell body change it to a cell magic.
-      if (code.length > 2 && code[0] == '%' && code[1] != '%') {
-        var lines = code.split('\n');
-        if (lines.length > 1) {
-          for (var i = 1; i < lines.length; i++) {
-            if (lines[i].trim().length > 0) {
-              code = '%' + code;
-              break;
-            }
-          }
-        }
-      }
-      return originalExecute.apply(this, [ code, callbacks, options ]);
-    }
-  });
-
   /**
    * Patch the cell auto_highlight code to use a working mode for magic_ MIME types.
    * The Jupyter code uses a broken multiplexor. This _auto_highlight function is


### PR DESCRIPTION
This code was added for the sake of convenience, but it's causing undesired behavior. For example, the following code doesn't work properly:
```
%timeit -n 1 print('line1')
print('line2')
```
Because it's getting converted to a cell magic, which means consecutive code will be part of the cell.

This fixes https://github.com/googledatalab/pydatalab/issues/71.