### PR TITLE
Reduce page load latency

### DIFF
--- a/sources/web/datalab/auth.ts
+++ b/sources/web/datalab/auth.ts
@@ -167,8 +167,7 @@ function persistCredentials(tokens: any): string {
   return saveUserCredFile(tokens);
 }
 
-export function isSignedIn(): boolean {
-  var gcloudAccount:string = getGcloudAccount();
+export function isSignedIn(gcloudAccount: string): boolean {
   return (gcloudAccount != '' && gcloudAccount != 'unknown');
 }
 
@@ -254,7 +253,7 @@ export function handleAuthFlow(request: http.ServerRequest, response: http.Serve
       });
     }
     return;
-  } else if (path.indexOf('/signin') == 0 && !isSignedIn()) {
+  } else if (path.indexOf('/signin') == 0 && !isSignedIn(getGcloudAccount())) {
     // Do auth.
     // TODO(gram): instead of initiating it here we should add a sign in button to our templates so it becomes
     // user-initiated.

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -366,9 +366,13 @@ export function handleRequest(request: http.ServerRequest, response: http.Server
 }
 
 function getBaseTemplateData(request: http.ServerRequest): common.Map<string> {
-  var userId: string = userManager.getUserId(request);
-  var reportingEnabled: string = process.env.ENABLE_USAGE_REPORTING;
-  var templateData: common.Map<string> = {
+  const userId: string = userManager.getUserId(request);
+  const reportingEnabled: string = process.env.ENABLE_USAGE_REPORTING;
+  // TODO: Cache the gcloudAccount value so that we are not
+  // calling `gcloud` on every page load.
+  const gcloudAccount : string = auth.getGcloudAccount();
+  const signedIn = auth.isSignedIn(gcloudAccount);
+  let templateData: common.Map<string> = {
     feedbackId: appSettings.feedbackId,
     versionId: appSettings.versionId,
     userId: userId,
@@ -377,12 +381,8 @@ function getBaseTemplateData(request: http.ServerRequest): common.Map<string> {
     baseUrl: appSettings.datalabBasePath,
     reportingEnabled: reportingEnabled,
     proxyWebSockets: appSettings.proxyWebSockets,
+    isSignedIn:  signedIn.toString(),
   };
-  // TODO: Cache the gcloudAccount value so that we are not
-  // calling `gcloud` on every page load.
-  var gcloudAccount : string = auth.getGcloudAccount();
-  var signedIn = auth.isSignedIn(gcloudAccount);
-  templateData['isSignedIn'] = signedIn.toString();
   if (signedIn) {
     templateData['account'] = gcloudAccount;
     if (process.env.PROJECT_NUMBER) {

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -368,12 +368,6 @@ export function handleRequest(request: http.ServerRequest, response: http.Server
 function getBaseTemplateData(request: http.ServerRequest): common.Map<string> {
   var userId: string = userManager.getUserId(request);
   var reportingEnabled: string = process.env.ENABLE_USAGE_REPORTING;
-  if (reportingEnabled) {
-    var userSettings: common.Map<string> = settings.loadUserSettings(userId);
-    if ('enableUsageReporting' in userSettings && userSettings['enableUsageReporting'] != 'true') {
-      reportingEnabled = 'false';
-    }
-  }
   var templateData: common.Map<string> = {
     feedbackId: appSettings.feedbackId,
     versionId: appSettings.versionId,
@@ -384,10 +378,13 @@ function getBaseTemplateData(request: http.ServerRequest): common.Map<string> {
     reportingEnabled: reportingEnabled,
     proxyWebSockets: appSettings.proxyWebSockets,
   };
-  var signedIn = auth.isSignedIn();
+  // TODO: Cache the gcloudAccount value so that we are not
+  // calling `gcloud` on every page load.
+  var gcloudAccount : string = auth.getGcloudAccount();
+  var signedIn = auth.isSignedIn(gcloudAccount);
   templateData['isSignedIn'] = signedIn.toString();
   if (signedIn) {
-    templateData['account'] = auth.getGcloudAccount();
+    templateData['account'] = gcloudAccount;
     if (process.env.PROJECT_NUMBER) {
       var hash = crypto.createHash('sha256');
       hash.update(process.env.PROJECT_NUMBER);


### PR DESCRIPTION
This change fixes two server-side performance issues that affected every page load:

1. Loading a user setting that was removed prior to the GA release (this was
   effectively dead code, but still slowed things down).
2. Calling `gcloud auth list` twice; once to determine if the user was signed
   in and a second time to find out the email address of their account. Even
   calling `gcloud auth list` once on every page load is overkill, but at least
   this cuts the number of calls in half. A TODO has been added to get this down
   even further.