### PR TITLE
Fix websocket initialization bug

### DIFF
--- a/sources/web/datalab/static/websocket.js
+++ b/sources/web/datalab/static/websocket.js
@@ -1,93 +1,96 @@
-function shouldShimWebsockets() {
-  return location.host.toLowerCase().substr(-12) === '.appspot.com';
-}
+define(['util'], (util) => {
 
-// Override WebSocket
-(function() {
-  if (!window.io) {
-    // If socket.io was not loaded into the page, then do not override the existing
-    // WebSocket functionality.
-    return;
+  function shouldShimWebsockets() {
+    return location.host.toLowerCase().substr(-12) === '.appspot.com';
   }
 
-  function WebSocketShim(url) {
-    var self = this;
-    this._url = url;
-    this.readyState = WebSocketShim.CLOSED;
+  // Override WebSocket
+  (function() {
+    if (!window.io) {
+      // If socket.io was not loaded into the page, then do not override the existing
+      // WebSocket functionality.
+      return;
+    }
 
-    var socketUri = location.protocol + '//' + location.host + '/session';
-    var socketOptions = {
-      upgrade: false,
-      multiplex: false
+    function WebSocketShim(url) {
+      var self = this;
+      this._url = url;
+      this.readyState = WebSocketShim.CLOSED;
+
+      var socketUri = location.protocol + '//' + location.host + '/session';
+      var socketOptions = {
+        upgrade: false,
+        multiplex: false
+      };
+
+      function errorHandler() {
+        if (self.onerror) {
+          self.onerror({ target: self });
+        }
+      }
+      var socket = io.connect(socketUri, socketOptions);
+      socket.on('connect', function() {
+        socket.emit('start', { url: url });
+      });
+      socket.on('disconnect', function() {
+        self._socket = null;
+        self.readyState = WebSocketShim.CLOSED;
+        if (self.onclose) {
+          self.onclose({ target: self });
+        }
+      });
+      socket.on('open', function(msg) {
+        self._socket = socket;
+        self.readyState = WebSocketShim.OPEN;
+        if (self.onopen) {
+          self.onopen({ target: self });
+        }
+      });
+      socket.on('close', function(msg) {
+        self._socket = null;
+        self.readyState = WebSocketShim.CLOSED;
+        if (self.onclose) {
+          self.onclose({ target: self });
+        }
+      });
+      socket.on('data', function(msg) {
+        if (self.onmessage) {
+          self.onmessage({ target: self, data: msg.data });
+        }
+      });
+      socket.on('error', errorHandler);
+      socket.on('connect_error', errorHandler);
+      socket.on('reconnect_error', errorHandler);
+    }
+    WebSocketShim.prototype = {
+      onopen: null,
+      onclose: null,
+      onmessage: null,
+      onerror: null,
+
+      send: function(data) {
+        if (this.readyState != WebSocketShim.OPEN) {
+          throw new Error('WebSocket is not yet opened');
+        }
+        this._socket.emit('data', { data: data });
+      },
+
+      close: function() {
+        if (this.readyState == WebSocketShim.OPEN) {
+          this.readyState = WebSocketShim.CLOSED;
+
+          this._socket.emit('stop', { url: this._url });
+          this._socket.close();
+        }
+      }
     };
+    WebSocketShim.CLOSED = 0;
+    WebSocketShim.OPEN = 1;
 
-    function errorHandler() {
-      if (self.onerror) {
-        self.onerror({ target: self });
-      }
+    if (shouldShimWebsockets()) {
+      util.debug.log('Replacing native websockets with socket.io');
+      window.nativeWebSocket = window.WebSocket;
+      window.WebSocket = WebSocketShim;
     }
-    var socket = io.connect(socketUri, socketOptions);
-    socket.on('connect', function() {
-      socket.emit('start', { url: url });
-    });
-    socket.on('disconnect', function() {
-      self._socket = null;
-      self.readyState = WebSocketShim.CLOSED;
-      if (self.onclose) {
-        self.onclose({ target: self });
-      }
-    });
-    socket.on('open', function(msg) {
-      self._socket = socket;
-      self.readyState = WebSocketShim.OPEN;
-      if (self.onopen) {
-        self.onopen({ target: self });
-      }
-    });
-    socket.on('close', function(msg) {
-      self._socket = null;
-      self.readyState = WebSocketShim.CLOSED;
-      if (self.onclose) {
-        self.onclose({ target: self });
-      }
-    });
-    socket.on('data', function(msg) {
-      if (self.onmessage) {
-        self.onmessage({ target: self, data: msg.data });
-      }
-    });
-    socket.on('error', errorHandler);
-    socket.on('connect_error', errorHandler);
-    socket.on('reconnect_error', errorHandler);
-  }
-  WebSocketShim.prototype = {
-    onopen: null,
-    onclose: null,
-    onmessage: null,
-    onerror: null,
-
-    send: function(data) {
-      if (this.readyState != WebSocketShim.OPEN) {
-        throw new Error('WebSocket is not yet opened');
-      }
-      this._socket.emit('data', { data: data });
-    },
-
-    close: function() {
-      if (this.readyState == WebSocketShim.OPEN) {
-        this.readyState = WebSocketShim.CLOSED;
-
-        this._socket.emit('stop', { url: this._url });
-        this._socket.close();
-      }
-    }
-  };
-  WebSocketShim.CLOSED = 0;
-  WebSocketShim.OPEN = 1;
-
-  if (shouldShimWebsockets()) {
-    debug.log('Replacing native websockets with socket.io');
-    window.nativeWebSocket = window.WebSocket;
-    window.WebSocket = WebSocketShim;
-  }
-})();
+  })();
+});


### PR DESCRIPTION
*hint: use querystring param `w=1` to view this PR*

This fixes a bug with the initialization path of the websocket patch code, which caused the recent failure on Cloud Shell and rollback.

I'm still looking for a good way to mock cloud shell and add a test for this, but we need to get this fix in as it's blocking the release.