### PR TITLE
Finish flushing out the Container Builder config.

### DIFF
--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -25,13 +25,13 @@ steps:
 
 # Push a tarball of the CLI
 - name: 'debian'
-  args: ['tar', '-cvzf', '/workspace/datalab_cli_${REVISION_ID}.tgz',
+  args: ['tar', '-cvzf', '/workspace/datalab-cli-${REVISION_ID}.tgz',
          '--transform', 's,^tools/cli,datalab,', 'tools/cli']
   id:   'createTarball'
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['cp',
-         '/workspace/datalab_cli_${REVISION_ID}.tgz',
-         'gs://${PROJECT_ID}/builds/datalab_cli_${REVISION_ID}.tgz']
+         '/workspace/datalab-cli-${REVISION_ID}.tgz',
+         'gs://${PROJECT_ID}/builds/datalab-cli-${REVISION_ID}.tgz']
   id:   'pushTarball'
   waitFor: ['createTarball']
 
@@ -40,7 +40,7 @@ steps:
   args: ['rm', '-rf',
          '/workspace/config_local.js',
          '/workspace/config_local_${REVISION_ID}.js',
-         '/workspace/datalab_cli_${REVISION_ID}.tgz']
+         '/workspace/datalab-cli-${REVISION_ID}.tgz']
   id:   'cleanupWorkspace'
   waitFor: ['pushConfigLocal', 'pushTarball']
 

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -23,6 +23,27 @@ steps:
   id:   'pushConfigLocal'
   waitFor: ['catConfigLocal']
 
+# Push a tarball of the CLI
+- name: 'debian'
+  args: ['tar', '-cvzf', '/workspace/datalab_cli_${REVISION_ID}.tgz',
+         '--transform', 's,^tools/cli,datalab,', 'tools/cli']
+  id:   'createTarball'
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['cp',
+         '/workspace/datalab_cli_${REVISION_ID}.tgz',
+         'gs://${PROJECT_ID}/builds/datalab_cli_${REVISION_ID}.tgz']
+  id:   'pushTarball'
+  waitFor: ['createTarball']
+
+# Cleanup the temporary files created to push build artifacts to GCS
+- name: 'debian'
+  args: ['rm', '-rf',
+         '/workspace/config_local.js',
+         '/workspace/config_local_${REVISION_ID}.js',
+         '/workspace/datalab_cli_${REVISION_ID}.tgz']
+  id:   'cleanupWorkspace'
+  waitFor: ['pushConfigLocal', 'pushTarball']
+
 # Build the base images. These are not pushed externally, but rather
 # used the build the final images which are pushed.
 
@@ -30,6 +51,7 @@ steps:
 - name: 'debian'
   args: ['mkdir', '-p', '/workspace/containers/base/pydatalab']
   id:   'makeDir'
+  waitFor: ['cleanupWorkspace']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['pull', 'ubuntu:16.04']
   id:   'pullUbuntu'


### PR DESCRIPTION
This change adds the bundling of the CLI tarball to our Container Build.

This was the last step covered by `tools/release/build.sh` that was
not covered by our Container Build, so this that conversion is complete
(although we are still using the daily build and will continue to do
so until our release process is updated).

This fixes #1400