### PR TITLE
Flush out the Container Builder config

### DIFF
--- a/containers/gateway/prepare.sh
+++ b/containers/gateway/prepare.sh
@@ -18,7 +18,7 @@
 # be followed by a `docker build` and then `cleanup.sh`.
 #
 # Usage:
-#   prepare.sh [path_of_pydatalab_dir]
+#   prepare.sh
 #   docker build -t datalab-gateway ./
 #   cleanup.sh
 #
@@ -30,6 +30,7 @@ HERE=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)
 cd ${HERE}
 
 # Create a versioned Dockerfile based on current date and git commit hash
+export REVISION_ID="${1:-}"
 source ../../tools/release/version.sh
 
 VERSION_SUBSTITUTION="s/_version_/$DATALAB_VERSION/"

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -1,8 +1,35 @@
 steps:
+
+# Write (and publish) a config_local.js file for this build. This
+# can be done in parallel with the rest of the build.
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['cp', 'gs://${PROJECT_ID}/deploy/config_local.js', '/workspace/config_local.js']
+  id:   'pullConfigLocal'
+- name: 'debian'
+  args: ['/workspace/tools/release/generate_config_local.sh',
+         '/workspace/config_local.js',
+         '/workspace/config_local_${REVISION_ID}.js',
+         '${REVISION_ID}']
+  id:   'generateConfigLocal'
+  waitFor: ['pullConfigLocal']
+- name: 'debian'
+  args: ['cat', '/workspace/config_local_${REVISION_ID}.js']
+  id:   'catConfigLocal'
+  waitFor: ['generateConfigLocal']
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['cp',
+         '/workspace/config_local_${REVISION_ID}.js',
+         'gs://${PROJECT_ID}/builds/config_local_${REVISION_ID}.js']
+  id:   'pushConfigLocal'
+  waitFor: ['catConfigLocal']
+
+# Build the base images. These are not pushed externally, but rather
+# used the build the final images which are pushed.
+
+## First, we build the non-GPU base image
 - name: 'debian'
   args: ['mkdir', '-p', '/workspace/containers/base/pydatalab']
   id:   'makeDir'
-
 - name: 'gcr.io/cloud-builders/docker'
   args: ['pull', 'ubuntu:16.04']
   id:   'pullUbuntu'
@@ -14,6 +41,8 @@ steps:
   args: ['build', '-t', 'datalab-base', '/workspace/containers/base/']
   id:   'buildBase'
   waitFor: ['makeDir', 'tagUbuntu']
+
+## Second, we build the GPU base image
 - name: 'gcr.io/cloud-builders/docker'
   args: ['pull', 'nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04']
   id:   'pullNvidiaUbuntu'
@@ -30,29 +59,45 @@ steps:
   id:   'buildGpuBase'
   waitFor: ['buildGpuCore']
 
+# Now, build the real images (which we push externally)
+
+## Start with the kernel gateway image...
 - name: 'debian'
-  args: ['/workspace/containers/datalab/prepare.sh', 'datalab-base', "${REVISION_ID}"]
+  args: ['/workspace/containers/gateway/prepare.sh', '${REVISION_ID}']
+  id:   'prepareGateway'
+  waitFor: ['buildBase']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-${REVISION_ID}', '/workspace/containers/gateway/']
+  id:   'buildGateway'
+  waitFor: ['prepareGateway']
+
+## Then build the non-GPU Datalab image...
+- name: 'debian'
+  args: ['/workspace/containers/datalab/prepare.sh', 'datalab-base', '${REVISION_ID}']
   id:   'prepareDatalab'
   waitFor: ['buildBase']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/${PROJECT_ID}/datalab:local-${REVISION_ID}', '/workspace/containers/datalab/']
+  args: ['build', '-t', 'gcr.io/${PROJECT_ID}/datalab:commit-${REVISION_ID}', '/workspace/containers/datalab/']
   id:   'buildDatalab'
   waitFor: ['prepareDatalab']
 - name: 'debian'
   args: ['/workspace/containers/datalab/cleanup.sh']
   id:   'cleanupDatalab'
   waitFor: ['buildDatalab']
+
+## And finally, build the GPU Datalab image...
 - name: 'debian'
-  args: ['/workspace/containers/datalab/prepare.sh', 'datalab-base-gpu', "${REVISION_ID}"]
+  args: ['/workspace/containers/datalab/prepare.sh', 'datalab-base-gpu', '${REVISION_ID}']
   id:   'prepareDatalabGPU'
   waitFor: ['cleanupDatalab', 'buildGpuBase']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/${PROJECT_ID}/datalab-gpu:local-${REVISION_ID}', '/workspace/containers/datalab/']
+  args: ['build', '-t', 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-${REVISION_ID}', '/workspace/containers/datalab/']
   id:   'buildDatalabGPU'
   waitFor: ['prepareDatalabGPU']
 
 images:
-  - 'gcr.io/${PROJECT_ID}/datalab:local-${REVISION_ID}'
-  - 'gcr.io/${PROJECT_ID}/datalab-gpu:local-${REVISION_ID}'
+  - 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-${REVISION_ID}'
+  - 'gcr.io/${PROJECT_ID}/datalab:commit-${REVISION_ID}'
+  - 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-${REVISION_ID}'
 
-timeout: '2400s'
+timeout: '3600s'

--- a/tools/release/generate_config_local.sh
+++ b/tools/release/generate_config_local.sh
@@ -1,0 +1,64 @@
+#!/bin/bash -e
+
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script generates the `config_local.js` file for a specific build
+#
+# Example usage:
+#   old_config=/tmp/config_local.js
+#   new_config=/tmp/config_local_`git log --pretty=format:'%H' -n 1`
+#   gsutil cp gs://${PROJECT_ID}/deploy/config_local.js ${old_config}
+#   ./tools/release/generate_config_local.sh ${old_config} ${new_config}
+
+OLD_CONFIG=${1}
+NEW_CONFIG=${2}
+export REVISION_ID=${3:-$(git log --pretty=format:'%H' -n 1)}
+
+# Get the latest and previous versions from the config_local. Note that older
+# config files don't have the full semantic version specified, so cannot extract using
+# the "LATEST_SEMVER = " pattern, and instead use "latest: "
+if [[ $(cat ${OLD_CONFIG} | grep "LATEST_SEMVER = ") ]]; then
+  CURRENT_VERSION=`cat ${OLD_CONFIG} | grep "LATEST_SEMVER = " | cut -d '=' -f 2 | tr -d '" ;'`
+  GTM_ACCOUNT=`cat ${OLD_CONFIG} | grep "GTM_ACCOUNT = " | cut -d '=' -f 2 | tr -d '"; '`
+else
+  CURRENT_VERSION=`cat ${OLD_CONFIG} | grep "latest: " | cut -d ':' -f 2 | tr -d ', '`
+  GTM_ACCOUNT=`cat ${OLD_CONFIG} | grep "gtmAccount = " | cut -d '=' -f 2 | tr -d "'; "`
+fi
+
+CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
+source "${CURRENT_DIR}"/version.sh
+CONFIG_TEMPLATE="${CURRENT_DIR}"/config_local_template.js
+
+# Only if the current version will be updated, do we need a new config_local.js file.
+# This affects cases where the previous release was published on the same day. Since our
+# release granularity is at the single-day level, such an update would be meaningless.
+#
+# Moreover, this would cause an issue because the new PREVIOUS_SEMVER would point to the
+# older release with the same date, and result in a loop for the rollback process.
+if [ "$CURRENT_VERSION" == "$DATALAB_VERSION" ]; then
+  echo "Simply reusing the existing config"
+  cp ${OLD_CONFIG} ${NEW_CONFIG}
+  exit 0
+fi
+
+cp ${CONFIG_TEMPLATE} ${NEW_CONFIG}
+echo "Filling latest=${DATALAB_VERSION}"
+sed -i -e s/{{DATALAB_VERSION_PLACEHOLDER}}/\"${DATALAB_VERSION}\"/ ${NEW_CONFIG}
+echo "Filling latest patch=${DATALAB_VERSION_PATCH}"
+sed -i -e s/{{DATALAB_VERSION_PATCH_PLACEHOLDER}}/\"${DATALAB_VERSION_PATCH}\"/ ${NEW_CONFIG}
+echo "Filling previous=${CURRENT_VERSION}"
+sed -i -e s/{{PREV_SEMVER_PLACEHOLDER}}/\"${CURRENT_VERSION}\"/ ${NEW_CONFIG}
+echo "Filling gtm account=${GTM_ACCOUNT}"
+sed -i -e s/{{GTM_ACCOUNT_PLACEHOLDER}}/\"${GTM_ACCOUNT}\"/ ${NEW_CONFIG}


### PR DESCRIPTION
This change adds two more components to our Container Builder builds:

1. The building of the kernel-gateway image
2. The generation of a `config_local.js` file for the build