### PR TITLE
Add preview images that are built on every push to master

### DIFF
--- a/containers/datalab/Dockerfile-preview
+++ b/containers/datalab/Dockerfile-preview
@@ -1,0 +1,29 @@
+# Copyright 2017 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file defines the "preview" Datalab images.
+#
+# These images are meant to be used by end users who want to try out
+# experiental features that are planned for a future release but are
+# not yet ready for general use.
+#
+# Each such feature has a corresponding environment variable that
+# controls whether or not the feature is enabled. This image extends
+# the standard Datalab images by setting those environment variables
+# to enable the various preview features.
+
+FROM datalab
+MAINTAINER Google Cloud DataLab
+
+env DATALAB_EXPERIMENTAL_UI true

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -107,7 +107,7 @@ steps:
   id:   'cleanupDatalab'
   waitFor: ['buildDatalab']
 
-## And finally, build the GPU Datalab image...
+## Next, build the GPU Datalab image...
 - name: 'debian'
   args: ['/workspace/containers/datalab/prepare.sh', 'datalab-base-gpu', '${REVISION_ID}']
   id:   'prepareDatalabGPU'
@@ -120,14 +120,33 @@ steps:
 ## Tag all of the images as "commit-latest-master-build" so that other processes
 ## can easily pick up the latest one.
 - name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-datalab/datalab:commit-${REVISION_ID}', 'gcr.io/cloud-datalab/datalab:commit-latest-master-build']
+  args: ['tag', 'gcr.io/${PROJECT_ID}/datalab:commit-${REVISION_ID}', 'gcr.io/${PROJECT_ID}/datalab:commit-latest-master-build']
   waitFor: ['buildDatalab']
+  id: 'tagDatalabMasterBuild'
 - name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-datalab/datalab-gpu:commit-${REVISION_ID}', 'gcr.io/cloud-datalab/datalab-gpu:commit-latest-master-build']
+  args: ['tag', 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-${REVISION_ID}', 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-latest-master-build']
   waitFor: ['buildDatalabGPU']
+  id: 'tagDatalabGpuMasterBuild'
 - name: gcr.io/cloud-builders/docker
-  args: ['tag', 'gcr.io/cloud-datalab/datalab-gateway:commit-${REVISION_ID}', 'gcr.io/cloud-datalab/datalab-gateway:commit-latest-master-build']
+  args: ['tag', 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-${REVISION_ID}', 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-latest-master-build']
   waitFor: ['buildGateway']
+
+## Create the "preview" versions of the `datalab` and `datalab-gpu` images
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'gcr.io/${PROJECT_ID}/datalab:commit-latest-master-build', 'datalab']
+  waitFor: [ 'tagDatalabMasterBuild' ]
+  id: 'tagDatalab'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/${PROJECT_ID}/datalab-preview', '-f', '/workspace/containers/datalab/Dockerfile-preview', '/workspace/containers/datalab/']
+  id:   'buildDatalabPreview'
+  waitFor: ['tagDatalab']
+- name: gcr.io/cloud-builders/docker
+  args: ['tag', 'gcr.io/${PROJECT_ID}/datalab:commit-latest-master-build', 'datalab']
+  waitFor: [ 'tagDatalabGpuMasterBuild', 'buildDatalabPreview' ]
+  id: 'tagDatalabGpu'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/${PROJECT_ID}/datalab-gpu-preview', '-f', '/workspace/containers/datalab/Dockerfile-preview', '/workspace/containers/datalab/']
+  waitFor: ['tagDatalabGpu']
 
 ## Tag the config local file with latest-master-build as well.
 - name: 'gcr.io/cloud-builders/gsutil'
@@ -144,5 +163,7 @@ images:
   - 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-latest-master-build'
   - 'gcr.io/${PROJECT_ID}/datalab:commit-latest-master-build'
   - 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-latest-master-build'
+  - 'gcr.io/${PROJECT_ID}/datalab-preview'
+  - 'gcr.io/${PROJECT_ID}/datalab-gpu-preview'
 
 timeout: '3600s'

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
 # Write (and publish) a config_local.js file for this build. This
 # can be done in parallel with the rest of the build.
 - name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', 'gs://${PROJECT_ID}/deploy/config_local.js', '/workspace/config_local.js']
+  args: ['cp', 'gs://cloud-datalab/deploy/config_local.js', '/workspace/config_local.js']
   id:   'pullConfigLocal'
 - name: 'debian'
   args: ['/workspace/tools/release/generate_config_local.sh',


### PR DESCRIPTION
This change also fixed some hard-coded bucket names so that it is possible to test the Container Builder config by pushing to a test project.

Similarly, this also changed the bucket name from where we pull the production `config_local.js` file so that it *is* hard-coded. The difference is that one is independent of the project ID, whereas the others are not.