### PR TITLE
Make the command line tool work well with redirected stdout.

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -160,7 +160,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
     connect_msg = ('Connecting to {0}.\n'
                    'This will create an SSH tunnel '
                    'and may prompt you to create an rsa key pair.')
-    print(connect_msg.format(instance))
+    utils.print_and_flush(connect_msg.format(instance))
 
     datalab_port = args.port
     datalab_address = 'http://localhost:{0}/'.format(str(datalab_port))
@@ -175,7 +175,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
           subprocess.CalledProcessError: If the connection dies on its own
         """
         if utils.print_info_messages(args):
-            print('Connecting to {0} via SSH').format(instance)
+            utils.print_and_flush('Connecting to {0} via SSH').format(instance)
 
         cmd = ['ssh']
         if args.zone:
@@ -209,16 +209,16 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
                 return
             webbrowser.open(datalab_address)
         except webbrowser.Error as e:
-            print('Unable to open the webbrowser: ' + str(e))
+            utils.print_and_flush('Unable to open the webbrowser: ' + str(e))
 
     def on_ready():
         """Callback that handles a successful connection."""
-        print('\nThe connection to Datalab is now open and will '
+        utils.print_and_flush('\nThe connection to Datalab is now open and will '
               'remain until this command is killed.')
         if in_cloud_shell:
-            print(web_preview_message.format(datalab_port))
+            utils.print_and_flush(web_preview_message.format(datalab_port))
         else:
-            print('You can connect to Datalab at ' + datalab_address)
+            utils.print_and_flush('You can connect to Datalab at ' + datalab_address)
             if not args.no_launch_browser:
                 maybe_open_browser(datalab_address)
         return
@@ -237,7 +237,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
         """
         health_url = '{0}_info/'.format(datalab_address)
         healthy = False
-        print('Waiting for Datalab to be reachable at ' + datalab_address)
+        utils.print_and_flush('Waiting for Datalab to be reachable at ' + datalab_address)
         while not cancelled_event.is_set():
             try:
                 health_resp = urllib2.urlopen(health_url)
@@ -267,7 +267,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
         try:
             create_tunnel()
         except subprocess.CalledProcessError:
-            print('Connection broken')
+            utils.print_and_flush('Connection broken')
         finally:
             cancelled_event.set()
             health_check_thread.join()
@@ -285,10 +285,10 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
         status, unused_metadata_items = utils.describe_instance(
             args, gcloud_compute, instance)
         if status != _STATUS_RUNNING:
-            print('Instance {0} is no longer running ({1})'.format(
+            utils.print_and_flush('Instance {0} is no longer running ({1})'.format(
                 instance, status))
             return
-        print('Attempting to reconnect...')
+        utils.print_and_flush('Attempting to reconnect...')
         remaining_reconnects -= 1
         # Don't launch the browser on reconnect...
         args.no_launch_browser = True
@@ -308,7 +308,7 @@ def maybe_start(args, gcloud_compute, instance, status):
     """
     if status != _STATUS_RUNNING:
         if utils.print_info_messages(args):
-            print('Restarting the instance {0} with status {1}'.format(
+            utils.print_and_flush('Restarting the instance {0} with status {1}'.format(
                 instance, status))
         start_cmd = ['instances', 'start']
         if args.zone:
@@ -335,7 +335,7 @@ def run(args, gcloud_compute, email='', in_cloud_shell=False, **unused_kwargs):
         args, gcloud_compute, instance)
     for_user = metadata_items.get('for-user', '')
     if (not args.no_user_checking) and for_user and (for_user != email):
-        print(wrong_user_message.format(for_user, email))
+        utils.print_and_flush(wrong_user_message.format(for_user, email))
         return
 
     maybe_start(args, gcloud_compute, instance, status)

--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -213,12 +213,13 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
 
     def on_ready():
         """Callback that handles a successful connection."""
-        utils.print_and_flush('\nThe connection to Datalab is now open and will '
-              'remain until this command is killed.')
+        utils.print_and_flush('\nThe connection to Datalab is now open '
+                              'and will remain until this command is killed.')
         if in_cloud_shell:
             utils.print_and_flush(web_preview_message.format(datalab_port))
         else:
-            utils.print_and_flush('You can connect to Datalab at ' + datalab_address)
+            utils.print_and_flush(
+                'You can connect to Datalab at ' + datalab_address)
             if not args.no_launch_browser:
                 maybe_open_browser(datalab_address)
         return
@@ -237,7 +238,8 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
         """
         health_url = '{0}_info/'.format(datalab_address)
         healthy = False
-        utils.print_and_flush('Waiting for Datalab to be reachable at ' + datalab_address)
+        utils.print_and_flush(
+            'Waiting for Datalab to be reachable at ' + datalab_address)
         while not cancelled_event.is_set():
             try:
                 health_resp = urllib2.urlopen(health_url)
@@ -285,8 +287,9 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
         status, unused_metadata_items = utils.describe_instance(
             args, gcloud_compute, instance)
         if status != _STATUS_RUNNING:
-            utils.print_and_flush('Instance {0} is no longer running ({1})'.format(
-                instance, status))
+            utils.print_and_flush(
+                'Instance {0} is no longer running ({1})'.format(
+                    instance, status))
             return
         utils.print_and_flush('Attempting to reconnect...')
         remaining_reconnects -= 1
@@ -308,8 +311,9 @@ def maybe_start(args, gcloud_compute, instance, status):
     """
     if status != _STATUS_RUNNING:
         if utils.print_info_messages(args):
-            utils.print_and_flush('Restarting the instance {0} with status {1}'.format(
-                instance, status))
+            utils.print_and_flush(
+                'Restarting the instance {0} with status {1}'.format(
+                    instance, status))
         start_cmd = ['instances', 'start']
         if args.zone:
             start_cmd.extend(['--zone', args.zone])

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -351,7 +351,8 @@ def create_network(args, gcloud_compute):
       subprocess.CalledProcessError: If the `gcloud` command fails
     """
     if utils.print_info_messages(args):
-        utils.print_and_flush('Creating the network {0}'.format(_DATALAB_NETWORK))
+        utils.print_and_flush(
+            'Creating the network {0}'.format(_DATALAB_NETWORK))
     create_cmd = [
         'networks', 'create', _DATALAB_NETWORK,
         '--description', _DATALAB_NETWORK_DESCRIPTION]
@@ -388,7 +389,8 @@ def create_firewall_rule(args, gcloud_compute):
       subprocess.CalledProcessError: If the `gcloud` command fails
     """
     if utils.print_info_messages(args):
-        utils.print_and_flush('Creating the firewall rule {0}'.format(_DATALAB_FIREWALL_RULE))
+        utils.print_and_flush(
+            'Creating the firewall rule {0}'.format(_DATALAB_FIREWALL_RULE))
     create_cmd = [
         'firewall-rules', 'create', _DATALAB_FIREWALL_RULE,
         '--allow', 'tcp:22',

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -351,7 +351,7 @@ def create_network(args, gcloud_compute):
       subprocess.CalledProcessError: If the `gcloud` command fails
     """
     if utils.print_info_messages(args):
-        print('Creating the network {0}'.format(_DATALAB_NETWORK))
+        utils.print_and_flush('Creating the network {0}'.format(_DATALAB_NETWORK))
     create_cmd = [
         'networks', 'create', _DATALAB_NETWORK,
         '--description', _DATALAB_NETWORK_DESCRIPTION]
@@ -388,7 +388,7 @@ def create_firewall_rule(args, gcloud_compute):
       subprocess.CalledProcessError: If the `gcloud` command fails
     """
     if utils.print_info_messages(args):
-        print('Creating the firewall rule {0}'.format(_DATALAB_FIREWALL_RULE))
+        utils.print_and_flush('Creating the firewall rule {0}'.format(_DATALAB_FIREWALL_RULE))
     create_cmd = [
         'firewall-rules', 'create', _DATALAB_FIREWALL_RULE,
         '--allow', 'tcp:22',
@@ -430,7 +430,7 @@ def create_disk(args, gcloud_compute, disk_name, report_errors):
       subprocess.CalledProcessError: If the `gcloud` command fails
     """
     if utils.print_info_messages(args):
-        print('Creating the disk {0}'.format(disk_name))
+        utils.print_and_flush('Creating the disk {0}'.format(disk_name))
     create_cmd = ['disks', 'create']
     if args.zone:
         create_cmd.extend(['--zone', args.zone])
@@ -493,7 +493,7 @@ def create_repo(args, gcloud_repos, repo_name):
       subprocess.CalledProcessError: If the `gcloud` command fails
     """
     if utils.print_info_messages(args):
-        print('Creating the repository {0}'.format(repo_name))
+        utils.print_and_flush('Creating the repository {0}'.format(repo_name))
 
     create_cmd = ['create', repo_name]
     utils.call_gcloud_quietly(args, gcloud_repos, create_cmd)
@@ -549,7 +549,7 @@ def run(args, gcloud_compute, gcloud_repos,
     if not args.no_create_repository:
         ensure_repo_exists(args, gcloud_repos, _DATALAB_NOTEBOOKS_REPOSITORY)
 
-    print('Creating the instance {0}'.format(instance))
+    utils.print_and_flush('Creating the instance {0}'.format(instance))
     cmd = ['instances', 'create']
     if args.zone:
         cmd.extend(['--zone', args.zone])

--- a/tools/cli/commands/delete.py
+++ b/tools/cli/commands/delete.py
@@ -76,7 +76,7 @@ def run(args, gcloud_compute, **unused_kwargs):
     instance = args.instance
     utils.maybe_prompt_for_zone(args, gcloud_compute, instance)
 
-    print('Deleting {0}'.format(instance))
+    utils.print_and_flush('Deleting {0}'.format(instance))
     base_cmd = ['instances', 'delete']
     if args.zone:
         base_cmd.extend(['--zone', args.zone])

--- a/tools/cli/commands/stop.py
+++ b/tools/cli/commands/stop.py
@@ -46,7 +46,7 @@ def run(args, gcloud_compute, **unused_kwargs):
     instance = args.instance
     utils.maybe_prompt_for_zone(args, gcloud_compute, instance)
 
-    print('Stopping {0}'.format(instance))
+    utils.print_and_flush('Stopping {0}'.format(instance))
     base_cmd = ['instances', 'stop']
     if args.zone:
         base_cmd.extend(['--zone', args.zone])

--- a/tools/cli/commands/utils.py
+++ b/tools/cli/commands/utils.py
@@ -21,6 +21,25 @@ import sys
 import tempfile
 
 
+def print_and_flush(msg):
+    """Helper method that immediately prints to stdout.
+
+    This method is different from just calling `print` in the situation
+    that stdout is a file rather than the user's console.
+
+    In that case, the output of `print` will be buffered until
+    `sys.stdout.flush()` is called. This can cause issues when a user is
+    running a command with output directed to a file, as nothing would be
+    written to that file until the program exits.
+
+    Args:
+      msg: The message to print
+    """
+    print(msg)
+    sys.stdout.flush()
+    return
+
+
 class InvalidInstanceException(Exception):
 
     _MESSAGE = (

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -24,6 +24,7 @@ from commands import create, connect, list, stop, delete, utils
 import argparse
 import os
 import subprocess
+import sys
 import traceback
 
 
@@ -243,6 +244,7 @@ def run():
         if utils.print_info_messages(args):
             traceback.print_exc(e)
         print(e)
+    sys.stdout.flush()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `datalab` command line tool prints various messages to stdout,
but it was previously never calling `sys.stdout.flush()`.

That is fine when the program is run with stdout being the user's
console, because in that case the writes would not be buffered.

However, if a user runs the tool with stdout directed to a regular
file, then the writes to stdout are buffered until `sys.stdout.flush()`
is called. That, in turn, meant that the output of `print` calls
would not be written until the program exited (which results in a flush).

This becomes an issue when a user wants to issue a long-running
invocation of the tool (such as the `connect` command) in a background
process and watch the status using something like `tail -f`.

This change fixes that issue by adding a new `print_and_flush` helper
method to the `utils` package and then using that instead of calling
`print` directly.