### PR TITLE
Improve the user experience around accessing help information and notebook navigation

### DIFF
--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -36,16 +36,16 @@
         <i class="material-icons">help_outline</i>
       </button>
       <ul class="dropdown-menu dropdown-menu-right" style="width: 200px">
-        <li><a href="/tree/datalab/docs/Readme.ipynb" target="_blank"><span>Getting Started</span></a></li>
-        <li><a href="/tree/datalab/docs" target="_blank"><span>Samples and Tutorials</span></a></li>
-        <li><a href="http://googledatalab.github.io/pydatalab/" target="_blank"><span>Datalab API</span></a></li>
-        <li class="divider"></li>
+        <li><a id="showHelpLink" style="display:none" href="#">Show Help</a></li>
         <li><a id="keyboardHelpLink" style="display:none" href="#">Keyboard Shortcuts</a></li>
         <li><a id="markdownHelpLink" style="display:none" href="#">Markdown Syntax</a></li>
         <li id="notebookHelpDivider" class="divider" style="display:none"></li>
-        <li><a href="https://cloud.google.com/bigquery/what-is-bigquery" target="_blank"><span>BigQuery&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></a></li>
-        <li><a href="https://cloud.google.com/storage/docs/overview" target="_blank"><span>Cloud Storage&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></a></li>
+        <li><a href="/tree/datalab/docs/Readme.ipynb" target="_blank"><span>Samples and Tutorials</span></a></li>
         <li class="divider"></li>
+        <li><a href="https://cloud.google.com/bigquery/what-is-bigquery" target="_blank"><span>BigQuery</span></a></li>
+        <li><a href="https://cloud.google.com/storage/docs/overview" target="_blank"><span>Cloud Storage</span></a></li>
+        <li class="divider"></li>
+        <li><a href="http://googledatalab.github.io/pydatalab/" target="_blank"><span>Datalab API</span></a></li>
         <li><a href="https://developers.google.com/chart/" target="_blank"><span>Google Charts</span></a></li>
         <li><a href="http://matplotlib.org/contents.html" target="_blank"><span>Matplotlib</span></a></li>
         <li><a href="http://docs.scipy.org/doc/numpy/reference/" target="_blank"><span>Numpy</span></a></li>
@@ -58,7 +58,7 @@
       <button id="accountDropdownButton" title="Account" class="toolbar-btn">
         <i class="material-icons">account_circle</i>
       </button>
-      <div class="dropdown-menu dropdown-menu-right" style="min-width: 250px;">
+      <div class="dropdown-menu dropdown-menu-right" style="min-width: 150px;">
         <div id="signInButton" style="display:none">
           <button title="Sign In" class="btn btn-success" style="width: 100%; float: none">Sign In</button>
         </div>
@@ -78,15 +78,9 @@
           <button id="stopVmButton" title="Stop VM" class="btn btn-danger" style="width: 100%; float: none">Stop VM</button>
         </div>
         <hr/>
-        <div id="settingsButton">
-          <button title="Settings" class="btn btn-default" style="width: 100%; float: none; border: 0">Settings</button>
-        </div>
-        <div id="aboutButton">
-          <button title="About Google Cloud Datalab" class="btn btn-default" style="width: 100%; float: none; border:0">About Datalab</button>
-        </div>
-        <div id="feedbackButton">
-          <button title="Provide feedback" class="btn btn-default" style="width: 100%; float: none; border:0">Feedback</button>
-        </div>
+        <li><a id="settingsButton" href="#">Settings</a></li>
+        <li><a id="aboutButton" href="#">About Datalab</a></li>
+        <li><a id="feedbackButton" href="#">Feedback</a></li>
       </div>
     </div>
   </div>

--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -13,11 +13,6 @@
   </span>
   <div class="btn-toolbar pull-right right-toolbar">
     <div class="btn-group">
-      <button id="settingsButton" class="toolbar-btn" title="Settings">
-        <i class="material-icons">settings</i>
-      </button>
-    </div>
-    <div class="btn-group">
       <button id="ungitButton" title="Open ungit on the notebooks repository" class="toolbar-btn">
         <span class="fa fa-code-fork"></span>
       </button>
@@ -30,10 +25,21 @@
       </a>
     </div>
     <div class="btn-group">
+      <a href="#" id="navigationButton" style="display:none;">
+        <button title="Navigation" class="toolbar-btn">
+          <i class="material-icons">bookmark</i>
+        </button>
+      </a>
+    </div>
+    <div class="btn-group">
       <button class="toolbar-btn" data-toggle="dropdown" title="Help Links">
         <i class="material-icons">help_outline</i>
       </button>
       <ul class="dropdown-menu dropdown-menu-right" style="width: 200px">
+        <li><a href="/tree/datalab/docs/Readme.ipynb" target="_blank"><span>Getting Started</span></a></li>
+        <li><a href="/tree/datalab/docs" target="_blank"><span>Samples and Tutorials</span></a></li>
+        <li><a href="http://googledatalab.github.io/pydatalab/" target="_blank"><span>Datalab API</span></a></li>
+        <li class="divider"></li>
         <li><a id="keyboardHelpLink" style="display:none" href="#">Keyboard Shortcuts</a></li>
         <li><a id="markdownHelpLink" style="display:none" href="#">Markdown Syntax</a></li>
         <li id="notebookHelpDivider" class="divider" style="display:none"></li>
@@ -46,15 +52,7 @@
         <li><a href="http://pandas.pydata.org/pandas-docs/stable/" target="_blank"><span>Pandas</span></a></li>
         <li><a href="http://scikit-learn.org/stable/" target="_blank"><span>SciKit-Learn</span></a></li>
         <li><a href="http://tensorflow.org" target="_blank"><span>TensorFlow</span></a></li>
-        <li class="divider"></li>
-        <li><a href="/tree/datalab/docs" target="_blank"><span>Samples and Tutorials</span></a></li>
-        <li><a href="http://googledatalab.github.io/pydatalab/" target="_blank"><span>Datalab API</span></a></li>
       </ul>
-    </div>
-    <div class="btn-group">
-      <button id="aboutButton" title="About Google Cloud Datalab" class="toolbar-btn">
-        <i class="material-icons">info_outline</i>
-      </button>
     </div>
     <div id="accountDropdown" class="btn-group">
       <button id="accountDropdownButton" title="Account" class="toolbar-btn">
@@ -79,11 +77,15 @@
           </div>
           <button id="stopVmButton" title="Stop VM" class="btn btn-danger" style="width: 100%; float: none">Stop VM</button>
         </div>
-        <div>
-          <div id="feedbackButton" title="Provide feedback" class="btn btn-default">
-            <i class="material-icons" id="feedbackButton">feedback</i>
-            <span>Feedback</span>
-          </div>
+        <hr/>
+        <div id="settingsButton">
+          <button title="Settings" class="btn btn-default" style="width: 100%; float: none; border: 0">Settings</button>
+        </div>
+        <div id="aboutButton">
+          <button title="About Google Cloud Datalab" class="btn btn-default" style="width: 100%; float: none; border:0">About Datalab</button>
+        </div>
+        <div id="feedbackButton">
+          <button title="Provide feedback" class="btn btn-default" style="width: 100%; float: none; border:0">Feedback</button>
         </div>
       </div>
     </div>

--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -31,7 +31,7 @@
     </div>
     <div class="btn-group">
       <button class="toolbar-btn" data-toggle="dropdown" title="Help Links">
-        <i class="material-icons">open_in_new</i>
+        <i class="material-icons">help_outline</i>
       </button>
       <ul class="dropdown-menu dropdown-menu-right" style="width: 200px">
         <li><a id="keyboardHelpLink" style="display:none" href="#">Keyboard Shortcuts</a></li>

--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -24,12 +24,10 @@
         </button>
       </a>
     </div>
-    <div class="btn-group">
-      <a href="#" id="navigationButton" style="display:none;">
-        <button title="Navigation" class="toolbar-btn">
-          <i class="material-icons">bookmark</i>
-        </button>
-      </a>
+    <div id="navigationButton" class="btn-group" style="display:none;">
+      <button title="Navigation" class="toolbar-btn">
+        <i class="material-icons">bookmark</i>
+      </button>
     </div>
     <div class="btn-group">
       <button class="toolbar-btn" data-toggle="dropdown" title="Help Links">
@@ -58,7 +56,7 @@
       <button id="accountDropdownButton" title="Account" class="toolbar-btn">
         <i class="material-icons">account_circle</i>
       </button>
-      <div class="dropdown-menu dropdown-menu-right" style="min-width: 150px;">
+      <div class="dropdown-menu dropdown-menu-right" style="min-width: 250px;">
         <div id="signInButton" style="display:none">
           <button title="Sign In" class="btn btn-success" style="width: 100%; float: none">Sign In</button>
         </div>

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -252,11 +252,6 @@ i.material-icons {
   font-size: 18px !important;
   vertical-align: sub !important;
 }
-#toggleSidebarButton {
-  margin-bottom: 8px;
-  background: none;
-  border: none;
-}
 /* Suppress the ipywidget Widgets menu until we figure out how to handle it. */
 #help_menu_container {
   display: none;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -252,6 +252,12 @@ i.material-icons {
   font-size: 18px !important;
   vertical-align: sub !important;
 }
+#toggleSidebarButton, #hideSidebarButton {
+  margin-bottom: 8px;
+  background: none;
+  border: none;
+ }
+
 /* Suppress the ipywidget Widgets menu until we figure out how to handle it. */
 #help_menu_container {
   display: none;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -521,7 +521,7 @@ div.modal-dialog pre, div.modal-dialog code, #help code, #help pre {
 }
 
 /* Responsive Design */
-@media screen and (max-width: 1270px) {
+@media screen and (max-width: 1230px) {
   span.toolbar-text {
     display: none;
   }

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -156,6 +156,11 @@ body {
 #mainToolbar, #sidebarToolbar {
   z-index: 8;
 }
+#mainToolbar {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}
 #updateMessageArea {
   display: none;
   margin-bottom: 0px;
@@ -252,7 +257,7 @@ i.material-icons {
   font-size: 18px !important;
   vertical-align: sub !important;
 }
-#toggleSidebarButton, #hideSidebarButton {
+#toggleSidebarButton {
   margin-bottom: 8px;
   background: none;
   border: none;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -521,7 +521,7 @@ div.modal-dialog pre, div.modal-dialog code, #help code, #help pre {
 }
 
 /* Responsive Design */
-@media screen and (max-width: 1230px) {
+@media screen and (max-width: 1080px) {
   span.toolbar-text {
     display: none;
   }

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -1096,6 +1096,13 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
       .then(success => removeCompletedMarks());
     this.blur();
   });
+  
+  $('#toggleSidebarButton').click(function() {
+    $('#sidebarArea').toggleClass('larger');
+    rotated = $('#toggleSidebarButton').css('transform').indexOf('matrix') > -1;
+    $('#toggleSidebarButton').css('transform', rotated ? '' : 'rotate(180deg)');
+    this.blur();
+  });
 
   $('#hideSidebarButton').click(function() {
     toggleSidebar();

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -304,6 +304,11 @@ function initializePage(dialog, saveFn) {
 
   // If inside a notebook, prepare notebook-specific help link inside the sidebar
   if (document.getElementById('sidebarArea') !== null) {
+    $('#showHelpLink').click(function(e) {
+      showHelp(document.getElementById('datalabHelp').textContent);
+      e.preventDefault();
+    });
+    $('#showHelpLink').show()
     $('#keyboardHelpLink').click(function(e) {
       showHelp(document.getElementById('shortcutsHelp').textContent);
       e.preventDefault();

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -146,13 +146,17 @@ function showHelp(markup) {
   document.getElementById('navigation').style.display = 'none';
   document.getElementById('help').style.display = '';
 
-  if (markup) {
-    document.getElementById('help').innerHTML = markup;
-  }
+  if (markup === undefined)
+    markup = $('#datalabHelp').text();
+  $('#help').html(markup);
+
   if (document.getElementById('sidebarArea').style.display == 'none') {
     toggleSidebar();
   }
 }
+// Populate help for the first time sidebar is opened
+markup = $('#datalabHelp').text();
+$('#help').html(markup);
 
 function xhr(url, callback, method) {
   method = method || "GET";
@@ -1224,8 +1228,7 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
       help = utils.fixCarriageReturn(utils.fixConsole(help)).replace(/\n/g, '<br />');
     }
 
-    document.getElementById('help').innerHTML = help;
-    showHelp();
+    showHelp(help);
   });
 }
 

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -146,9 +146,6 @@ function showHelp(markup) {
   document.getElementById('navigation').style.display = 'none';
   document.getElementById('help').style.display = '';
 
-  document.getElementById('navigationButton').classList.remove('active');
-  document.getElementById('helpButton').classList.add('active');
-
   if (markup) {
     document.getElementById('help').innerHTML = markup;
   }
@@ -318,6 +315,8 @@ function initializePage(dialog, saveFn) {
     });
     $('#markdownHelpLink').show()
     $('#notebookHelpDivider').show()
+
+    $('#navigationButton').show()
   }
   $('#aboutButton').click(showAbout);
   $('#settingsButton').click(function() {
@@ -1093,13 +1092,6 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
     this.blur();
   });
 
-  $('#toggleSidebarButton').click(function() {
-    document.getElementById('sidebarArea').classList.toggle('larger');
-    rotated = $('#toggleSidebarButton').css('transform').indexOf('matrix') > -1;
-    $('#toggleSidebarButton').css('transform', rotated ? '' : 'rotate(180deg)');
-    this.blur();
-  });
-
   $('#hideSidebarButton').click(function() {
     toggleSidebar();
   });
@@ -1109,14 +1101,6 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
       toggleSidebar();
     }
     showNavigation();
-    this.blur();
-  });
-
-  $('#helpButton').click(function() {
-    if (document.getElementById('sidebarArea').style.display == 'none') {
-      toggleSidebar();
-    }
-    showHelp();
     this.blur();
   });
 
@@ -1136,9 +1120,6 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
   function showNavigation() {
     document.getElementById('navigation').style.display = '';
     document.getElementById('help').style.display = 'none';
-
-    document.getElementById('navigationButton').classList.add('active');
-    document.getElementById('helpButton').classList.remove('active');
   }
 
   function updateNavigation() {

--- a/sources/web/datalab/static/light.css
+++ b/sources/web/datalab/static/light.css
@@ -78,6 +78,11 @@ code {
   background-color: #eee;
 }
 
+/* Modals */
+.modal-header,.modal-body,.modal-body>textarea,.modal-footer {
+  color: #333;
+}
+
 /* Code theme */
 .cm-s-ipython span.cm-comment {
   color: #008000 !important;

--- a/sources/web/datalab/static/light.css
+++ b/sources/web/datalab/static/light.css
@@ -14,6 +14,9 @@
 body {
   background: #fff;
 }
+.dropdown-menu, .dropdown-menu li a {
+  color: #333;
+}
 #sidebarArea, #sidebarContent {
   color: #000;
 }

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -182,11 +182,9 @@
           <div id="sidebarContent">
             <div>
               <div class="btn-group pull-right">
-                <div class="btn-group">
-                  <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Close sidebar">
-                    <i class="material-icons">close</i>
-                  </button>
-                </div>
+                <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Close sidebar">
+                  <i class="material-icons">close</i>
+                </button>
               </div>
             </div>
             <div>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -101,8 +101,6 @@
                 <li id="convertPythonButton"><a href="#">Convert to Python</a></li>
               </ul>
             </div>
-          </div>
-          <div class="btn-toolbar pull-left">
             <div class="btn-group">
               <button id="addCodeCellButton" type="button" class="toolbar-btn" title="Append a new code cell">
                 <i class="material-icons">add_box</i>
@@ -165,6 +163,13 @@
               </div>
             </div>
           </div>
+          <div class="btn-toolbar pull-right">
+             <div id="sidebarToolbar" class="btn-group" style="">
+               <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Toggle sidebar on/off">
+                 <i class="material-icons">keyboard_arrow_down</i>
+               </button>
+             </div>
+           </div>
         </div>
       </div>
       <div id="contentArea">
@@ -181,11 +186,6 @@
         <div id="sidebarArea" style="display:none">
           <div id="sidebarContent">
             <div style="overflow: auto">
-              <div class="btn-group pull-right">
-                <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Close sidebar" style="padding:2px">
-                  <i class="material-icons">close</i>
-                </button>
-              </div>
               <div class="btn-group">
                <button id="toggleSidebarButton" type="button" class="toolbar-btn" title="Toggle the size of the sidebar">
                  <i class="material-icons">chevron_left</i>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -182,10 +182,15 @@
           <div id="sidebarContent">
             <div style="overflow: auto">
               <div class="btn-group pull-right">
-                <button id="hideSidebarButton" type="button" class="btn btn-default" title="Close sidebar" style="padding:2px">
+                <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Close sidebar" style="padding:2px">
                   <i class="material-icons">close</i>
                 </button>
               </div>
+              <div class="btn-group">
+               <button id="toggleSidebarButton" type="button" class="toolbar-btn" title="Toggle the size of the sidebar">
+                 <i class="material-icons">chevron_left</i>
+               </button>
+  </div>
             </div>
             <div>
               <div id="navigation" style="display: none"></div>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -169,16 +169,6 @@
         <div id="sidebarToolbar">
           <div class="btn-toolbar pull-right">
             <div class="btn-group">
-              <button id="navigationButton" type="button" class="toolbar-btn" title="Notebook Navigation">
-                <i class="material-icons">bookmark</i>
-                <span class="toolbar-text">Navigation</span>
-              </button>
-              <button id="helpButton" type="button" class="toolbar-btn active" title="Help">
-                <i class="material-icons">help</i>
-                <span class="toolbar-text">Help</span>
-              </button>
-            </div>
-            <div class="btn-group">
               <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Toggle sidebar on/off">
                 <i class="material-icons">keyboard_arrow_down</i>
               </button>
@@ -199,37 +189,9 @@
         </div>
         <div id="sidebarArea" style="display:none">
           <div id="sidebarContent">
-            <div class="btn-group">
-              <button id="toggleSidebarButton" type="button" class="toolbar-btn" title="Toggle the size of the sidebar">
-                <i class="material-icons">chevron_left</i>
-              </button>
-            </div>
             <div>
               <div id="navigation" style="display: none"></div>
-              <div id="help">
-                <p><b>Help for Python APIs</b></p>
-                <p>
-                  You can enter <code>class?</code> or <code>member?</code> within a code cell in the
-                  notebook to get help on a Python API.
-                </p>
-                <br />
-                <p>
-                  For example, try <code>str?</code> to get help information on the built-in Python
-                  method to convert a value to its string representation.
-                </p>
-                <br />
-                <p>
-                  Additional help topics and links are also available from the menu off the Help
-                  icon on the top of the page.
-                </p>
-                <br />
-                <p><b>Docs and Samples</b></p>
-                <p>
-                  The <a href="/notebooks/datalab/docs/Readme.ipynb"
-                    target="_blank">Cloud Datalab Guide</a> featuring
-                  documentation and sample notebooks is also a great way to check out how you can use Cloud Datalab.
-                </p>
-              </div>
+              <div id="help"></div>
             </div>
           </div>
         </div>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -180,9 +180,9 @@
         </div>
         <div id="sidebarArea" style="display:none">
           <div id="sidebarContent">
-            <div>
+            <div style="overflow: auto">
               <div class="btn-group pull-right">
-                <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Close sidebar">
+                <button id="hideSidebarButton" type="button" class="btn btn-default" title="Close sidebar" style="padding:2px">
                   <i class="material-icons">close</i>
                 </button>
               </div>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -166,15 +166,6 @@
             </div>
           </div>
         </div>
-        <div id="sidebarToolbar">
-          <div class="btn-toolbar pull-right">
-            <div class="btn-group">
-              <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Toggle sidebar on/off">
-                <i class="material-icons">keyboard_arrow_down</i>
-              </button>
-            </div>
-          </div>
-        </div>
       </div>
       <div id="contentArea">
         <div id="mainArea">
@@ -189,6 +180,15 @@
         </div>
         <div id="sidebarArea" style="display:none">
           <div id="sidebarContent">
+            <div>
+              <div class="btn-group pull-right">
+                <div class="btn-group">
+                  <button id="hideSidebarButton" type="button" class="toolbar-btn" title="Close sidebar">
+                    <i class="material-icons">close</i>
+                  </button>
+                </div>
+              </div>
+            </div>
             <div>
               <div id="navigation" style="display: none"></div>
               <div id="help"></div>
@@ -265,6 +265,29 @@
         <div class="progress-bar" style="width: 100%"></div>
       </div>
     </div>
+  </script>
+  <script type="text/fragment" id="datalabHelp">
+    <p><b>Help for Python APIs</b></p>
+    <p>
+      You can enter <code>class?</code> or <code>member?</code> within a code cell in the
+      notebook to get help on a Python API.
+    </p>
+    <br />
+    <p>
+      For example, try <code>str?</code> to get help information on the built-in Python
+      method to convert a value to its string representation.
+    </p>
+    <br />
+    <p>
+      Additional help topics and links are also available from the menu off the Help
+      icon on the top of the page.
+    </p>
+    <br />
+    <p><b>Docs and Samples</b></p>
+    <p>
+      The <a href="/notebooks/datalab/docs/Readme.ipynb" target="_blank">Cloud Datalab Guide</a> featuring
+      documentation and sample notebooks is also a great way to check out how you can use Cloud Datalab.
+    </p>
   </script>
   <script type="text/fragment" id="shortcutsHelp">
     <p>The notebook has two keyboard modes: Edit mode allows you to type code/text into a cell indicated by a raised cell with a shadow. Command mode allows notebook level actions.</p>


### PR DESCRIPTION
It took a few seconds to locate the help documentation in the Datalab app bar (hover the icons until I found 'Help links').

This PR changes the icon for the link titled 'Help links'  to use the 'help_outline' icon instead of 'open in new' from https://material.io/icons/.

I've included a screenshot from my local environment.

Feel free to close if the 'open in new' icon is preferred.

![datalabscreenshot](https://cloud.githubusercontent.com/assets/5184014/24145886/a009cd1a-0e09-11e7-953d-639c3e3704eb.png)