### PR TITLE
Make old ui backward compatible with the new startuppath format

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -91,7 +91,7 @@ do
 
   SRC_DIR=$REPO_DIR/sources/$SRC
   cd $SRC_DIR
-  ./build.sh | tee -a $LOG_FILE
+  ./build.sh
 
   if [ "$?" -ne "0" ]; then
     echo "failed" | tee -a $LOG_FILE

--- a/sources/build.sh
+++ b/sources/build.sh
@@ -91,7 +91,7 @@ do
 
   SRC_DIR=$REPO_DIR/sources/$SRC
   cd $SRC_DIR
-  ./build.sh >> $LOG_FILE 2>&1
+  ./build.sh | tee -a $LOG_FILE
 
   if [ "$?" -ne "0" ]; then
     echo "failed" | tee -a $LOG_FILE

--- a/sources/web/datalab/backupUtility.ts
+++ b/sources/web/datalab/backupUtility.ts
@@ -39,7 +39,7 @@ function readBackupLog() {
   }
 }
 function writeBackupLog(log_history: Object) {
-  return fs.writeFileSync(backupLogPath, JSON.stringify(log_history), 'utf8');
+  return fs.writeFileSync(backupLogPath, JSON.stringify(log_history), { encoding: 'utf8'});
 }
 
 /**

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -118,7 +118,7 @@ class ApiManager {
     const xhrOptions: XhrOptions = {
       noCache: true,
     };
-    return ApiManager._xhrAsync(this.sessionsApiUrl, xhrOptions);
+    return <Promise<Session[]>>ApiManager._xhrAsync(this.sessionsApiUrl, xhrOptions);
   }
 
   /**
@@ -132,7 +132,7 @@ class ApiManager {
     const xhrOptions: XhrOptions = {
       noCache: true,
     };
-    return ApiManager._xhrAsync(this.contentApiUrl + '/' + path, xhrOptions);
+    return <Promise<JupyterFile>>ApiManager._xhrAsync(this.contentApiUrl + '/' + path, xhrOptions);
   }
 
   /**
@@ -165,7 +165,7 @@ class ApiManager {
         files.forEach((file: ApiFile) => {
           file.status = runningPaths.indexOf(file.path) > -1 ? 'running' : '';
         });
-        return files;
+        return <ApiFile[]>files;
       });
   }
 

--- a/sources/web/datalab/polymer/tsconfig.json
+++ b/sources/web/datalab/polymer/tsconfig.json
@@ -14,5 +14,8 @@
   "include": [
     "**/*.ts",
     "../../../../third_party/externs/ts/polymer/polymer.d.ts"
+  ],
+  "exclude": [
+    "bower_components"
   ]
 }

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -127,7 +127,7 @@ function handleRequest(request: http.ServerRequest,
     if (startup_path_setting in loadedSettings) {
       let startuppath = loadedSettings[startup_path_setting];
 
-      // For backward compatibility with the old path format, trim /tree prefix.
+      // For backward compatibility with the old path format, prepend /tree prefix.
       // This code path should only be hit by the old Jupyter-based UI, which expects
       // a '/' prefix in the startup path, but we don't want to replicate it if it
       // is already saved in the user setting.

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -125,7 +125,16 @@ function handleRequest(request: http.ServerRequest,
     response.statusCode = 302;
     var redirectUrl : string;
     if (startup_path_setting in loadedSettings) {
-      redirectUrl = '/tree' + loadedSettings[startup_path_setting];
+      let startuppath = loadedSettings[startup_path_setting];
+
+      // For backward compatibility with the old path format, trim /tree prefix.
+      // This code path should only be hit by the old Jupyter-based UI, which expects
+      // a '/' prefix in the startup path, but we don't want to replicate it if it
+      // is already saved in the user setting.
+      if (startuppath.indexOf('/tree') !== 0) {
+        startuppath = '/tree' + startuppath;
+      }
+      redirectUrl = startuppath;
     } else {
       redirectUrl = '/tree/datalab';
     }


### PR DESCRIPTION
I recently changed the `startuppath` format to not contain the `/tree` prefix, but the old UI still expects the prefix. This broke clients that already have the setting saved in the old format, and were not using the experimental UI. This change makes the old UI work with or without it so it can talk to either format.

This change also lets the `sources/build.sh` output to stdout directly, and fixes a few things that broke with the new `tsc`.