### PR TITLE
Don't attempt to reconnect if the instance is no longer RUNNING.

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -277,6 +277,13 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
             return
         if remaining_reconnects == 0:
             return
+        # Before we try to reconnect, check to see if the VM is still running.
+        status, metadata_items = utils.describe_instance(
+            args, gcloud_compute, instance)
+        if status != 'RUNNING':
+            print('Instance {0} is no longer running ({1})'.format(
+                instance, status))
+            return
         print('Attempting to reconnect...')
         remaining_reconnects -= 1
         # Don't launch the browser on reconnect...

--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -76,6 +76,10 @@ unsupported_browsers = [
 ]
 
 
+# Status values from describe_instance that we care about.
+_STATUS_RUNNING = 'RUNNING'
+
+
 def flags(parser):
     """Add command line flags for the `connect` subcommand.
 
@@ -278,9 +282,9 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
         if remaining_reconnects == 0:
             return
         # Before we try to reconnect, check to see if the VM is still running.
-        status, metadata_items = utils.describe_instance(
+        status, unused_metadata_items = utils.describe_instance(
             args, gcloud_compute, instance)
-        if status != 'RUNNING':
+        if status != _STATUS_RUNNING:
             print('Instance {0} is no longer running ({1})'.format(
                 instance, status))
             return
@@ -302,7 +306,7 @@ def maybe_start(args, gcloud_compute, instance, status):
     Raises:
       subprocess.CalledProcessError: If one of the `gcloud` calls fail
     """
-    if status != 'RUNNING':
+    if status != _STATUS_RUNNING:
         if utils.print_info_messages(args):
             print('Restarting the instance {0} with status {1}'.format(
                 instance, status))


### PR DESCRIPTION
This fixes #1111. If the instance is no longer RUNNING when it is time to attempt to reconnect, it just prints a message and exits.