### PR TITLE
Add a settings pane

### DIFF
--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -166,8 +166,7 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
     'datalab.css': 'datalab.css',
     'appbar.html': 'appbar.html',
     'settings.html': 'settings.html',
-    'settings.js': 'settings.js',
-    'settings.css': 'settings.css'
+    'settings.js': 'settings.js'
   };
 
   var subpath = path.substr(path.lastIndexOf('/') + 1);

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -158,23 +158,21 @@ function sendUserCustomTheme(userId: string, response: http.ServerResponse): voi
 function requestHandler(request: http.ServerRequest, response: http.ServerResponse): void {
   var path = url.parse(request.url).pathname;
 
-  if (path.lastIndexOf('/favicon.ico') > 0) {
-    sendDataLabFile('datalab.ico', response);
-  }
-  else if (path.lastIndexOf('/logo.png') > 0) {
-    sendDataLabFile('datalab.png', response);
-  }
-  else if (path.lastIndexOf('/about.txt') > 0) {
-    sendDataLabFile('datalab.txt', response);
-  }
-  else if (path.lastIndexOf('/reporting.html') > 0) {
-    sendDataLabFile('reporting.html', response);
-  }
-  else if (path.lastIndexOf('/datalab.css') > 0) {
-    sendDataLabFile('datalab.css', response);
-  }
-  else if (path.lastIndexOf('/appbar.html') > 0) {
-    sendDataLabFile('appbar.html', response);
+  var staticResourcesMap: {[key:string]: string} = {
+    'favicon.ico': 'datalab.ico',
+    'logo.png': 'datalab.png',
+    'about.txt': 'datalab.txt',
+    'reporting.html': 'reporting.html',
+    'datalab.css': 'datalab.css',
+    'appbar.html': 'appbar.html',
+    'settings.html': 'settings.html',
+    'settings.js': 'settings.js',
+    'settings.css': 'settings.css'
+  };
+
+  var subpath = path.substr(path.lastIndexOf('/') + 1);
+  if (subpath in staticResourcesMap) {
+    sendDataLabFile(staticResourcesMap[subpath], response);
   }
   else if (path.indexOf('/codemirror/mode/') > 0) {
     var split = path.lastIndexOf('/');

--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -13,6 +13,11 @@
   </span>
   <div class="btn-toolbar pull-right right-toolbar">
     <div class="btn-group">
+      <button id="settingsButton" class="toolbar-btn" title="Settings">
+        <i class="material-icons">settings</i>
+      </button>
+    </div>
+    <div class="btn-group">
       <button id="ungitButton" title="Open ungit on the notebooks repository" class="toolbar-btn">
         <span class="fa fa-code-fork"></span>
       </button>
@@ -73,15 +78,6 @@
             <a href="javascript:manageVm()">Click here to manage the VM</a>
           </div>
           <button id="stopVmButton" title="Stop VM" class="btn btn-danger" style="width: 100%; float: none">Stop VM</button>
-        </div>
-        <div>
-          <hr/>
-          <div class="radio">
-            <label><input type="radio" id="lightThemeRadioOption" checked="">Light Theme</label>
-          </div>
-          <div class="radio">
-            <label><input type="radio" id="darkThemeRadioOption" checked="">Dark Theme</label>
-          </div>
         </div>
         <div>
           <div id="feedbackButton" title="Provide feedback" class="btn btn-default">

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -526,7 +526,7 @@ div.modal-dialog pre, div.modal-dialog code, #help code, #help pre {
 }
 
 /* Responsive Design */
-@media screen and (max-width: 1230px) {
+@media screen and (max-width: 1270px) {
   span.toolbar-text {
     display: none;
   }

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -170,10 +170,6 @@ function xhr(url, callback, method) {
   request.send();
 }
 
-function getSettingKeyAddress(setting) {
-  return window.location.protocol + "//" + window.location.host + "/_settings?key=" + setting;
-}
-
 function restartDatalab() {
   var restartUrl = window.location.protocol + "//" + window.location.host + "/_restart";
 
@@ -309,36 +305,6 @@ function initializePage(dialog, saveFn) {
     }
   });
 
-  // More UI that relies on appbar load
-  // Prepare the theme selector radio boxes
-  lightThemeRadioOption = document.getElementById("lightThemeRadioOption")
-  darkThemeRadioOption = document.getElementById("darkThemeRadioOption")
-
-  // By default, check the light theme radio button
-  // TODO: When we have support for default settings on server side, remove this
-  lightThemeRadioOption.checked = true;
-  darkThemeRadioOption.checked = false;
-  xhr(getSettingKeyAddress("theme"), function() {
-    lightThemeRadioOption.checked = this.responseText === "\"light\"";
-    darkThemeRadioOption.checked = this.responseText === "\"dark\"";
-  });
-  lightThemeRadioOption.onclick = function() {
-    setTheme("light");
-    darkThemeRadioOption.checked = false;
-  };
-  darkThemeRadioOption.onclick = function() {
-    setTheme("dark");
-    lightThemeRadioOption.checked = false;
-  };
-
-  function setTheme(theme) {
-    xhr(getSettingKeyAddress("theme") + "&value=" + theme, function() {
-      // Reload the stylesheet by resetting its address with a random (time) version querystring
-      sheetAddress = document.getElementById("themeStylesheet").href + "?v=" + Date.now()
-      document.getElementById("themeStylesheet").setAttribute('href', sheetAddress);
-    }, "POST");
-  }
-
   // If inside a notebook, prepare notebook-specific help link inside the sidebar
   if (document.getElementById('sidebarArea') !== null) {
     $('#keyboardHelpLink').click(function(e) {
@@ -354,6 +320,15 @@ function initializePage(dialog, saveFn) {
     $('#notebookHelpDivider').show()
   }
   $('#aboutButton').click(showAbout);
+  $('#settingsButton').click(function() {
+    $.get('/static/settings.html', (markup) => {
+      dialog.modal({
+        title: 'Settings',
+        body: $(markup),
+        buttons: { Close: {} }
+      });
+    });
+  });
   $('#feedbackButton').click(function() {
     window.open('https://groups.google.com/forum/#!newtopic/google-cloud-datalab-feedback');
   });

--- a/sources/web/datalab/static/settings.html
+++ b/sources/web/datalab/static/settings.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="/static/settings.css" type="text/css" />
+</head>
+<body>
+  Theme:
+  <div>
+    <div class="radio">
+      <label><input type="radio" id="lightThemeRadioOption" checked="">Light Theme</label>
+    </div>
+    <div class="radio">
+      <label><input type="radio" id="darkThemeRadioOption" checked="">Dark Theme</label>
+    </div>
+  </div>
+  <script src="/static/settings.js" async="true" defer="true"></script>
+</body>
+</html>

--- a/sources/web/datalab/static/settings.js
+++ b/sources/web/datalab/static/settings.js
@@ -1,0 +1,45 @@
+function xhr(url, callback, method) {
+  method = method || "GET";
+
+  let request = new XMLHttpRequest();
+  request.onreadystatechange = function() {
+    if (request.readyState === 4 && request.status === 200) {
+      callback.call(request);
+    }
+  }
+  request.open(method, url);
+  request.send();
+}
+
+function getSettingKeyAddress(setting) {
+  return window.location.protocol + "//" + window.location.host + "/_settings?key=" + setting;
+}
+
+// Prepare the theme selector radio boxes
+lightThemeRadioOption = document.getElementById("lightThemeRadioOption")
+darkThemeRadioOption = document.getElementById("darkThemeRadioOption")
+
+// By default, check the light theme radio button
+// TODO: When we have support for default settings on server side, remove this
+lightThemeRadioOption.checked = true;
+darkThemeRadioOption.checked = false;
+xhr(getSettingKeyAddress("theme"), function() {
+  lightThemeRadioOption.checked = this.responseText === "\"light\"";
+  darkThemeRadioOption.checked = this.responseText === "\"dark\"";
+});
+lightThemeRadioOption.onclick = function() {
+  setTheme("light");
+  darkThemeRadioOption.checked = false;
+};
+darkThemeRadioOption.onclick = function() {
+  setTheme("dark");
+  lightThemeRadioOption.checked = false;
+};
+
+function setTheme(theme) {
+  xhr(getSettingKeyAddress("theme") + "&value=" + theme, function() {
+    // Reload the stylesheet by resetting its address with a random (time) version querystring
+    sheetAddress = document.getElementById("themeStylesheet").href + "?v=" + Date.now()
+    document.getElementById("themeStylesheet").setAttribute('href', sheetAddress);
+  }, "POST");
+}


### PR DESCRIPTION
As we're adding more features to the editor, and more user preferences, we need a standalone settings pane. This PR adds a simple one that shows as a modal using a new settings button.

This is becoming too many buttons on the top right toolbar, we might want to discuss rearrangement there.

Fixes #1110 

![image](https://cloud.githubusercontent.com/assets/1424661/23972037/8e37f7e0-098d-11e7-93b8-2c6344ea2570.png)
