### PR TITLE
Load optional env file in live mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ staging
 *.swo
 *.ipynb.yaml
 *.log
+container.env
 containers/datalab/Dockerfile
 containers/datalab/content/license.txt
 containers/gateway/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.ipynb_checkpoints
 build
+dev
 staging
 *.gradle
 *.pyc
@@ -11,7 +12,6 @@ staging
 *.swo
 *.ipynb.yaml
 *.log
-container.env
 containers/datalab/Dockerfile
 containers/datalab/content/license.txt
 containers/gateway/Dockerfile

--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -131,9 +131,9 @@ if [ -d /devroot ]; then
   export DATALAB_LIVE_TEMPLATES_DIR=/devroot/sources/web/datalab/templates
   # Use our internal node_modules dir
   export NODE_PATH="${NODE_PATH}:/datalab/web/node_modules"
-  if [ -f /devroot/container.env ]; then
-    echo source /devroot/container.env
-    source /devroot/container.env
+  if [ -f /devroot/dev/container.env ]; then
+    echo source /devroot/dev/container.env
+    source /devroot/dev/container.env
   fi
   # Auto-restart when the developer builds from the typescript files.
   echo ${FOREVER_CMD} --watch --watchDirectory /devroot/build/web/nb /devroot/build/web/nb/app.js

--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -131,6 +131,10 @@ if [ -d /devroot ]; then
   export DATALAB_LIVE_TEMPLATES_DIR=/devroot/sources/web/datalab/templates
   # Use our internal node_modules dir
   export NODE_PATH="${NODE_PATH}:/datalab/web/node_modules"
+  if [ -f /devroot/container.env ]; then
+    echo source /devroot/container.env
+    source /devroot/container.env
+  fi
   # Auto-restart when the developer builds from the typescript files.
   echo ${FOREVER_CMD} --watch --watchDirectory /devroot/build/web/nb /devroot/build/web/nb/app.js
   ${FOREVER_CMD} --watch --watchDirectory /devroot/build/web/nb /devroot/build/web/nb/app.js


### PR DESCRIPTION
This PR adds code that executes only in live (developer) mode. It looks for an optional env file to source from within the container before starting the datalab server. This makes it easy for the developer to add environment variables during development. Or to use apt-get to install personal favorite packages that are useful for development.