### PR TITLE
[Polymer UI] Implement input dialog as a subclass of base dialog

### DIFF
--- a/sources/web/datalab/polymer/components/base-dialog/base-dialog.html
+++ b/sources/web/datalab/polymer/components/base-dialog/base-dialog.html
@@ -17,6 +17,10 @@ the License.
 <dom-module id="base-dialog">
   <template>
     <style include="datalab-shared-styles">
+      #theDialog {
+        display: flex;
+        flex-direction: column;
+      }
       .dialog-big--true {
         min-width: 60%;
         min-height: 60%;
@@ -28,13 +32,15 @@ the License.
       #title {
         font-size: 16px;
         text-align: center;
-        height: 20px;
+        flex: 0 0 20px;
         margin: 0px;
         padding: 15px; /*Total height: 50px*/
         background-color: var(--app-secondary-color);
       }
       #body {
         margin: 0px;
+        flex-grow: 1;
+        position: relative;
       }
       hr {
         border-left: none;
@@ -47,7 +53,7 @@ the License.
         display: flex;
         justify-content: center;
         padding: 0px;
-        height: 40px;
+        flex: 0 0 40px;
         margin: 15px; /*Total height: 70px*/
       }
       .confirm {
@@ -59,7 +65,7 @@ the License.
                   on-keydown="_checkEnter">
       <div id="title">{{title}}</div>
       <!--message value is bound in javascript because it needs to bind to innerHTML-->
-      <div id="message" hidden$="{{!message}}">{{message}}</div>
+      <div id="message" hidden$="{{!messageHtml}}">{{messageHtml}}</div>
       <!--body acts as a place holder for extending elements, their custom
       markup is inserted here by stamping it from Javascript-->
       <div id="body"></div>

--- a/sources/web/datalab/polymer/components/base-dialog/base-dialog.html
+++ b/sources/web/datalab/polymer/components/base-dialog/base-dialog.html
@@ -1,0 +1,77 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../bower_components/paper-dialog/paper-dialog.html">
+
+<dom-module id="base-dialog">
+  <template>
+    <style include="datalab-shared-styles">
+      .dialog-big--true {
+        min-width: 60%;
+        min-height: 60%;
+      }
+      .dialog-big--false {
+        min-width: 300px;
+        min-height: 180px;
+      }
+      #title {
+        font-size: 16px;
+        text-align: center;
+        height: 20px;
+        margin: 0px;
+        padding: 15px; /*Total height: 50px*/
+        background-color: var(--app-secondary-color);
+      }
+      #body {
+        margin: 0px;
+      }
+      hr {
+        border-left: none;
+        border-right: none;
+        border-bottom: none;
+        border-top: 1px solid #eee;
+        margin: 0px;
+      }
+      .buttons {
+        display: flex;
+        justify-content: center;
+        padding: 0px;
+        height: 40px;
+        margin: 15px; /*Total height: 70px*/
+      }
+      .confirm {
+        background-color: var(--app-secondary-color);
+        font-weight: bold;
+      }
+    </style>
+    <paper-dialog id="theDialog" class$="dialog-big--{{big}}" with-backdrop
+                  on-keydown="_checkEnter">
+      <div id="title">{{title}}</div>
+      <!--message value is bound in javascript because it needs to bind to innerHTML-->
+      <div id="message" hidden$="{{!message}}">{{message}}</div>
+      <!--body acts as a place holder for extending elements, their custom
+      markup is inserted here by stamping it from Javascript-->
+      <div id="body"></div>
+      <hr>
+      <div class="buttons">
+        <paper-button id="okButton" on-click="_confirmClose" class="confirm" >
+          {{okLabel}}
+        </paper-button>
+        <paper-button on-click="_cancelClose">{{cancelLabel}}</paper-button>
+      </div>
+    </paper-dialog>
+  </template>
+</dom-module>
+
+<script src="base-dialog.js"></script>

--- a/sources/web/datalab/polymer/components/base-dialog/base-dialog.ts
+++ b/sources/web/datalab/polymer/components/base-dialog/base-dialog.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Dialog close context, includes whether the dialog was confirmed.
+ */
+interface BaseDialogCloseResult {
+  confirmed: boolean,
+}
+
+/**
+ * Base Dialog element for Datalab. This element can be extended to insert custom markup
+ * (including other custom elements) inside it. This can be best done by stamping the
+ * subclass's element template into the #body element of this class.
+ */
+class BaseDialogElement extends Polymer.Element {
+
+  /**
+   * Title string of the dialog, shows up as <h2>
+   */
+  public title: string;
+
+  /**
+   * Message to show in dialog
+   */
+  public messageHtml: string;
+
+  /**
+   * Whether to show a big dialog
+   */
+  public big: boolean;
+
+  /**
+   * String for confirm button
+   */
+  public okLabel: string;
+
+  /**
+   * String for cancel button
+   */
+  public cancelLabel: string;
+
+  private _closeCallback: (result: BaseDialogCloseResult) => void;
+
+  static get is() { return "base-dialog"; }
+
+  static get properties() {
+    return {
+      title: {
+        type: String,
+        value: '',
+      },
+      messageHtml: {
+        type: String,
+        value: '',
+      },
+      big: {
+        type: Boolean,
+        value: false,
+      },
+      okLabel: {
+        type: String,
+        value: 'Ok',
+      },
+      cancelLabel: {
+        type: String,
+        value: 'Cancel'
+      },
+    }
+  }
+
+  open() {
+    const self = this;
+
+    // Set the message's inner HTML
+    if (this.messageHtml) {
+      this.$.message.innerHTML = this.messageHtml;
+    }
+
+    // If the closed event fires then the confirm button hasn't been clicked
+    this.$.theDialog.addEventListener('iron-overlay-closed', function() {
+      self._cancelClose();
+    });
+    this.$.theDialog.open();
+  }
+
+  /**
+   * Opens the dialog and takes a callback function that will be called when
+   * the dialog is closed with the close options.
+   */
+  openAndWaitAsync(callback: (_: BaseDialogCloseResult) => void) {
+    if (callback) {
+      this._closeCallback = callback;
+    }
+    this.open();
+  }
+
+  /**
+   * Returns any extra data to be augmented with the closing context object. Classes
+   * extending this element can override this method to pass back extra information.
+   */
+  getCloseResult() {
+    return {};
+  }
+
+  _confirmClose() {
+    this._dialogClosed(true);
+  }
+
+  _cancelClose() {
+    this._dialogClosed(false);
+  }
+
+  _dialogClosed(confirmed: boolean) {
+    if (this._closeCallback) {
+      this._closeCallback(Object.assign({
+        confirmed: confirmed,
+      }, this.getCloseResult()));
+    }
+    this.$.theDialog.close();
+  }
+
+  /**
+   * Helper method to listen for Enter key when an input is present
+   */
+  _checkEnter(e: KeyboardEvent) {
+    if (e.keyCode === 13) // Enter
+      this._confirmClose();
+  }
+
+}
+
+customElements.define(BaseDialogElement.is, BaseDialogElement);

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -13,6 +13,7 @@ the License.
 -->
 
 <link rel="import" href="../../components/input-dialog/input-dialog.html">
+<link rel="import" href="../../components/base-dialog/base-dialog.html">
 <link rel="import" href="../../components/item-list/item-list.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 
@@ -20,7 +21,6 @@ the License.
 <link rel="import" href="../../bower_components/iron-icons/editor-icons.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../bower_components/paper-progress/paper-progress.html">
-<link rel="import" href="../../bower_components/polymer/polymer.html">
 
 <dom-module id="datalab-files">
   <template>

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -280,13 +280,12 @@ class FilesElement extends Polymer.Element {
     // First, open a dialog to let the user specify a name for the notebook.
     const inputOptions: DialogOptions = {
       title: 'New ' + type, 
-      withInput: true,
       inputLabel: 'Name',
       okLabel: 'Create',
     };
 
-    return Utils.getUserInputAsync(inputOptions)
-      .then((closeResult: DialogCloseResult) => {
+    return Utils.showDialog(DialogType.input, inputOptions)
+      .then((closeResult: InputDialogCloseResult) => {
         // Only if the dialog has been confirmed with some user input, rename the
         // newly created file. Then if that is successful, reload the file list
         if (closeResult.confirmed && closeResult.userInput) {
@@ -318,7 +317,6 @@ class FilesElement extends Polymer.Element {
       // Open a dialog to let the user specify the new name for the selected item.
       const inputOptions: DialogOptions = {
         title: 'Rename ' + selectedObject.type.toString(), 
-        withInput: true,
         inputLabel: 'New name',
         inputValue: selectedObject.name,
         okLabel: 'Rename',
@@ -326,8 +324,8 @@ class FilesElement extends Polymer.Element {
 
       // Only if the dialog has been confirmed with some user input, rename the
       // selected item. Then if that is successful, and reload the file list.
-      return Utils.getUserInputAsync(inputOptions)
-        .then((closeResult: DialogCloseResult) => {
+      return Utils.showDialog(DialogType.input, inputOptions)
+        .then((closeResult: InputDialogCloseResult) => {
           if (closeResult.confirmed && closeResult.userInput) {
             const newName = this.currentPath + '/' + closeResult.userInput;
             return ApiManager.renameItem(selectedObject.path, newName)
@@ -375,20 +373,20 @@ class FilesElement extends Polymer.Element {
         itemList += '+ ' + (num - FilesElement._deleteListLimit) + ' more.';
       }
       itemList += '</ul>'
-      const bodyHtml = '<div>Are you sure you want to delete:</div>' + itemList;
+      const messageHtml = '<div>Are you sure you want to delete:</div>' + itemList;
 
       // Open a dialog to let the user confirm deleting the list of selected items.
       const inputOptions: DialogOptions = {
         title: title,
-        bodyHtml: bodyHtml,
+        messageHtml: messageHtml,
         okLabel: 'Delete',
       };
 
       // Only if the dialog has been confirmed, call the ApiManager to delete each
       // of the selected items, and wait for all promises to finish. Then if that
       // is successful, reload the file list.
-      return Utils.getUserInputAsync(inputOptions)
-        .then((closeResult: DialogCloseResult) => {
+      return Utils.showDialog(DialogType.confirm, inputOptions)
+        .then((closeResult: BaseDialogCloseResult) => {
           if (closeResult.confirmed) {
             let deletePromises = selectedIndices.map((i: number) => {
               return ApiManager.deleteItem(this._fileList[i].path);

--- a/sources/web/datalab/polymer/components/input-dialog/input-dialog.html
+++ b/sources/web/datalab/polymer/components/input-dialog/input-dialog.html
@@ -20,7 +20,7 @@ the License.
   <template>
     <style>
       #inputBox {
-        margin: auto 0px;
+        margin: 20px 0px;
         /*Disable input underline animation*/
         --paper-input-container-underline-focus: {
           display: none;

--- a/sources/web/datalab/polymer/components/input-dialog/input-dialog.html
+++ b/sources/web/datalab/polymer/components/input-dialog/input-dialog.html
@@ -12,50 +12,24 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
-<link rel="import" href="../../bower_components/paper-dialog/paper-dialog.html">
+<link rel="import" href="../base-dialog/base-dialog.html">
+
 <link rel="import" href="../../bower_components/paper-input/paper-input.html">
-<link rel="import" href="../../bower_components/polymer/polymer.html">
 
 <dom-module id="input-dialog">
   <template>
-    <style include="datalab-shared-styles">
-      #theDialog {
-        width: 300px;
+    <style>
+      #inputBox {
+        margin: auto 0px;
         /*Disable input underline animation*/
         --paper-input-container-underline-focus: {
           display: none;
         };
       }
-      hr {
-        border-left: none;
-        border-right: none;
-        border-bottom: none;
-        border-top: 1px solid #eee;
-      }
-      #title {
-        font-size: 16px;
-        text-align: center;
-      }
-      .confirm {
-        background-color: var(--app-secondary-color);
-        font-weight: bold;
-      }
     </style>
-    <paper-dialog id="theDialog" class="dialog" with-backdrop>
-      <h2><div id="title">{{title}}</div></h2>
-      <!--Body value is bound in javascript because it needs to bind to innerHTML-->
-      <div id="body" hidden$="{{!bodyHtml}}"></div>
-      <paper-input id="inputBox" hidden$="{{!withInput}}" label="{{inputLabel}}" spellcheck=false
-                   value="{{inputValue}}" on-keydown="_checkEnter" no-label-float>
-      </paper-input>
-      <hr />
-      <div class="buttons">
-        <paper-button id="okButton" on-click="_confirmClose" class="confirm" >
-          {{okLabel}}
-        </paper-button>
-        <paper-button on-click="_cancelClose">{{cancelLabel}}</paper-button>
-      </div>
-    </paper-dialog>
+    <paper-input id="inputBox" label="{{inputLabel}}" spellcheck=false autofocus
+                 value="{{inputValue}}" no-label-float>
+    </paper-input>
   </template>
 </dom-module>
 

--- a/sources/web/datalab/polymer/components/input-dialog/input-dialog.ts
+++ b/sources/web/datalab/polymer/components/input-dialog/input-dialog.ts
@@ -44,7 +44,7 @@ class InputDialogElement extends BaseDialogElement {
    */
   public inputValue: string;
 
-  private static _memoizedTemplate: {content: HTMLElement};
+  private static _memoizedTemplate: PolymerTemplate;
 
   static get is() { return "input-dialog"; }
 

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -15,23 +15,19 @@
 /**
  * Options for opening a dialog.
  */
+enum DialogType {
+  input,
+  confirm,
+}
 interface DialogOptions {
   title: string,
+  messageHtml?: string,
   bodyHtml?: string,
-  withInput?: boolean,
   inputLabel?: string,
   inputValue?: string,
   okLabel?: string,
   cancelLabel?: string,
-}
-
-/**
- * Dialog close context, includes whether the dialog was confirmed, and any
- * user input given.
- */
-interface DialogCloseResult {
-  confirmed: boolean
-  userInput: string,
+  big?: boolean,
 }
 
 /**
@@ -41,32 +37,40 @@ class Utils {
 
   /**
    * Opens a dialog with the specified options. It uses the Datalab custom element
-   * <input-dialog>, attaches a new instance to the current document, opens it
-   * and returns a promise that resolves when the dialog is closed.
-   * @param dialogOptions options for configuring the dialog
+   * according to the specified dialog type, attaches a new instance to the current
+   * document, opens it, and returns a promise that resolves when the dialog is closed.
+   * @param type specifies which type of dialog to use
+   * @param dialogOptions specifies different options for opening the dialog
    */
-  static getUserInputAsync(dialogOptions: DialogOptions) {
-    const createModal = <InputDialogElement>document.createElement('input-dialog');
-    document.body.appendChild(createModal);
+  static showDialog(type: DialogType, dialogOptions: DialogOptions) {
+    let dialogElement = '';
+    if (type === DialogType.input) {
+      dialogElement = 'input-dialog';
+    } else if (type === DialogType.confirm) {
+      dialogElement = 'base-dialog';
+    }
+    const dialog = <any>document.createElement(dialogElement);
+    document.body.appendChild(dialog);
 
-    createModal.title = dialogOptions.title;
-    if (dialogOptions.bodyHtml)
-      createModal.bodyHtml = dialogOptions.bodyHtml;
-    if (dialogOptions.withInput !== undefined)
-      createModal.withInput = dialogOptions.withInput;
+    if (dialogOptions.title)
+      dialog.title = dialogOptions.title;
+    if (dialogOptions.messageHtml)
+      dialog.messageHtml = dialogOptions.messageHtml;
     if (dialogOptions.inputLabel)
-      createModal.inputLabel = dialogOptions.inputLabel;
+      dialog.inputLabel = dialogOptions.inputLabel;
     if (dialogOptions.inputValue)
-      createModal.inputValue = dialogOptions.inputValue;
+      dialog.inputValue = dialogOptions.inputValue;
     if (dialogOptions.okLabel)
-      createModal.okLabel = dialogOptions.okLabel;
+      dialog.okLabel = dialogOptions.okLabel;
     if (dialogOptions.cancelLabel)
-      createModal.cancelLabel = dialogOptions.cancelLabel;
+      dialog.cancelLabel = dialogOptions.cancelLabel;
+    if (dialogOptions.big !== undefined)
+      dialog.big = dialogOptions.big;
 
     // Open the dialog
     return new Promise(resolve => {
-      createModal.openAndWaitAsync((closeResult: DialogCloseResult) => {
-        document.body.removeChild(createModal);
+      dialog.openAndWaitAsync((closeResult: InputDialogCloseResult) => {
+        document.body.removeChild(dialog);
         resolve(closeResult);
       });
     });

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -96,7 +96,7 @@ class Utils {
     const basetypeTemplate = Polymer.DomModule.import(baseType, 'template');
     const subtypeTemplate = Polymer.DomModule.import(subType, 'template');
     // Clone the base template; we don't want to change it in-place
-    let stampedTemplate = <PolymerTemplate>basetypeTemplate.cloneNode(true);
+    const stampedTemplate = <PolymerTemplate>basetypeTemplate.cloneNode(true);
 
     // Insert this template's elements in the base class's #body
     const bodyElement = stampedTemplate.content.querySelector(baseRootElementSelector);

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -16,8 +16,8 @@
  * Options for opening a dialog.
  */
 enum DialogType {
-  input,
   confirm,
+  input,
 }
 interface DialogOptions {
   title: string,
@@ -93,8 +93,10 @@ class Utils {
   static stampInBaseTemplate(subType: string, baseType: string,
                              baseRootElementSelector: string) {
     // Start with the base class's template
-    let stampedTemplate = Polymer.DomModule.import(baseType, 'template');
+    const basetypeTemplate = Polymer.DomModule.import(baseType, 'template');
     const subtypeTemplate = Polymer.DomModule.import(subType, 'template');
+    // Clone the base template; we don't want to change it in-place
+    let stampedTemplate = <PolymerTemplate>basetypeTemplate.cloneNode(true);
 
     // Insert this template's elements in the base class's #body
     const bodyElement = stampedTemplate.content.querySelector(baseRootElementSelector);

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -75,5 +75,37 @@ class Utils {
       });
     });
   }
+
+  /**
+   * Utility function that helps with the Polymer inheritance mechanism. It takes the subclass,
+   * the superclass, and an element selector. It loads the templates for the two classes,
+   * and inserts all of the elements from the subclass into the superclass's template, under
+   * the element specified with the CSS selector, then returns the merged template.
+   * 
+   * This allows for a very flexible expansion of the superclass's HTML template, so that we're
+   * not limited by wrapping the extended element, but we can actually inject extra elements
+   * into its template, all while extending all of its javascript and styles.
+   * @param subType class that is extending a superclass
+   * @param baseType the superclass being extended
+   * @param baseRootElementSelector a selector for an element that will be root
+   *                                for the stamped template
+   */
+  static stampInBaseTemplate(subType: string, baseType: string,
+                             baseRootElementSelector: string) {
+    // Start with the base class's template
+    let stampedTemplate = Polymer.DomModule.import(baseType, 'template');
+    const subtypeTemplate = Polymer.DomModule.import(subType, 'template');
+
+    // Insert this template's elements in the base class's #body
+    const bodyElement = stampedTemplate.content.querySelector(baseRootElementSelector);
+    if (bodyElement) {
+      while (subtypeTemplate.content.children.length) {
+        const childNode = <HTMLElement>subtypeTemplate.content.firstElementChild;
+        bodyElement.insertAdjacentElement('beforeend', childNode);
+      }
+    }
+
+    return stampedTemplate;
+  }
  
 }

--- a/third_party/externs/ts/polymer/polymer.d.ts
+++ b/third_party/externs/ts/polymer/polymer.d.ts
@@ -26,6 +26,10 @@ interface ElementDefinitionOptions {
   extends: string;
 }
 
+interface PolymerTemplate {
+  content: HTMLElement;
+}
+
 declare module Polymer {
 
   class Element extends HTMLElement {
@@ -83,6 +87,7 @@ declare module Polymer {
     setScrollDirection(direction: string, node: HTMLElement): void;
     shift(path: string, value: any): any;
     splice(path: string, start: number, deleteCount: number, ...items: any[]): any;
+    static template: PolymerTemplate;
     toggleAttribute(name: string, bool: boolean, node?: HTMLElement): void;
     toggleClass(name: string, bool: boolean, node?: HTMLElement): void;
     transform(transform: string, node?: HTMLElement): void;
@@ -92,6 +97,7 @@ declare module Polymer {
     unshift(path: string, value: any): any;
     updateStyles(properties?: Object): void;
     shadowRoot: ShadowRoot;
+    is: string;
     properties?: Object;
     listeners?: Object;
     behaviors?: Object[];
@@ -104,6 +110,10 @@ declare module Polymer {
     connectedCallback(): void;
     attributeChanged?(attrName: string, oldVal: any, newVal: any): void;
     prototype?: Object;
+  }
+
+  class DomModule {
+    static import(element: string, property: string): PolymerTemplate;
   }
 
   function importHref(href: string,

--- a/third_party/externs/ts/polymer/polymer.d.ts
+++ b/third_party/externs/ts/polymer/polymer.d.ts
@@ -26,7 +26,7 @@ interface ElementDefinitionOptions {
   extends: string;
 }
 
-interface PolymerTemplate {
+interface PolymerTemplate extends Node {
   content: HTMLElement;
 }
 


### PR DESCRIPTION
As we're adding more types of dialogs, using inheritance is a cleaner and easier approach.

In order to use inheritance with Polymer, this change adds a template stamp mechanism, which takes the subclass and baseclass, and stamps the former into an element inside the latter. This way we can reuse the Javascript across the elements, and we can extend the template at the same time.

This change adds a BaseDialog type that shows a dialog with room for a title, messag, and ok/cancel buttons. The InputDialog then extends this to add an input element with some more input behavior.