### PR TITLE
Fix missing site element in file tree page

### DIFF
--- a/sources/web/datalab/templates/edit.html
+++ b/sources/web/datalab/templates/edit.html
@@ -28,6 +28,7 @@
   <div id="app">
     <div id="appBar">
     </div>
+    <div id="site">
     <div id="appContent">
       <div id="toolbarArea">
         <div id="mainToolbar">
@@ -61,6 +62,7 @@
           </div>
         </div>
       </div>
+    </div>
     </div>
   </div>
   <script src="/static/components/es6-promise/promise.min.js"></script>

--- a/sources/web/datalab/templates/sessions.html
+++ b/sources/web/datalab/templates/sessions.html
@@ -25,6 +25,7 @@
   <div id="app">
     <div id="appBar">
     </div>
+    <div id="site">
     <div id="appContent">
       <div id="mainArea">
         <div id="mainContent" class="container treeMainContent">
@@ -48,6 +49,7 @@
           </div>
         </div>
       </div>
+    </div>
     </div>
   </div>
   <script src="/static/components/es6-promise/promise.min.js"></script>

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -58,6 +58,7 @@
   <div id="app">
     <div id="appBar">
     </div>
+    <div id="site">
     <div id="appContent">
       <div id="mainArea">
         <div id="mainContent" class="container treeMainContent">
@@ -126,6 +127,7 @@
           </div>
         </div>
       </div>
+    </div>
     </div>
   </div>
   <script src="/static/components/es6-promise/promise.min.js"></script>


### PR DESCRIPTION
The last css fix missed the fact that we don't have a site element on all pages. even though they all have the same appbar/other content split. This PR updates all pages to have the same element hierarchy.