### PR TITLE
Add a terminal functionality

### DIFF
--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -94,6 +94,7 @@ var callbackManager: callbacks.CallbackManager = new callbacks.CallbackManager()
 const templates: common.Map<string> = {
   // These cached templates can be overridden in sendTemplate
   'tree': fs.readFileSync(path.join(__dirname, 'templates', 'tree.html'), { encoding: 'utf8' }),
+  'terminals': fs.readFileSync(path.join(__dirname, 'templates', 'terminals.html'), { encoding: 'utf8' }),
   'sessions': fs.readFileSync(path.join(__dirname, 'templates', 'sessions.html'), { encoding: 'utf8' }),
   'edit': fs.readFileSync(path.join(__dirname, 'templates', 'edit.html'), { encoding: 'utf8' }),
   'nb': fs.readFileSync(path.join(__dirname, 'templates', 'nb.html'), { encoding: 'utf8' })
@@ -433,7 +434,8 @@ function responseHandler(proxyResponse: http.ClientResponse,
   // Set a cookie to provide information about the project and authenticated user to the client.
   // Ensure this happens only for page requests, rather than for API requests.
   var path = url.parse(request.url).pathname;
-  if ((path.indexOf('/tree') == 0) || (path.indexOf('/notebooks') == 0) || (path.indexOf('/edit') == 0)) {
+  if ((path.indexOf('/tree') == 0) || (path.indexOf('/notebooks') == 0) ||
+      (path.indexOf('/edit') == 0) || (path.indexOf('/terminals') == 0)) {
     var templateData: common.Map<string> = getBaseTemplateData(request);
     var page: string = null;
     if (path.indexOf('/tree') == 0) {
@@ -447,6 +449,9 @@ function responseHandler(proxyResponse: http.ClientResponse,
       templateData['fileName'] = path.substr(path.lastIndexOf('/') + 1);
 
       page = 'edit';
+    } else if (path.indexOf('/terminals') == 0) {
+      templateData['terminalId'] = 'terminals/websocket/' + path.substr(path.lastIndexOf('/') + 1);
+      page = 'terminals';
     } else {
       // stripping off the /notebooks/ from the path
       templateData['notebookPath'] = path.substr(11);

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -153,6 +153,7 @@ function handleRequest(request: http.ServerRequest,
       (path.indexOf('/nbextensions') == 0) ||
       (path.indexOf('/files') == 0) ||
       (path.indexOf('/edit') == 0) ||
+      (path.indexOf('/terminals') == 0) ||
       (path.indexOf('/sessions') == 0)) {
 
     if (path.indexOf('/tree') == 0) {

--- a/sources/web/datalab/static/dark.css
+++ b/sources/web/datalab/static/dark.css
@@ -106,6 +106,15 @@ input {
   color: #333;
 }
 
+/* Terminal Page */
+#running .panel {
+  background-color: #444;
+  border-color: #333;
+}
+#running .panel-group .panel .panel-heading {
+  background-color: #333;
+}
+
 /* Inside Notebooks */
 #contentArea,#notebook-container {
   background-color: #444;

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -349,6 +349,17 @@ span.autosave_status {
   padding: 0px;
 }
 
+/* Terminals page */
+.terminal-app #terminado-container {
+  margin: 0px;
+  height: 100%;
+  width: 100vw;
+}
+.terminal-app .terminal, .terminal-app {
+  width: 100%;
+  height: 100%;
+}
+
 /* Cell Customizations */
 div.cell {
   border: solid 1px transparent;

--- a/sources/web/datalab/static/notebook-list.js
+++ b/sources/web/datalab/static/notebook-list.js
@@ -32,6 +32,24 @@ function initNotebookList_postLoad(ipy, notebookList, newNotebook, events, dialo
     e.target.blur();
   }
 
+  function addTerminal(e) {
+    let newWindow = window.open(undefined, IPython._target);
+    let prefix = location.protocol + '//' + location.host + '/';
+    let addTerminalUrl = prefix + 'api/terminals';
+    let settings = {
+      type : 'POST',
+      dataType: 'json',
+      success: (data, status, xhr) => {
+        newWindow.location = prefix + 'terminals/' + encodeURIComponent(data.name);
+      },
+      error : function(jqXHR, status, error){
+        newWindow.close();
+        debug.log(jqXHR, status, error);
+      },
+    };
+    $.ajax(addTerminalUrl, settings);
+  }
+
   function openEditor(e) {
     prefix = location.protocol + '//' + location.host + "/edit/";
     Jupyter.notebook_list.selected.forEach(notebook => {
@@ -51,6 +69,7 @@ function initNotebookList_postLoad(ipy, notebookList, newNotebook, events, dialo
 
   document.getElementById('addNotebookButton').addEventListener('click', addNotebook, false);
   document.getElementById('addFolderButton').addEventListener('click', addFolder, false);
+  document.getElementById('addTerminalButton').addEventListener('click', addTerminal, false);
   document.getElementById('editorButton').addEventListener('click', openEditor, false);
 
   (function buildBreadcrumbContent() {

--- a/sources/web/datalab/templates/sessions.html
+++ b/sources/web/datalab/templates/sessions.html
@@ -16,7 +16,7 @@
 <body class="session_list"
   data-base-url="<%baseUrl%>"
   data-notebook-path="/"
-  data-terminals-available="False"
+  data-terminals-available="True"
   data-feedback-id="<%feedbackId%>"
   data-version-id="<%versionId%>"
   data-signed-in="<%isSignedIn%>"

--- a/sources/web/datalab/templates/sessions.html
+++ b/sources/web/datalab/templates/sessions.html
@@ -33,15 +33,37 @@
           <div id="ipython-main-app">
             <div id="tab_content" class="tabbable">
               <div class="tab-content">
-                <div id="running" class="tab-pane active">
-                  <div id="running_list">
-                    <div id="running_list_header" class="row list_header">
-                      <div>
-                        Active Notebooks
+                <div id="running">
+                  <div class="panel-group" id="accordion">
+                    <div class="panel panel-default">
+                      <div class="panel-heading">
+                        <a data-toggle="collapse" data-target="#collapseOne" href="#"
+                           aria-expanded="true" class="">Active Notebooks </a>
+                      </div>
+                      <div id="collapseOne" class="collapse in" aria-expanded="true">
+                        <div class="panel-body">
+                          <div id="running_list" class="list_container">
+                            <div id="running_list_placeholder" class="row list_placeholder">
+                              <div>There are no notebooks running.</div>
+                            </div>
+                          </div>
+                        </div>
                       </div>
                     </div>
-                    <div id="running_list_placeholder" class="row list_placeholder">
-                      <div> There are no running sessions. </div>
+                    <div class="panel panel-default">
+                      <div class="panel-heading">
+                        <a data-toggle="collapse" data-target="#collapseTwo" href="#"
+                           aria-expanded="true" class="">Active Terminals </a>
+                      </div>
+                      <div id="collapseTwo" class="collapse in" aria-expanded="true">
+                        <div class="panel-body">
+                          <div id="terminal_list" class="list_container">
+                            <div id="terminal_list_header" class="row list_placeholder">
+                              <div>There are no terminals running.</div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/sources/web/datalab/templates/terminals.html
+++ b/sources/web/datalab/templates/terminals.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
   <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
   <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" />
-  <link rel="stylesheet" href="/static/terminal/css/override.css?v=b71f5060e3fa5cdd606894114e92b952" type="text/css">
+  <link rel="stylesheet" href="/static/terminal/css/override.css" type="text/css">
 
   <script src="/static/components/jquery/jquery.min.js"></script>
 </head>
@@ -116,11 +116,10 @@
     window.datalab = {};
 
     $("#appBar").load("/static/appbar.html", function() {
-      require(['tree/js/main.min']);
+      require(['tree/js/main.min', '/static/terminal/js/main.min.js']);
     });
   </script>
   <script src="//www.gstatic.com/feedback/api.js" async="true" defer="true"></script>
-  <script src="/static/terminal/js/main.min.js" type="text/javascript" charset="utf-8"></script>
 </body>
 </html>
 

--- a/sources/web/datalab/templates/terminals.html
+++ b/sources/web/datalab/templates/terminals.html
@@ -33,6 +33,8 @@
       </div>
     </div>
     <div style="position:absolute; left:-1000em">
+      <!-- The following elements contain dummy content that is used to calculate
+      the size of the terminal characters. For more context, look at terminal/js/main.js -->
       <pre id="dummy-screen" style="border: solid 5px white;" class="terminal">
         0
         1
@@ -58,6 +60,7 @@
         1
         2
         3
+        4
       <span id="dummy-screen-rows" style="">01234567890123456789012345678901234567890123456789012345678901234567890123456789</span>
       </pre>
     </div>

--- a/sources/web/datalab/templates/terminals.html
+++ b/sources/web/datalab/templates/terminals.html
@@ -16,7 +16,6 @@
 </head>
 <body class="terminal-app"
   data-base-url="<%baseUrl%>"
-  data-terminals-available="True"
   data-notebook-path="/"
   data-ws-path="<%terminalId%>"
   data-feedback-id="<%feedbackId%>"

--- a/sources/web/datalab/templates/terminals.html
+++ b/sources/web/datalab/templates/terminals.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>Google Cloud DataLab</title>
+  <link rel="shortcut icon" type="image/x-icon" href="/static/favicon.ico">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <link rel="stylesheet" href="/static/components/codemirror/lib/codemirror.css" />
+  <link rel="stylesheet" href="/static/style/style.min.css" type="text/css" />
+  <link rel="stylesheet" href="/static/style/datalab.css" type="text/css" />
+  <link rel="stylesheet" id="themeStylesheet" href="/static/style/custom.css" type="text/css" />
+  <link rel="stylesheet" href="/static/terminal/css/override.css?v=b71f5060e3fa5cdd606894114e92b952" type="text/css">
+
+  <script src="/static/components/jquery/jquery.min.js"></script>
+</head>
+<body class="terminal-app"
+  data-base-url="<%baseUrl%>"
+  data-terminals-available="True"
+  data-notebook-path="/"
+  data-ws-path="<%terminalId%>"
+  data-feedback-id="<%feedbackId%>"
+  data-version-id="<%versionId%>"
+  data-signed-in="<%isSignedIn%>"
+  data-user-id="<%userId%>"
+  data-account="<%account%>">
+
+  <div id="app">
+    <div id="appBar">
+    </div>
+    <div id="header"></div>
+    <div id="site">
+      <div id="terminado-container">
+      </div>
+    </div>
+    <div style="position:absolute; left:-1000em">
+      <pre id="dummy-screen" style="border: solid 5px white;" class="terminal">
+        0
+        1
+        2
+        3
+        4
+        5
+        6
+        7
+        8
+        9
+        0
+        1
+        2
+        3
+        4
+        5
+        6
+        7
+        8
+        9
+        0
+        1
+        2
+        3
+      <span id="dummy-screen-rows" style="">01234567890123456789012345678901234567890123456789012345678901234567890123456789</span>
+      </pre>
+    </div>
+  </div>
+  <script src="/static/components/es6-promise/promise.min.js"></script>
+  <script src="/static/components/requirejs/require.js"></script>
+  <script>
+    require.config({
+      baseUrl: '/static/',
+      paths: {
+        'auth/js/main': 'auth/js/main.min',
+        custom : '/custom',
+        nbextensions : '/nbextensions',
+        widgets : '/deprecatedwidgets',
+        kernelspecs : '/kernelspecs',
+        underscore : 'components/underscore/underscore-min',
+        backbone : 'components/backbone/backbone-min',
+        jquery: 'components/jquery/jquery.min',
+        bootstrap: 'components/bootstrap/js/bootstrap.min',
+        bootstraptour: 'components/bootstrap-tour/build/js/bootstrap-tour.min',
+        jqueryui: 'components/jquery-ui/ui/minified/jquery-ui.min',
+        moment: 'components/moment/moment',
+        codemirror: 'components/codemirror',
+        termjs: 'components/term.js/src/term',
+      },
+      shim: {
+        underscore: {
+          exports: '_'
+        },
+        backbone: {
+          deps: ["underscore", "jquery"],
+          exports: "Backbone"
+        },
+        bootstrap: {
+          deps: ["jquery"],
+          exports: "bootstrap"
+        },
+        bootstraptour: {
+          deps: ["bootstrap"],
+          exports: "Tour"
+        },
+        jqueryui: {
+          deps: ["jquery"],
+          exports: "$"
+        }
+      }
+    });
+    require.config({
+       map: {
+         '*': {
+           'contents': 'services/contents',
+         }
+       }
+    });
+    window.datalab = {};
+
+    $("#appBar").load("/static/appbar.html", function() {
+      require(['tree/js/main.min']);
+    });
+  </script>
+  <script src="//www.gstatic.com/feedback/api.js" async="true" defer="true"></script>
+  <script src="/static/terminal/js/main.min.js" type="text/javascript" charset="utf-8"></script>
+</body>
+</html>
+

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -78,6 +78,9 @@
                           <button id="addFolderButton" type="button" class="toolbar-btn" title="Add a new folder">
                             <i class="material-icons">add_box</i> Folder
                           </button>
+                          <button id="addTerminalButton" type="button" class="toolbar-btn" title="Add a new terminal">
+                            <i class="material-icons">add_box</i> Terminal
+                          </button>
                           <button id="uploadButton" type="button" class="toolbar-btn" title="Upload notebook(s)">
                             <i class="material-icons">file_upload</i>
                             <input type="file" name="datafile" class="fileinput" multiple="multiple" value="Upload" style="cursor: pointer" />


### PR DESCRIPTION
This adds the Jupyter terminal functionality in Datalab. We will want to customize this for the Datalab experience, but we can do that in a later PR when we decide on a good usability design for it.

This PR adds the necessary plumbing for Jupyter's terminal, which is:
- A new HTML template with just the appbar and one big div for the terminal, and some css styling. A div (`dummy-screen`) is also needed to measure height and width of the terminal element, with some dummy data inside it.
- Changes to `server.ts` and `jupyter.ts` to pass that template page when requested
- An "Add Terminal" button in the tree page
- Changes to the sessions page to list active terminals under active notebooks

![addterminal](https://cloud.githubusercontent.com/assets/1424661/25507062/c53501a0-2b5e-11e7-9ca2-1ca65944be1b.png)
![terminal](https://cloud.githubusercontent.com/assets/1424661/25507071/d2a8f6ac-2b5e-11e7-85fc-f1a3ee4695ad.png)
![sessions](https://cloud.githubusercontent.com/assets/1424661/25507076/d4140838-2b5e-11e7-8d32-e697c5356012.png)
