### PR TITLE
Map $HOME/datalab as /content/datalab

### DIFF
--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -21,7 +21,7 @@
 # manually starting the server.
 
 HERE=$(dirname $0)
-CONTENT=$HOME
+CONTENT=$HOME/datalab_home
 ENTRYPOINT="/datalab/run.sh"
 DEVROOT_DOCKER_OPTION=''
 LIVE_MODE=1

--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -21,7 +21,7 @@
 # manually starting the server.
 
 HERE=$(dirname $0)
-CONTENT=$HOME/datalab_home
+CONTENT=$HOME
 ENTRYPOINT="/datalab/run.sh"
 DEVROOT_DOCKER_OPTION=''
 LIVE_MODE=1
@@ -64,7 +64,7 @@ fi
 
 docker run -it --entrypoint=$ENTRYPOINT \
   -p 127.0.0.1:8081:8080 \
-  -v "$CONTENT:/content" \
+  -v "$CONTENT/datalab:/content/datalab" \
   ${DEVROOT_DOCKER_OPTION} \
   -e "PROJECT_ID=$PROJECT_ID" \
   -e "DATALAB_ENV=local" \


### PR DESCRIPTION
We get a performance hit when starting the server on OSX if the home directory contains a lot of files, because of a limitation on the package we're using to index the file system (see https://github.com/paulmillr/chokidar/issues/597).

Since this script is used for the dev workflow, we can use a new directory `$HOME/datalab_home` that will only contain datalab files, just like the case on a VM.