### PR TITLE
Add "Interrupt Execution" (stop cell) button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ containers/datalab/Dockerfile
 containers/datalab/content/license.txt
 containers/gateway/Dockerfile
 containers/gateway/content/license.txt
+containers/base/pydatalab

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -64,10 +64,14 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir matplotlib==1.5.3 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir ggplot==0.6.8 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir seaborn==0.7.0 && \
-    pip install -U --upgrade-strategy only-if-needed --no-cache-dir notebook==4.2.3 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir PyYAML==3.11 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir six==1.10.0 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir ipywidgets==5.2.2 && \
+    # Install notebook after ipywidgets, and keep it pinned to 4.2.3, higher versions may
+    # not work well with datalab. For example, kernel gateway doesn't work with 4.3.0 notebook
+    # (https://github.com/googledatalab/datalab/issues/1083)
+    pip install -U --upgrade-strategy only-if-needed --no-cache-dir notebook==4.2.3 && \
+    pip install -U --upgrade-strategy only-if-needed --no-cache-dir ipykernel==4.5.2 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir future==0.15.2 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir psutil==4.3.0 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir google-api-python-client==1.5.1  && \
@@ -136,11 +140,6 @@ RUN pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow==
 RUN gsutil cp gs://cloud-ml/sdk/cloudml.latest.tar.gz cloudml.latest.tar.gz && \
     pip install --upgrade-strategy only-if-needed --no-cache-dir cloudml.latest.tar.gz && \
     rm cloudml.latest.tar.gz
-
-# Install notebook again and pin version to 4.2.3 
-# ipywidgets and maybe others will update notebook to a newer version that may not work well with datalab.
-# For example, kernel gateway doesn't work with 4.3.0 notebook (https://github.com/googledatalab/datalab/issues/1083)
-RUN pip install -U --upgrade-strategy only-if-needed --no-cache-dir notebook==4.2.3
 
 ADD config/ipython.py /etc/ipython/ipython_config.py
 ADD config/nbconvert.py /etc/jupyter/jupyter_notebook_config.py

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -1101,6 +1101,11 @@ function initializeNotebookApplication(ipy, notebook, events, dialog, utils) {
     this.blur();
   });
   
+  $('#interruptKernelButton').click(function() {
+    Jupyter.notebook.kernel.interrupt();
+    this.blur();
+  });
+  
   $('#toggleSidebarButton').click(function() {
     $('#sidebarArea').toggleClass('larger');
     rotated = $('#toggleSidebarButton').css('transform').indexOf('matrix') > -1;

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -154,6 +154,12 @@
                 <i id="kernel_indicator_icon"></i> Reset
                 <span class="toolbar-text">Session</span>
               </button>
+              <button type="button" class="toolbar-btn dropdown-toggle" data-toggle="dropdown">
+                <span class="caret"></span>
+              </button>
+              <ul class="dropdown-menu">
+                <li id="interruptKernelButton"><a href="#">Interrupt Execution</a></li>
+              </ul>
             </div>
             <!-- The next div and its contents are for ipywidgets. They insert their own menu before #help_menu -->
             <div class="btn-group" id="help_menu_container">


### PR DESCRIPTION
(Depends on https://github.com/googledatalab/pydatalab/pull/325)

This button interrupts the kernel execution, and can be accessed in a dropdown menu under the `Reset Session` button.

![image](https://cloud.githubusercontent.com/assets/1424661/24392113/5c8fc01a-1347-11e7-8c01-3c29b9869bb6.png)

The `ipykernel` update is needed because the older `ipykernel` version had the undesired behavior of continuing queued cell execution after interrupting the first running cell.

Fixes https://github.com/googledatalab/datalab/issues/1049.