### PR TITLE
Fix css cut-off issue on cell mini-toolbar

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -115,12 +115,14 @@ body {
   justify-content: space-between;
 }
 #contentArea {
-  height: 100%;
   -webkit-order: 2;
   order: 2;
   -webkit-flex: 1 1 auto;
   flex: 1 1 auto;
   overflow: auto;
+}
+#mainContent {
+  height: 100%;
 }
 #mainArea {
   -webkit-order: 1;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -115,6 +115,7 @@ body {
   justify-content: space-between;
 }
 #contentArea {
+  height: 100%;
   -webkit-order: 2;
   order: 2;
   -webkit-flex: 1 1 auto;


### PR DESCRIPTION
Fixes https://github.com/googledatalab/datalab/issues/1063.