### PR TITLE
Add window level flag signaling proper load events

### DIFF
--- a/containers/test/content/startup.sh
+++ b/containers/test/content/startup.sh
@@ -15,8 +15,14 @@
 # limitations under the License.
 
 /datalab/run.sh &
-sleep 10
 Xvfb :10 -ac &
+
+echo -n "Polling on Datalab.."
+until $(curl --output /dev/null --silent --head --fail http://localhost:8080); do
+  printf "."
+  sleep 1
+done
+echo " Done."
 
 cd /datalab/test
 python test.py

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -64,17 +64,45 @@ function initializeDataLab(ipy, events, dialog, utils, security) {
 
   var pageClass = document.body.className;
   if (pageClass.indexOf('notebook_app') >= 0) {
-    initializeNotebookApplication(ipy, ipy.notebook, events, dialog, utils);
+    initNotebookApplication_preLoad(ipy, ipy.notebook, events, dialog, utils);
+    events.on('notebook_loaded.Notebook', function() {
+      initNotebookApplication_postLoad(ipy, ipy.notebook, events, dialog, utils);
+      window.datalab.loaded = true;
+    });
   }
   else if (pageClass.indexOf('edit_app') >= 0) {
-    initializeEditApplication(ipy, ipy.editor);
+    events.on('file_loaded.Editor', function() {
+      initEditApplication_postLoad(ipy, ipy.editor);
+      window.datalab.loaded = true;
+    });
   }
   else if (pageClass.indexOf('notebook_list') >= 0) {
-    initializeNotebookList(ipy, ipy.notebook_list, ipy.new_notebook_widget, events, dialog, utils);
+    events.on('draw_notebook_list.NotebookList', function() {
+      initNotebookList_postLoad(ipy, ipy.notebook_list, ipy.new_notebook_widget,
+                             events, dialog, utils);
+      window.datalab.loaded = true;
+    });
+  }
+  else if (pageClass.indexOf('session_list') >= 0) {
+    events.on('draw_notebook_list.NotebookList', function() {
+      window.datalab.loaded = true;
+    });
   }
 }
 
-require(['base/js/namespace', 'base/js/events', 'base/js/dialog', 'base/js/utils', 'base/js/security',
-    'static/appbar', 'static/edit-app', 'static/minitoolbar', 'static/notebook-app',
-    'static/notebook-list', 'static/websocket'],
-        initializeDataLab);
+define([
+  'base/js/namespace',
+  'base/js/events',
+  'base/js/dialog',
+  'base/js/utils',
+  'base/js/security',
+  'static/appbar',
+  'static/edit-app',
+  'static/minitoolbar',
+  'static/notebook-app',
+  'static/notebook-list',
+  'static/websocket'
+], function(ipy, events, dialog, utils, security, appbar, editapp,
+            minitoolbar, notebookapp, notebooklist, websocket) {
+  initializeDataLab(IPython, events, dialog, utils, security);
+});

--- a/sources/web/datalab/static/edit-app.js
+++ b/sources/web/datalab/static/edit-app.js
@@ -1,4 +1,4 @@
-function initializeEditApplication(ipy, editor) {
+function initEditApplication_postLoad(ipy, editor) {
   function navigateAlternate(alt) {
     var url = document.location.href.replace('/edit', alt);
     if (url.includes("?")) {

--- a/sources/web/datalab/static/notebook-list.js
+++ b/sources/web/datalab/static/notebook-list.js
@@ -1,4 +1,4 @@
-function initializeNotebookList(ipy, notebookList, newNotebook, events, dialog, utils) {
+function initNotebookList_postLoad(ipy, notebookList, newNotebook, events, dialog, utils) {
   function addNotebook(e) {
     newNotebook.new_notebook();
     e.target.blur();

--- a/sources/web/datalab/templates/sessions.html
+++ b/sources/web/datalab/templates/sessions.html
@@ -15,6 +15,7 @@
 </head>
 <body class="session_list"
   data-base-url="<%baseUrl%>"
+  data-notebook-path="/"
   data-terminals-available="False"
   data-feedback-id="<%feedbackId%>"
   data-version-id="<%versionId%>"
@@ -54,7 +55,6 @@
   </div>
   <script src="/static/components/es6-promise/promise.min.js"></script>
   <script src="/static/components/requirejs/require.js"></script>
-  <script src="<%configUrl%>"></script>
   <script>
     require.config({
       baseUrl: '/static/',


### PR DESCRIPTION
This is fixing the previously arbitrary script load order, by waiting on events triggered by Jupyter for each of the four template pages.

The scripts we execute in any given page to customize it can have some code that must execute before the page is initialized by Jupyter (such as adding event listeners), but it also has some code that assumes elements have already been loaded (such as customizing functionality of buttons). This PR splits Datalab's customization scripts into preLoad and postLoad scripts, and calls them appropriately.

The big change in `nb.html` is just moving code around, no changes to that code were made.

The change also adds a `window.datalab.loaded` flag signaling that loading was finished. Later on I'll use this so that tests can wait on pages to load.