### PR TITLE
Give the last successful master branch build a static tag.

### DIFF
--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -117,24 +117,24 @@ steps:
   id:   'buildDatalabGPU'
   waitFor: ['prepareDatalabGPU']
 
-## Tag all of the images as "latest-master-commit" so that other processes
+## Tag all of the images as "commit-latest-master-build" so that other processes
 ## can easily pick up the latest one.
 - name: gcr.io/cloud-builders/docker
-  args: ["tag", "gcr.io/cloud-datalab/datalab:commit-${REVISION_ID}", "gcr.io/cloud-datalab/datalab:commit-latest-master-commit"]
+  args: ["tag", "gcr.io/cloud-datalab/datalab:commit-${REVISION_ID}", "gcr.io/cloud-datalab/datalab:commit-latest-master-build"]
   waitFor: ["buildDatalab"]
 - name: gcr.io/cloud-builders/docker
-  args: ["tag", "gcr.io/cloud-datalab/datalab-gpu:commit-${REVISION_ID}", "gcr.io/cloud-datalab/datalab-gpu:commit-latest-master-commit"]
+  args: ["tag", "gcr.io/cloud-datalab/datalab-gpu:commit-${REVISION_ID}", "gcr.io/cloud-datalab/datalab-gpu:commit-latest-master-build"]
   waitFor: ["buildDatalabGPU"]
 - name: gcr.io/cloud-builders/docker
-  args: ["tag", "gcr.io/cloud-datalab/datalab-gateway:commit-${REVISION_ID}", "gcr.io/cloud-datalab/datalab-gateway:commit-latest-master-commit"]
+  args: ["tag", "gcr.io/cloud-datalab/datalab-gateway:commit-${REVISION_ID}", "gcr.io/cloud-datalab/datalab-gateway:commit-latest-master-build"]
   waitFor: ["buildGateway"]
 
 images:
   - 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-${REVISION_ID}'
   - 'gcr.io/${PROJECT_ID}/datalab:commit-${REVISION_ID}'
   - 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-${REVISION_ID}'
-  - 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-latest-master-commit'
-  - 'gcr.io/${PROJECT_ID}/datalab:commit-latest-master-commit'
-  - 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-latest-master-commit'
+  - 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-latest-master-build'
+  - 'gcr.io/${PROJECT_ID}/datalab:commit-latest-master-build'
+  - 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-latest-master-build'
 
 timeout: '3600s'

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -117,9 +117,24 @@ steps:
   id:   'buildDatalabGPU'
   waitFor: ['prepareDatalabGPU']
 
+## Tag all of the images as "latest-master-commit" so that other processes
+## can easily pick up the latest one.
+- name: gcr.io/cloud-builders/docker
+  args: ["tag", "gcr.io/cloud-datalab/datalab:commit-${REVISION_ID}", "gcr.io/cloud-datalab/datalab:commit-latest-master-commit"]
+  waitFor: ["buildDatalab"]
+- name: gcr.io/cloud-builders/docker
+  args: ["tag", "gcr.io/cloud-datalab/datalab-gpu:commit-${REVISION_ID}", "gcr.io/cloud-datalab/datalab-gpu:commit-latest-master-commit"]
+  waitFor: ["buildDatalabGPU"]
+- name: gcr.io/cloud-builders/docker
+  args: ["tag", "gcr.io/cloud-datalab/datalab-gateway:commit-${REVISION_ID}", "gcr.io/cloud-datalab/datalab-gateway:commit-latest-master-commit"]
+  waitFor: ["buildGateway"]
+
 images:
   - 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-${REVISION_ID}'
   - 'gcr.io/${PROJECT_ID}/datalab:commit-${REVISION_ID}'
   - 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-${REVISION_ID}'
+  - 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-latest-master-commit'
+  - 'gcr.io/${PROJECT_ID}/datalab:commit-latest-master-commit'
+  - 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-latest-master-commit'
 
 timeout: '3600s'


### PR DESCRIPTION
This makes it much easier to pull it down as a default.