### PR TITLE
Hide the Kernel Picker menu until it's ready.

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -268,6 +268,11 @@ i.material-icons {
   display: none;
 }
 
+/* Hide the python kernel picker dropdown until it's ready for release. */
+#kernel_picker_menu {
+  display: none;
+}
+
 #logo {
   margin-left: 12px;
   flex: 0 0 auto;

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -161,7 +161,7 @@
                 <li id="interruptKernelButton"><a href="#">Interrupt Execution</a></li>
               </ul>
             </div>
-            <div class="btn-group">
+            <div class="btn-group" id="kernel_picker_menu">
               <button id="kernelSelectorButton" type="button" data-toggle="dropdown" class="toolbar-btn" title="Select kernel">
                 <i class="material-icons">track_changes</i>
                 <span class="toolbar-text">Kernel: </span>


### PR DESCRIPTION
Hide the Kernel Picker menu until it's ready for the next release.  Dataflow, Cloud ML Engine, and ML Toolbox still need py3 support.