### PR TITLE
Terminal fixes: use bash, UI improvements

### DIFF
--- a/containers/datalab/Dockerfile.in
+++ b/containers/datalab/Dockerfile.in
@@ -22,6 +22,7 @@ ADD content/ /datalab
 # Install the build artifacts
 RUN ln -s /datalab/web/static/datalab.css /datalab/nbconvert/datalab.css && \
     cd /datalab/web && /tools/node/bin/npm install && \
+    mv /datalab/.bashrc /root/.bashrc && \
     cd / && \
 
 # Install ungit
@@ -29,6 +30,8 @@ RUN ln -s /datalab/web/static/datalab.css /datalab/nbconvert/datalab.css && \
     /tools/node/bin/npm install -s chokidar@1.6.1
 
 # Startup
+ENV ENV /root/.bashrc
+ENV SHELL /bin/bash
 ENV DATALAB_VERSION _version_
 ENV DATALAB_COMMIT _commit_
 ENV ENABLE_USAGE_REPORTING true

--- a/containers/datalab/content/.bashrc
+++ b/containers/datalab/content/.bashrc
@@ -1,0 +1,10 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+
+cd /content
+STARTCOLOR='\e[1;32m';
+ENDCOLOR="\e[0m"
+export PS1="$STARTCOLOR\u# \w> $ENDCOLOR"
+echo 'Welcome to Google Cloud Datalab.
+Please note that only changes inside /content will be preserved if
+the Datalab VM is shutdown or restarted. Package installations
+(pip, apt-get... etc) and other system changes will not be saved.'

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -355,12 +355,16 @@ span.autosave_status {
 }
 
 /* Terminals page */
+.terminal-app #site {
+  background-color: #222;
+}
 .terminal-app #terminado-container {
-  margin: 0px;
-  height: 100%;
-  width: 100vw;
+  margin: 20px;
+  width: calc(100vw - 40px);
+  height: calc(100% - 40px);
 }
 .terminal-app .terminal, .terminal-app {
+  line-height: 1.1;
   width: 100%;
   height: 100%;
 }

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -106,7 +106,6 @@ function initializeDataLab(
 define([
   'base/js/namespace',
   'base/js/events',
-  'base/js/dialog',
   'base/js/utils',
   'base/js/security',
   'static/appbar',
@@ -114,9 +113,10 @@ define([
   'static/notebook-app',
   'static/notebook-list',
   'static/minitoolbar',
-  'static/websocket'
-], function(ipy, events, dialog, utils, security, appbar, editapp,
-            notebookapp, notebooklist, minitoolbar, websocket) {
+  'static/websocket',
+  'base/js/dialog'
+], function(ipy, events, utils, security, appbar, editapp,
+            notebookapp, notebooklist, minitoolbar, websocket, dialog) {
      initializeDataLab(
             ipy, events, dialog, utils, security, appbar, editapp,
             notebookapp, notebooklist);

--- a/sources/web/datalab/templates/terminals.html
+++ b/sources/web/datalab/templates/terminals.html
@@ -116,7 +116,7 @@
     window.datalab = {};
 
     $("#appBar").load("/static/appbar.html", function() {
-      require(['tree/js/main.min', '/static/terminal/js/main.min.js']);
+      require(['/static/terminal/js/main.min.js', 'tree/js/main.min']);
     });
   </script>
   <script src="//www.gstatic.com/feedback/api.js" async="true" defer="true"></script>

--- a/sources/web/datalab/templates/terminals.html
+++ b/sources/web/datalab/templates/terminals.html
@@ -29,13 +29,12 @@
     </div>
     <div id="header"></div>
     <div id="site">
-      <div id="terminado-container">
-      </div>
+      <div id="terminado-container"></div>
     </div>
     <div style="position:absolute; left:-1000em">
       <!-- The following elements contain dummy content that is used to calculate
       the size of the terminal characters. For more context, look at terminal/js/main.js -->
-      <pre id="dummy-screen" style="border: solid 5px white;" class="terminal">
+      <pre id="dummy-screen" class="terminal">
         0
         1
         2
@@ -60,9 +59,8 @@
         1
         2
         3
-        4
-      <span id="dummy-screen-rows" style="">01234567890123456789012345678901234567890123456789012345678901234567890123456789</span>
-      </pre>
+        </pre>
+      <span id="dummy-screen-rows" style="">01234567890123456789012345678901234567890123456789012345678901234567890123456789012</span>
     </div>
   </div>
   <script src="/static/components/es6-promise/promise.min.js"></script>

--- a/test/ui/test.js
+++ b/test/ui/test.js
@@ -27,9 +27,9 @@ const resemble = require('node-resemble');
 
 var driver = null;
 
-const suiteTimeout = 60000; // maximum of one minute for running each suite
-const initTimeout = 10000;  // 10 seconds for initialization time, building the webdriver
-const scriptTimeout = 5000; // 5 seconds for running synchronous js scripts in the driver
+const suiteTimeout = 60000;  // maximum of one minute for running each suite
+const initTimeout = 10000;   // 10 seconds for initialization time, building the webdriver
+const scriptTimeout = 10000; // 10 seconds for running synchronous js scripts in the driver
 const misMatchThreshold = 0;
 const goldenPathPrefix = 'ui/golden/';
 const brokenPathPrefix = 'ui/broken/';


### PR DESCRIPTION
This fix adds a bashrc file inside the container to set up the enviornment for the user. Currently it changes directory to `/content`, colors the prompt, and adds a message to tell the user to keep sensitive work in `/content`. The `ENV` env var is set so that file gets loaded by all shells.

The rest of the PR is UI fixes to make things look better, and fixed the order of loading the Jupyter dialog module.

![image](https://cloud.githubusercontent.com/assets/1424661/25717519/8c4dcf94-30b7-11e7-827d-fd3bd06ace5d.png)
