### PR TITLE
Don't prompt for a zone when the user specifies a non-existant instance.

### DIFF
--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -19,11 +19,12 @@
 This tool is specific to the use case of running in the Google Cloud Platform.
 """
 
-from commands import create, connect, list, stop, delete
+from commands import create, connect, list, stop, delete, utils
 
 import argparse
 import os
 import subprocess
+import traceback
 
 
 _SUBCOMMANDS = {
@@ -241,6 +242,10 @@ def run():
             in_cloud_shell=('DEVSHELL_CLIENT_PORT' in os.environ))
     except subprocess.CalledProcessError:
         print('A nested call to gcloud failed.')
+    except Exception as e:
+        if utils.print_info_messages(args):
+            traceback.print_exc(e)
+        print(e)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prior to this change, running a datalab command against a non-existant
instance (e.g. `datalab connect does-not-exist`) would prompt the user
to specify a zone for that instance prior to telling them that it does
not exist.

However, at that point the code already ran a list command to find
matching instances, so it should no that there are none.

This change makes the pompt a little more intelligent so that it
can bail out early if it knows there is no valid zone a user could
provide for which the instance could be found.

This change also makes changes the entrypoint so that we only print
stack traces for user errors when the `--verbosity` flag has been
set to either `debug` or `info`.

This fixes #1224