### PR TITLE
Add polymer UI elements for sign-in and sign-out.

### DIFF
--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.html
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.html
@@ -1,0 +1,62 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
+
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+
+<dom-module id="auth-panel">
+  <template>
+    <style include="datalab-shared-styles">
+      #signInButton {
+        color: #fff;
+        background-color: #449d44;
+        border-color: #398439;
+      }
+      #signOutButton {
+        color: #fff;
+        background-color: #d9534f;
+        border-color: #d43f3a;
+      }
+      .signIoButton {
+        width: 100%;
+        float: none;
+        margin: 0;
+      }
+      .infoLabel {
+        display: block;
+        padding-bottom: 10px;
+        bottom-margin: 5px;
+      }
+    </style>
+
+    <div>
+      <div id="signInGroup" hidden="{{_signedIn}}">
+        <paper-button id="signInButton" title="Sign In" class="signIoButton" on-click="_signInClicked">
+          Sign In
+        </paper-button>
+      </div>
+      <div id="signOutGroup" hidden="{{!_signedIn}}">
+        <label id="userInfoLabel" class="infoLabel">{{_userInfo}}</label>
+        <label id="projectInfoLabel" class="infoLabel">{{_projectInfo}}</label>
+        <paper-button id="signOutButton" title="Sign Out" class="signIoButton" on-click="_signOutClicked">
+          Sign Out
+        </paper-button>
+      </div>
+    </div>
+
+  </template>
+</dom-module>
+
+<script src="auth-panel.js"></script>

--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Auth sign-in/sign-out panel.
+ * This element provides buttons to sign in and out, and display some
+ * information when signed in.
+ */
+class AuthPanel extends Polymer.Element {
+
+  private _projectInfo : string;
+  private _signedIn : boolean;
+  private _userInfo : string;
+
+  static get is() { return "auth-panel"; }
+
+  static get properties() {
+    return {
+      _projectInfo: {
+        type: String,
+        value: '',
+      },
+      _signedIn: {
+        type: Boolean,
+        value: false,
+      },
+      _userInfo: {
+        type: String,
+        value: '',
+      },
+    }
+  }
+
+  _signInClicked() {
+    this._signedIn = true;
+    this._userInfo = 'Not actually signed in';
+    this._projectInfo = 'No project is set';
+  }
+
+  _signOutClicked() {
+    this._signedIn = false;
+  }
+}
+
+customElements.define(AuthPanel.is, AuthPanel);

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -28,9 +28,6 @@ the License.
   <template>
 
     <style include="datalab-shared-styles">
-      [hidden] {
-        display: none !important;
-      }
       div {
         font-family: var(--app-content-font-family);
         font-size: var(--app-content-font-size);

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -24,6 +24,9 @@ the License.
 <dom-module id="datalab-toolbar">
   <template>
     <style include="datalab-shared-styles">
+      [hidden] {
+        display: none !important;
+      }
       :host {
         --toolbar-button-dimension: 35px;
       }
@@ -71,10 +74,34 @@ the License.
         right: 0px;
         top: var(--toolbar-height);
         margin: 0px;
-        min-width: 160px;
+        min-width: 250px;
         max-width: 300px;
         box-shadow: -3px 3px 10px -3px rgba(0, 0, 0, 0.3);
         z-index: 3;
+      }
+      #signInButton {
+        width: 100%;
+        float: none;
+        color: #fff;
+        background-color: #449d44;
+        border-color: #398439;
+      }
+      #signOutButton {
+        width: 100%;
+        float: none;
+        color: #fff;
+        background-color: #d9534f;
+        border-color: #d43f3a;
+      }
+      #userInfoLabel {
+        display: block;
+        padding-bottom: 10px;
+        bottom-margin: 5px;
+      }
+      #projectInfoLabel {
+        display: block;
+        padding-bottom: 10px;
+        bottom-margin: 5px;
       }
     </style>
 
@@ -97,7 +124,20 @@ the License.
     <!--Account dropdown dialog. This always shows at the top left corner
     below the toolbar-->
     <paper-dialog id="accountDropdown" class="account-dropdown">
-      <div>Account menu contents</div>
+      <div>
+        <div id="signInGroup" hidden="{{_signedIn}}">
+          <paper-button id="signInButton" title="Sign In" class="btn btn-success" on-click="_signInClicked">
+            Sign In
+          </paper-button>
+        </div>
+        <div id="signOutGroup" hidden="{{!_signedIn}}">
+          <label id="userInfoLabel">{{_userInfo}}</label>
+          <label id="projectInfoLabel">{{_projectInfo}}</label>
+          <paper-button id="signOutButton" title="Sign Out" class="btn btn-danger" on-click="_signOutClicked">
+            Sign Out
+          </paper-button>
+        </div>
+      </div>
     </paper-dialog>
 
     <!--Info dialog. This shows centered in the middle of the window-->

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -12,6 +12,7 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
+<link rel="import" href="../../components/auth-panel/auth-panel.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 
 <link rel="import" href="../../bower_components/app-layout/app-header/app-header.html">
@@ -24,9 +25,6 @@ the License.
 <dom-module id="datalab-toolbar">
   <template>
     <style include="datalab-shared-styles">
-      [hidden] {
-        display: none !important;
-      }
       :host {
         --toolbar-button-dimension: 35px;
       }
@@ -74,34 +72,11 @@ the License.
         right: 0px;
         top: var(--toolbar-height);
         margin: 0px;
+        padding: 10px;
         min-width: 250px;
         max-width: 300px;
         box-shadow: -3px 3px 10px -3px rgba(0, 0, 0, 0.3);
         z-index: 3;
-      }
-      #signInButton {
-        width: 100%;
-        float: none;
-        color: #fff;
-        background-color: #449d44;
-        border-color: #398439;
-      }
-      #signOutButton {
-        width: 100%;
-        float: none;
-        color: #fff;
-        background-color: #d9534f;
-        border-color: #d43f3a;
-      }
-      #userInfoLabel {
-        display: block;
-        padding-bottom: 10px;
-        bottom-margin: 5px;
-      }
-      #projectInfoLabel {
-        display: block;
-        padding-bottom: 10px;
-        bottom-margin: 5px;
       }
     </style>
 
@@ -121,23 +96,10 @@ the License.
       </app-toolbar>
     </app-header>
 
-    <!--Account dropdown dialog. This always shows at the top left corner
+    <!--Account dropdown dialog. This always shows at the top right corner
     below the toolbar-->
     <paper-dialog id="accountDropdown" class="account-dropdown">
-      <div>
-        <div id="signInGroup" hidden="{{_signedIn}}">
-          <paper-button id="signInButton" title="Sign In" class="btn btn-success" on-click="_signInClicked">
-            Sign In
-          </paper-button>
-        </div>
-        <div id="signOutGroup" hidden="{{!_signedIn}}">
-          <label id="userInfoLabel">{{_userInfo}}</label>
-          <label id="projectInfoLabel">{{_projectInfo}}</label>
-          <paper-button id="signOutButton" title="Sign Out" class="btn btn-danger" on-click="_signOutClicked">
-            Sign Out
-          </paper-button>
-        </div>
-      </div>
+      <auth-panel></auth-panel>
     </paper-dialog>
 
     <!--Info dialog. This shows centered in the middle of the window-->

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
@@ -20,7 +20,28 @@
  */
 class ToolbarElement extends Polymer.Element {
 
+  private _projectInfo : string;
+  private _signedIn : boolean;
+  private _userInfo : string;
+
   static get is() { return "datalab-toolbar"; }
+
+  static get properties() {
+    return {
+      _projectInfo: {
+        type: String,
+        value: '',
+      },
+      _signedIn: {
+        type: Boolean,
+        value: false,
+      },
+      _userInfo: {
+        type: String,
+        value: '',
+      },
+    }
+  }
 
   /**
    * When account menu icon is clicked, toggles account menu visibility
@@ -43,6 +64,15 @@ class ToolbarElement extends Polymer.Element {
     this.$.settingsDialog.open();
   }
 
+  _signInClicked() {
+    this._signedIn = true;
+    this._userInfo = 'Not actually signed in';
+    this._projectInfo = 'No project is set';
+  }
+
+  _signOutClicked() {
+    this._signedIn = false;
+  }
 }
 
 customElements.define(ToolbarElement.is, ToolbarElement);

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
@@ -20,28 +20,7 @@
  */
 class ToolbarElement extends Polymer.Element {
 
-  private _projectInfo : string;
-  private _signedIn : boolean;
-  private _userInfo : string;
-
   static get is() { return "datalab-toolbar"; }
-
-  static get properties() {
-    return {
-      _projectInfo: {
-        type: String,
-        value: '',
-      },
-      _signedIn: {
-        type: Boolean,
-        value: false,
-      },
-      _userInfo: {
-        type: String,
-        value: '',
-      },
-    }
-  }
 
   /**
    * When account menu icon is clicked, toggles account menu visibility
@@ -63,17 +42,6 @@ class ToolbarElement extends Polymer.Element {
   _settingsClicked() {
     this.$.settingsDialog.open();
   }
-
-  _signInClicked() {
-    this._signedIn = true;
-    this._userInfo = 'Not actually signed in';
-    this._projectInfo = 'No project is set';
-  }
-
-  _signOutClicked() {
-    this._signedIn = false;
-  }
 }
 
 customElements.define(ToolbarElement.is, ToolbarElement);
-

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -46,6 +46,9 @@ the License.
       a:visited {
         color: var(--selection-fg-color);
       }
+      [hidden] {
+        display: none !important;
+      }
     </style>
   </template>
 </dom-module>


### PR DESCRIPTION
This PR adds sign-in and sign-out buttons to the account menu in the Polymer UI. At the moment, they do nothing except toggle the signed-in state, they don't actually sign in.

When signed out, the sign-in button is visible:
![accountmenusignin](https://user-images.githubusercontent.com/116825/27666767-072ebb44-5c2b-11e7-8a39-f2eb99c398c0.png)

When signed in, some info about user and project appears along with the sign-out button:
![accountmenusignout](https://user-images.githubusercontent.com/116825/27666780-17d168e8-5c2b-11e7-86e0-6ccd464611fa.png)


