### PR TITLE
Fix appContent height bug that shows on Safari

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -72,11 +72,11 @@ body {
   height: 100% !important;
 }
 #appContent {
+  position: absolute;
   top: 0px;
   bottom: 0px;
   left: 0px;
   right: 0px;
-  height: 100%;
   -webkit-order: 2;
   order: 2;
   -webkit-flex: 1 1 auto;


### PR DESCRIPTION
Fixes https://github.com/googledatalab/datalab/issues/1261.