### PR TITLE
Initial pass at using Container Builder.

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,10 +15,33 @@
 
 # Builds all components.
 
-if [ -z "$REPO_DIR" ];
-  then echo "REPO_DIR is not set. Please run source \`../tools/initenv.sh\` first";
-  exit 1;
-fi
+function install_node() {
+  echo "Installing NodeJS"
+
+  mkdir -p /tools/node
+  wget -nv https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-x64.tar.gz -O node.tar.gz
+  tar xzf node.tar.gz -C /tools/node --strip-components=1
+  rm node.tar.gz
+  export "PATH=${PATH}:/tools/node/bin"
+}
+
+function install_typescript() {
+  npm -h >/dev/null 2>&1 || install_node
+
+  echo "Installing Typescript"
+  /tools/node/bin/npm install -g typescript
+}
+
+function install_prereqs() {
+  tsc -h >/dev/null 2>&1  || install_typescript
+  rsync -h >/dev/null 2>&1  || apt-get install -y -qq rsync
+  source ./tools/initenv.sh
+}
+
+pushd ./
+cd $(dirname "${BASH_SOURCE[0]}")/../
+install_prereqs
+popd
 
 SRC_PATHS=(
   "web"

--- a/tools/release/build.sh
+++ b/tools/release/build.sh
@@ -37,32 +37,8 @@ DATALAB_IMAGE="gcr.io/${PROJECT_ID}/datalab:local-${LABEL}"
 DATALAB_GPU_IMAGE="gcr.io/${PROJECT_ID}/datalab-gpu:local-${LABEL}"
 CLI_TARBALL="datalab-cli-${LABEL}.tgz"
 
-function install_node() {
-  echo "Installing NodeJS"
-
-  mkdir -p /tools/node
-  wget -nv https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-x64.tar.gz -O node.tar.gz
-  tar xzf node.tar.gz -C /tools/node --strip-components=1
-  rm node.tar.gz
-  export "PATH=${PATH}:/tools/node/bin"
-}
-
-function install_typescript() {
-  npm -h >/dev/null 2>&1 || install_node
-
-  echo "Installing Typescript"
-  /tools/node/bin/npm install -g typescript
-}
-
-function install_prereqs() {
-  tsc -h >/dev/null 2>&1  || install_typescript
-  rsync -h >/dev/null 2>&1  || apt-get install -y -qq rsync
-  source ./tools/initenv.sh
-}
-
 pushd ./
-cd $(dirname "${BASH_SOURCE[0]}")/../../
-install_prereqs
+cd $(dirname "${BASH_SOURCE[0]}")/../
 
 echo "Building the Datalab server"
 ./sources/build.sh

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -1,0 +1,34 @@
+steps:
+- name: 'debian'
+  args: ['/workspace/sources/build.sh']
+  id:   ['buildSource']
+- name: 'debian'
+  args: ['mkdir', '-p', '/workspace/containers/base/pydatalab']
+  id:   ['makeDir']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['pull', 'ubuntu:16.04']
+  id:   'pullUbuntu'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['tag', 'ubuntu:16.04', 'datalab-external-base-image']
+  id:   'tagUbuntu'
+  waitFor: ['pullUbuntu']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'datalab-base', '/workspace/containers/base/']
+  id:   'buildBase'
+  waitFor: ['buildSource', 'makeDir', 'tagUbuntu']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['pull', 'nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04']
+  id:   'pullNvidiaUbuntu'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['tag', 'nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04', 'datalab-external-base-image']
+  id:   'tagNvidiaUbuntu'
+  waitFor: ['buildBase']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'datalab-core-gpu', '/workspace/containers/base/']
+  id:   'buildGpuCore'
+  waitFor: ['tagNvidiaUbuntu']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'datalab-base-gpu', '-f', 'Dockerfile.gpu', '/workspace/containers/base/']
+  id:   'buildGpuBase'
+  waitFor: ['buildGpuCore']


### PR DESCRIPTION
This commit is a first-pass at using
[Container Builder](https://cloud.google.com/container-builder/)
to build our Docker images.

For now, this is not very useful, as it only builds our base images,
which are only ever used as prerequisites for later image builds.

However, this does let us make progress towards a more complete build
by ensuring that our base images build successfully in Container Builder.

This is part of the work towards fixing https://github.com/googledatalab/datalab/issues/1400