### PR TITLE
Implement live mode for faster development.

### DIFF
--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -114,5 +114,13 @@ then
   FOREVER_CMD="${FOREVER_CMD} -s"
 fi
 
+if [ -d /devroot ]; then
+  # For development purposes, if the user has mapped a /devroot dir, use it.
+  echo "Running notebook server in live mode"
+  export DATALAB_LIVE_STATIC_DIR=/devroot/sources/web/datalab/static
+  export DATALAB_LIVE_TEMPLATES_DIR=/devroot/sources/web/datalab/templates
+  # Make sure we have the latest compiled typescript output
+  cp -p /devroot/build/web/nb/*.js /datalab/web
+fi
 echo "Open your browser to http://localhost:8081/ to connect to Datalab."
 ${FOREVER_CMD} /datalab/web/app.js

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -91,7 +91,8 @@ var callbackManager: callbacks.CallbackManager = new callbacks.CallbackManager()
 /**
  * Templates
  */
-var templates: common.Map<string> = {
+const templates: common.Map<string> = {
+  // These cached templates can be overridden in sendTemplate
   'tree': fs.readFileSync(path.join(__dirname, 'templates', 'tree.html'), { encoding: 'utf8' }),
   'sessions': fs.readFileSync(path.join(__dirname, 'templates', 'sessions.html'), { encoding: 'utf8' }),
   'edit': fs.readFileSync(path.join(__dirname, 'templates', 'edit.html'), { encoding: 'utf8' }),
@@ -393,16 +394,18 @@ function getBaseTemplateData(request: http.ServerRequest): common.Map<string> {
 }
 
 function sendTemplate(key: string, data: common.Map<string>, response: http.ServerResponse) {
-  var template = templates[key];
+  let template = templates[key];
 
-  // NOTE: Uncomment to use external templates mapped into the container.
-  //       This is only useful when actively developing the templates themselves.
-  // template = fs.readFileSync('/sources/datalab/templates/' + key + '.html', { encoding: 'utf8' });
+  // Set this env var to point to source directory for live updates without restart.
+  const liveTemplatesDir = process.env.DATALAB_LIVE_TEMPLATES_DIR
+  if (liveTemplatesDir) {
+    template = fs.readFileSync(path.join(liveTemplatesDir, key + '.html'), { encoding: 'utf8' });
+  }
 
   // Replace <%name%> placeholders with actual values.
   // TODO: Error handling if template placeholders are out-of-sync with
   //       keys in passed in data object.
-  var htmlContent = template.replace(/\<\%(\w+)\%\>/g, function(match, name) {
+  const htmlContent = template.replace(/\<\%(\w+)\%\>/g, function(match, name) {
     return data[name];
   });
 

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -111,7 +111,15 @@ function sendFile(filePath: string, response: http.ServerResponse,
  * @param response the out-going response associated with the current HTTP request.
  */
 function sendDataLabFile(filePath: string, response: http.ServerResponse) {
-  sendFile(path.join(__dirname, 'static', filePath), response);
+  let live = false
+  let staticDir = path.join(__dirname, 'static')
+  // Set this env var to point to source directory for live updates without restart.
+  const liveStaticDir = process.env.DATALAB_LIVE_STATIC_DIR
+  if (liveStaticDir) {
+    live = true
+    staticDir = liveStaticDir
+  }
+  sendFile(path.join(staticDir, filePath), response, '', live);
 }
 
 /**


### PR DESCRIPTION
This change takes advantage of existing code to implement a better and simpler live-mode than in #1316.
1. When running container/datalab/run.sh during development, by default it now starts the container with a mount point for /devroot that points to the datalab root directory.
2. Inside the container, when datalab/run.sh sees that a /devroot mount point exists, it copies in the latest js files for the notebook server, and sets a couple of environment variables to point to the source directories for the static and templates folders.
3. In the code, when those environment variables are set, it pulls static and template files from those locations, and files in those directories are not cached, but are reloaded when they are changed.

Usage:
1. By default, live-mode is enabled when starting the container using containers/datalab/run.sh. To disable live-mode, add the --no-live option.
2. When running in live mode, after making changes to files in the static and templates directories, just reload the page in the web browser.
3. If you will be making changes to typescript files, you should include the "shell" option to containers/datalab/run.sh. At the shell prompt in the container, start the notebook server by running datalab/run.sh. After making changes to typescript files on your workstation, run sources/web/build.sh, then stop the notebook server in the container and rerun datalab/run.sh. Alternatively, if you don't use the "shell" option, run "docker exec" to open a shell in the container in another window, then after making changes to typescript files, manually run "cp -p /devroot/build/web/nb/*.js /datalab/web" in the container, then restart the notebook server from the UI.