### PR TITLE
Avoid failing if empty settings file found

### DIFF
--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -62,7 +62,7 @@ export function loadAppSettings(): common.AppSettings {
       metadata = <Metadata>JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
     }
 
-    var settings = <common.AppSettings>JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    var settings = <common.AppSettings>JSON.parse(fs.readFileSync(settingsPath, 'utf8') || '{}');
     settings.versionId = process.env['DATALAB_VERSION'] || '';
     if (process.env['DATALAB_CONFIG_URL']) {
       settings.configUrl = process.env['DATALAB_CONFIG_URL'];
@@ -127,7 +127,7 @@ export function loadUserSettings(userId: string): common.UserSettings {
   }
 
   try {
-    var settings = <common.UserSettings>JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    var settings = <common.UserSettings>JSON.parse(fs.readFileSync(settingsPath, 'utf8') || '{}');
     return settings;
   }
   catch (e) {
@@ -176,7 +176,7 @@ export function updateUserSetting(userId: string, key: string, value: string,
   let settings: common.UserSettings;
   if (fs.existsSync(settingsPath)) {
     try {
-      settings = <common.UserSettings>JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      settings = <common.UserSettings>JSON.parse(fs.readFileSync(settingsPath, 'utf8') || '{}');
     }
     catch (e) {
       console.log(e);

--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -62,7 +62,7 @@ export function loadAppSettings(): common.AppSettings {
       metadata = <Metadata>JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
     }
 
-    var settings = <common.AppSettings>JSON.parse(fs.readFileSync(settingsPath, 'utf8') || '{}');
+    const settings = <common.AppSettings>JSON.parse(fs.readFileSync(settingsPath, 'utf8') || '{}');
     settings.versionId = process.env['DATALAB_VERSION'] || '';
     if (process.env['DATALAB_CONFIG_URL']) {
       settings.configUrl = process.env['DATALAB_CONFIG_URL'];
@@ -127,7 +127,7 @@ export function loadUserSettings(userId: string): common.UserSettings {
   }
 
   try {
-    var settings = <common.UserSettings>JSON.parse(fs.readFileSync(settingsPath, 'utf8') || '{}');
+    const settings = <common.UserSettings>JSON.parse(fs.readFileSync(settingsPath, 'utf8') || '{}');
     return settings;
   }
   catch (e) {


### PR DESCRIPTION
If a user settings or app settings file is found but empty, the `JSON.parse` will fail, since empty string isn't valid JSON.