### PR TITLE
[Polymer UI] Remove explicit z-index from toolbar

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -30,9 +30,6 @@ the License.
         display: flex;
         flex-direction: column;
       }
-      datalab-toolbar {
-        z-index: 1;
-      }
       .datalab-contents {
         display: flex;
         height: calc(100% - var(--toolbar-height));


### PR DESCRIPTION
Polymer overlay behaviors require no parent elements with higher z-index stacking context. Since we currently don't have any issue with z-index (this was just added for safety), I'm removing this. When we need, we'll have to specify z-index for all our layers.

See the limitation section here: https://www.webcomponents.org/element/PolymerElements/iron-overlay-behavior, and read on stacking contexts here: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context