### PR TITLE
Switch to the GA version of the `gcloud source repos` commands.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -487,7 +487,7 @@ def create_repo(args, gcloud_repos, repo_name):
     Args:
       args: The Namespace returned by argparse
       gcloud_repos: Function that can be used for invoking
-        `gcloud alpha source repos`
+        `gcloud source repos`
       repo_name: The name of the repository to create
     Raises:
       subprocess.CalledProcessError: If the `gcloud` command fails
@@ -505,7 +505,7 @@ def ensure_repo_exists(args, gcloud_repos, repo_name):
     Args:
       args: The Namespace returned by argparse
       gcloud_repos: Function that can be used for invoking
-        `gcloud alpha source repos`
+        `gcloud source repos`
       repo_name: The name of the repository to check
     Raises:
       subprocess.CalledProcessError: If the `gcloud` command fails
@@ -532,7 +532,7 @@ def run(args, gcloud_compute, gcloud_repos,
       args: The Namespace instance returned by argparse
       gcloud_compute: Function that can be used to invoke `gcloud compute`
       gcloud_repos: Function that can be used to invoke
-        `gcloud alpha source repos`
+        `gcloud source repos`
       email: The user's email address
       in_cloud_shell: Whether or not the command is being run in the
         Google Cloud Shell

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -142,7 +142,7 @@ def gcloud_repos(
       KeyboardInterrupt: If the user kills the command
       subprocess.CalledProcessError: If the command dies on its own
     """
-    base_cmd = [gcloud_cmd, 'alpha', 'source', 'repos']
+    base_cmd = [gcloud_cmd, 'source', 'repos']
     if args.project:
         base_cmd.extend(['--project', args.project])
     base_cmd.append('--verbosity={}'.format(args.verbosity))

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -130,11 +130,11 @@ def gcloud_compute(
 
 def gcloud_repos(
         args, repos_cmd, stdin=None, stdout=None, stderr=None):
-    """Run the given subcommand of `gcloud alpha source repos`
+    """Run the given subcommand of `gcloud source repos`
 
     Args:
       args: The Namespace instance returned by argparse
-      repos_cmd: The subcommand of `gcloud alpha source repos` to run
+      repos_cmd: The subcommand of `gcloud source repos` to run
       stdin: The 'stdin' argument for the subprocess call
       stdout: The 'stdout' argument for the subprocess call
       stderr: The 'stderr' argument for the subprocess call


### PR DESCRIPTION
As of version 156.0.0 of the Cloud SDK, the `gcloud source repos`
command group has been moved to the GA release track, so we no
longer need to rely on the `alpha` commands.