### PR TITLE
Make local build and run verbose by default

### DIFF
--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -43,4 +43,6 @@ docker run -it --entrypoint=$ENTRYPOINT \
   -v "$CONTENT:/content" \
   -e "PROJECT_ID=$PROJECT_ID" \
   -e "DATALAB_ENV=local" \
+  -e "DATALAB_DEBUG=true" \
+  -e 'DATALAB_SETTINGS_OVERRIDES={"consoleLogLevel": "debug" }' \
   datalab


### PR DESCRIPTION
The `run.sh` script should used in local development only, make it verbose by default.

Fixes https://github.com/googledatalab/datalab/issues/1236.