### PR TITLE
Fix the `sources/build.sh` dependency setup:

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -24,11 +24,11 @@ function install_node() {
   wget --version || install_wget
 
   echo "Installing NodeJS"
-  mkdir -p ./tools/node
+  mkdir -p /tools/node
   wget -nv https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-x64.tar.gz -O node.tar.gz
-  tar xzf node.tar.gz -C ./tools/node --strip-components=1
+  tar xzf node.tar.gz -C /tools/node --strip-components=1
   rm node.tar.gz
-  export "PATH=${PATH}:${PWD}/tools/node/bin"
+  export "PATH=${PATH}:/tools/node/bin"
 }
 
 function install_bower() {

--- a/sources/web/build.sh
+++ b/sources/web/build.sh
@@ -31,7 +31,7 @@ mkdir -p $WEB_DIR
 
 # Experimental UI build step
 cd datalab/polymer
-bower install
+bower --allow-root install
 tsc
 polymer build
 rsync -avpq ./build/experimental/ ../static/experimental


### PR DESCRIPTION
1. Make the node setup consistent with its use. We are using npm
   to install other dependencies globally, so placing the node
   installation under the current working directory caused issues.
2. Make the bower invocation work when we run it inside of a Docker
   container (such as when run in Container Builder). Specifically,
   the default setup in a container is that there is only one user;
   root. As such, we should disable bower's defensive check against
   running as root.