### PR TITLE
Revert "Fix css cut-off issue on cell mini-toolbar (#1287)"

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -122,9 +122,6 @@ body {
   flex: 1 1 auto;
   overflow: auto;
 }
-#mainContent {
-  height: 100%;
-}
 #mainArea {
   -webkit-order: 1;
   order: 1;


### PR DESCRIPTION
This reverts commit 4d6b4e0da33acbd79a4049f768bb9a5882811602, which fixed https://github.com/googledatalab/datalab/issues/1063.

The css fix causes bad side effects with code cells that have very long outputs, where switching code cells takes several seconds for some reason, it gets worse the longer the cell output is. The situation is a little better in Firefox, but I can't seem to figure out why.

I'll revert because the performance issue has more priority than fixing the css for the menu. I'll also reopen that issue.