### PR TITLE
Add support for customizing `docker build` args.

### DIFF
--- a/containers/base/build.sh
+++ b/containers/base/build.sh
@@ -34,4 +34,4 @@ else
 fi
 
 trap 'rm -rf pydatalab' exit
-docker build -t datalab-base .
+docker build ${DOCKER_BUILD_ARGS} -t datalab-base .

--- a/containers/datalab/build.sh
+++ b/containers/datalab/build.sh
@@ -45,7 +45,7 @@ cd ../base
 cd ../datalab
 
 # Build the docker image
-docker build -t datalab .
+docker build ${DOCKER_BUILD_ARGS} -t datalab .
 
 # Finally cleanup
 rm -rf build

--- a/containers/datalab/run-extended.sh
+++ b/containers/datalab/run-extended.sh
@@ -63,7 +63,7 @@ then
     fi
 
     # Build the customized docker image derived from the standard datalab image
-    docker build -t $DOCKERIMAGE -f $DOCKERFILE .
+    docker build ${DOCKER_BUILD_ARGS} -t $DOCKERIMAGE -f $DOCKERFILE .
 fi
 
 # On linux docker runs directly on host machine, so bind to 127.0.0.1 only

--- a/containers/gateway/build.sh
+++ b/containers/gateway/build.sh
@@ -39,7 +39,7 @@ cd ../base
 cd ../gateway
 
 # Build the docker image
-docker build -t datalab-gateway .
+docker build ${DOCKER_BUILD_ARGS} -t datalab-gateway .
 
 # Finally cleanup
 rm -rf build

--- a/containers/test/build.sh
+++ b/containers/test/build.sh
@@ -20,5 +20,5 @@ cd ../datalab
 cd ../test
 
 # Build the docker image
-docker build -t datalab-test .
+docker build ${DOCKER_BUILD_ARGS} -t datalab-test .
 


### PR DESCRIPTION
I have a collection of cases where I'm calling into
`containers/datalab/build.sh` from another script, and I'd like to customize
the args passed to `docker build`.

In my case, I'd like to add `--no-cache` to the build args. Given that this
calls docker from several places (there and in `containers/base/build.sh`),
setting an env var seems like the cleanest way to wire this in.

PTAL @chmeyers @yebrahim @jimmc (Not sure who watches the dockerfiles)