### PR TITLE
Upgrade DataFlow from 0.6 to 2.0.

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -83,8 +83,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir bs4==0.0.1 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir crcmod==1.7 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir pillow==3.4.1 && \
-    pip install -U --upgrade-strategy only-if-needed --no-cache-dir google-cloud-dataflow==0.6.0 && \
-    pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow-transform==0.1.7 && \
+    pip install -U --upgrade-strategy only-if-needed --no-cache-dir google-cloud-dataflow==2.0.0 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow==1.0.1 && \
     # Setting protobuf to 3.1.0 to workaround a tensorflow 1.0 issue in tcmalloc
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir protobuf==3.1.0 && \

--- a/containers/base/Dockerfile.py2
+++ b/containers/base/Dockerfile.py2
@@ -80,7 +80,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir bs4==0.0.1 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir crcmod==1.7 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir pillow==3.4.1 && \
-    pip install -U --upgrade-strategy only-if-needed --no-cache-dir google-cloud-dataflow==0.6.0 && \
+    pip install -U --upgrade-strategy only-if-needed --no-cache-dir google-cloud-dataflow==2.0.0 && \
     find /usr/local/lib/python2.7 -type d -name tests | xargs rm -rf && \
 
 
@@ -130,9 +130,6 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     rm -rf /usr/share/locale/* && \
     rm -rf /usr/share/i18n/locales/* && \
     cd /
-
-# Install tf-transform
-RUN pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow-transform==0.1.7
 
 # Install TensorFlow
 # Setting protobuf to 3.1.0 to workaround a tensorflow 1.0 issue in tcmalloc


### PR DESCRIPTION
Changes needed to work with Dataflow 2.0 in MLToolbox is submitted to pydatalab repo.