### PR TITLE
Allow alternate access to experimental UI via /exp/ path.

### DIFF
--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -169,6 +169,9 @@ function sendUserCustomTheme(userId: string, response: http.ServerResponse): voi
  * @param path the incoming request path
  */
 export function isExperimentalResource(pathname: string) {
+  if (pathname.indexOf('/exp/') === 0) {
+    return true;
+  }
   const experimentalUiEnabled = process.env.DATALAB_EXPERIMENTAL_UI;
   return experimentalUiEnabled === 'true' && (
       pathname.indexOf('/files') === 0 ||
@@ -194,9 +197,14 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
   // -------------------------------- start of experimental UI resources
   if (isExperimentalResource(pathname)) {
     logging.getLogger().debug('Serving experimental UI resource: ' + pathname);
+    let rootRedirect = 'files';
+    if (pathname.indexOf('/exp/') === 0) {
+      pathname = pathname.substr('/exp'.length);
+      rootRedirect = 'exp/files';
+    }
     if (pathname === '/') {
       response.statusCode = 302;
-      response.setHeader('Location', path.join(appSettings.datalabBasePath, 'files'));
+      response.setHeader('Location', path.join(appSettings.datalabBasePath, rootRedirect));
       response.end();
       return;
     }


### PR DESCRIPTION
This change allows me to more easily compare details of the old and new UIs. I can run without the experiment flag to view and use the old UI, then open another tab at localhost:80801/exp/ to view and use the new UI at the same time.