### PR TITLE
Move to version file backwards-compatible release.sh

### DIFF
--- a/containers/datalab/build.sh
+++ b/containers/datalab/build.sh
@@ -19,11 +19,10 @@
 # Otherwise, it will get the pydatalab by "git clone" from pydatalab repo.
 
 # Create a versioned Dockerfile based on current date and git commit hash
-VERSION=`date +%Y%m%d`
-VERSION_SUBSTITUTION="s/_version_/0.5.$VERSION/"
+source ../../tools/release/version.sh
 
-COMMIT=`git log --pretty=format:'%H' -n 1`
-COMMIT_SUBSTITUTION="s/_commit_/$COMMIT/"
+VERSION_SUBSTITUTION="s/_version_/$DATALAB_VERSION/"
+COMMIT_SUBSTITUTION="s/_commit_/$DATALAB_COMMIT/"
 
 if [ -z "$1" ]; then
   pydatalabPath=''

--- a/containers/gateway/build.sh
+++ b/containers/gateway/build.sh
@@ -19,11 +19,10 @@
 # Otherwise, it will get the pydatalab by "git clone" from pydatalab repo.
 
 # Create a versioned Dockerfile based on current date and git commit hash
-VERSION=`date +%Y%m%d`
-VERSION_SUBSTITUTION="s/_version_/0.5.$VERSION/"
+source ../../tools/release/version.sh
 
-COMMIT=`git log --pretty=format:'%H' -n 1`
-COMMIT_SUBSTITUTION="s/_commit_/$COMMIT/"
+VERSION_SUBSTITUTION="s/_version_/$DATALAB_VERSION/"
+COMMIT_SUBSTITUTION="s/_commit_/$DATALAB_COMMIT/"
 
 cat Dockerfile.in | sed $VERSION_SUBSTITUTION | sed $COMMIT_SUBSTITUTION > Dockerfile
 

--- a/tools/release/config_local_template.js
+++ b/tools/release/config_local_template.js
@@ -1,8 +1,9 @@
 const vid = document.body.getAttribute("data-version-id");
 const GTM_ACCOUNT = {{GTM_ACCOUNT_PLACEHOLDER}};
 const LATEST_SEMVER = {{DATALAB_VERSION_PLACEHOLDER}};
-const latest = vid.split('.')[2] < "20170523" ? {{DATALAB_VERSION_PATCH_PLACEHOLDER}} : LATEST_SEMVER;
-if (latest) {
+const version_tokens = vid.split('.');
+if (version_tokens.length === 3) {
+  const latest = version_tokens[2] < "20170523" ? {{DATALAB_VERSION_PATCH_PLACEHOLDER}} : LATEST_SEMVER;
   const LAST_SEMVER = "0.5.20160802";
   const PREV_SEMVER = {{PREV_SEMVER_PLACEHOLDER}};
 

--- a/tools/release/config_local_template.js
+++ b/tools/release/config_local_template.js
@@ -1,0 +1,19 @@
+const vid = document.body.getAttribute("data-version-id");
+const LATEST_SEMVER = {{DATALAB_VERSION_PLACEHOLDER}};
+const latest = vid.split('.')[2] < "20170523" ? {{DATALAB_VERSION_PATCH_PLACEHOLDER}} : LATEST_SEMVER;
+const LAST_SEMVER = "20160802";
+const PREV_SEMVER = {{PREV_SEMVER_PLACEHOLDER}};
+const GTM_ACCOUNT = {{GTM_ACCOUNT_PLACEHOLDER}};
+
+window.datalab.versions = {
+  latest:   latest,
+  last:     LAST_SEMVER,
+  previous: PREV_SEMVER,
+};
+
+window.datalab.gtmAccount = GTM_ACCOUNT;
+window.dataLayer = window.dataLayer || [];
+window.dataLayer.push({
+	hostname:"datalab.cloud.google.com",
+	pagePath:"/notebook/"
+});

--- a/tools/release/config_local_template.js
+++ b/tools/release/config_local_template.js
@@ -1,15 +1,17 @@
 const vid = document.body.getAttribute("data-version-id");
+const GTM_ACCOUNT = {{GTM_ACCOUNT_PLACEHOLDER}};
 const LATEST_SEMVER = {{DATALAB_VERSION_PLACEHOLDER}};
 const latest = vid.split('.')[2] < "20170523" ? {{DATALAB_VERSION_PATCH_PLACEHOLDER}} : LATEST_SEMVER;
-const LAST_SEMVER = "20160802";
-const PREV_SEMVER = {{PREV_SEMVER_PLACEHOLDER}};
-const GTM_ACCOUNT = {{GTM_ACCOUNT_PLACEHOLDER}};
+if (latest) {
+  const LAST_SEMVER = "0.5.20160802";
+  const PREV_SEMVER = {{PREV_SEMVER_PLACEHOLDER}};
 
-window.datalab.versions = {
-  latest:   latest,
-  last:     LAST_SEMVER,
-  previous: PREV_SEMVER,
-};
+  window.datalab.versions = {
+    latest:   latest,
+    last:     LAST_SEMVER,
+    previous: PREV_SEMVER,
+  };
+}
 
 window.datalab.gtmAccount = GTM_ACCOUNT;
 window.dataLayer = window.dataLayer || [];

--- a/tools/release/version.sh
+++ b/tools/release/version.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script keeps the current Datalab version, and should be incremented
+# properly on new releases
+
+DATALAB_VERSION_MAJOR=1
+DATALAB_VERSION_MINOR=2
+DATALAB_VERSION_PATCH=`date +%Y%m%d`
+DATALAB_VERSION="${DATALAB_VERSION_MAJOR}.${DATALAB_VERSION_MINOR}.${DATALAB_VERSION_PATCH}"
+DATALAB_COMMIT=`git log --pretty=format:'%H' -n 1`


### PR DESCRIPTION
This change adds a template file for the config_local.js that gets uploaded to GCS on release. This template has placeholders for fields that are changed by the release process.

The release script is also changed to be backwards-compatible with this new format and the old one.

In addition, I added a `version.sh` file that contains the source of truth for the Datalab version that is used by the Datalab/Gateway build scripts as well as release script. *I also bumped the version to the next semver value `1.2.DATE`*, ideally this should be a standalone change before each release.