### PR TITLE
docker mount $CONTENT/datalab (not $HOME)

### DIFF
--- a/containers/datalab/run-extended.sh
+++ b/containers/datalab/run-extended.sh
@@ -81,7 +81,7 @@ fi
 #  -v $REPO_DIR/sources/web:/sources \
 docker run -it --entrypoint=$ENTRYPOINT \
   -p $PORTMAP \
-  -v "$CONTENT:/content" \
+  -v "$CONTENT/datalab:/content/datalab" \
   -e "PROJECT_ID=$PROJECT_ID" \
   -e "DATALAB_ENV=local" \
   -e "EXPERIMENTAL_KERNEL_GATEWAY_URL=${EXPERIMENTAL_KERNEL_GATEWAY_URL}" \


### PR DESCRIPTION
In `containers/datalab/run-extended.sh` by default `CONTENT=$HOME` is more than enough to be mounted. `$CONTENT/datalab` should be more sensible, the same way it's done in `containers/datalab/run.sh`.

Actually, on my Mac, without this modification `run-extended.sh` takes very long to start, and then only a buggy navigation bar would appear in the browser.
 