### PR TITLE
Run notebook tests in sequence instead of parallel

### DIFF
--- a/containers/test/content/test.py
+++ b/containers/test/content/test.py
@@ -27,7 +27,6 @@ import argparse
 import os
 import re
 import sys
-from threading import Thread
 import time
 import yaml
 
@@ -98,25 +97,19 @@ def run_notebook_test(test, notebook, url_base, results, testscript):
 
 
 def run_tests(url_base, tests=[], testscript=None):
-  threads = []
   results = {}
   failed = False
 
   print 'Tests started..'
 
+  # Create each browser sequentially as doing it in parallel can cause the 
+  # tests to be flaky
   for test in tests:
     if 'disabled' in test and test['disabled']:
       continue
 
     notebook = test['notebook']
-
-    # start tests in parallel browser sessions
-    t = Thread(target=run_notebook_test, args=[test, notebook, url_base, results, testscript])
-    threads.append(t)
-    t.start()
-
-  for t in threads:
-    t.join()
+    run_notebook_test(test, notebook, url_base, results, testscript)
 
   for result in results.values():
     print '\n'.join(result[0])

--- a/containers/test/run.sh
+++ b/containers/test/run.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 CONTENT=$HOME
-ENTRYPOINT=""
+ENTRYPOINT="/datalab/test/startup.sh"
 if [ "$1" != "" ]; then
   if [ "$1" != "shell" ]; then
     CONTENT=$1


### PR DESCRIPTION
Running them in parallel caused some flakiness locally, moving to sequential browser creation fixed it.
I also added the default entrypoint for the test script, which was missing.