### PR TITLE
Fix bug in the list command that filtered new instances.

### DIFF
--- a/tools/cli/commands/list.py
+++ b/tools/cli/commands/list.py
@@ -76,7 +76,7 @@ def _filter(args):
     Returns:
       A string suitable for passing to the `gcloud` command
     """
-    base_expr = 'labels.{0}=\'\''.format('datalab')
+    base_expr = 'tags.items=\'{0}\''.format('datalab')
     if args.filter:
         return '({0}) ({1})'.format(base_expr, args.filter)
     else:
@@ -99,4 +99,4 @@ def run(args, gcloud_compute, **unused_kwargs):
         zones.append(args.zone)
     if zones:
         base_cmd.extend(['--zones'] + zones)
-    gcloud_compute(args, base_cmd + ['--filter', filter_expr], api='beta')
+    gcloud_compute(args, base_cmd + ['--filter', filter_expr])

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -103,13 +103,12 @@ except:
 
 
 def gcloud_compute(
-        args, compute_cmd, api='', stdin=None, stdout=None, stderr=None):
+        args, compute_cmd, stdin=None, stdout=None, stderr=None):
     """Run the given subcommand of `gcloud compute`
 
     Args:
       args: The Namespace instance returned by argparse
       compute_cmd: The subcommand of `gcloud compute` to run
-      api: The optional API version to use (e.g. 'alpha', 'beta', etc)
       stdin: The 'stdin' argument for the subprocess call
       stdout: The 'stdout' argument for the subprocess call
       stderr: The 'stderr' argument for the subprocess call
@@ -118,8 +117,6 @@ def gcloud_compute(
       subprocess.CalledProcessError: If the command dies on its own
     """
     base_cmd = [gcloud_cmd]
-    if api:
-        base_cmd.append(api)
     base_cmd.append('compute')
     if args.project:
         base_cmd.extend(['--project', args.project])


### PR DESCRIPTION
The `datalab` command line tool adds a `datalab` tag to every
instance that it creates. As such, the `datalab list` command
should only show the instances that have that tag.

Previously, `gcloud compute instances list` did not support
filtering on nested fields (such as the 'items' field of the
'tags' object), so we could not directly filter on that tag.

However, the beta labels feature (at that time) created a top
level label for every tag on an instance. This meant that we
could filter out non-datalab instances by filtering on that label.

The label feature has since been changed so that tags no longer
get copied into labels. That change results in the `datalab list`
command being too aggressive in its filtering, and the output
always being empty.

Coincidentally, the limitation on filtering on nested fields
has since been removed, so we can fix the bug by switching over
to filtering on tags (rather than labels).

This fixes #1366