### PR TITLE
Fix web sockets when using a base dir.

### DIFF
--- a/sources/web/datalab/sockets.ts
+++ b/sources/web/datalab/sockets.ts
@@ -171,6 +171,6 @@ export function init(settings: common.AppSettings): void {
     allowUpgrades: false
   });
 
-  io.of(path_.join(settings.datalabBasePath, 'session'))
+  io.of('/session')
     .on('connection', socketHandler);
 }

--- a/sources/web/datalab/static/websocket.js
+++ b/sources/web/datalab/static/websocket.js
@@ -20,8 +20,10 @@ define(['util'], (util) => {
       this._url = url;
       this.readyState = WebSocketShim.CLOSED;
 
-      var socketUri = util.datalabLink('/session');
+      var socketUri = location.protocol + '//' + location.host + '/session';
+      var basePath = document.body.getAttribute('data-base-url');
       var socketOptions = {
+        path: basePath + 'socket.io',
         upgrade: false,
         multiplex: false
       };


### PR DESCRIPTION
The confusion here was around the differences between "namespace" and "path" for socket.io