### PR TITLE
Add setting to force shimming of websockets.

### DIFF
--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -13,6 +13,7 @@
   "socketioPort": 8084,
   "datalabRoot": "",
   "datalabBasePath": "",
+  "shimWebsockets": false,
   "contentDir": "/content",
   "useWorkspace": false,
   "supportUserOverride": false,

--- a/sources/web/datalab/static/websocket.js
+++ b/sources/web/datalab/static/websocket.js
@@ -1,6 +1,9 @@
 define(['util'], (util) => {
 
   function shouldShimWebsockets() {
+    if (appSettings.shimWebsockets) {
+      return true;
+    }
     return location.host.toLowerCase().substr(-12) === '.appspot.com';
   }
 


### PR DESCRIPTION
This setting can be set with the DATALAB_SETTINGS_OVERRIDES env
variable.