### PR TITLE
[Polymer UI] Add theme switcher setting

### DIFF
--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -15,6 +15,7 @@
     "paper-input": "PolymerElements/paper-input#^2.0.1",
     "paper-item": "PolymerElements/paper-item#^2.0.0",
     "paper-progress": "PolymerElements/paper-progress#^2.0.0",
+    "paper-radio-group": "PolymerElements/paper-radio-group#^2.0.0",
     "polymer": "Polymer/polymer#^2.0.1",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.9",
     "xterm.js": "^2.7.0"

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -59,6 +59,7 @@ the License.
       #navbar {
         display: flex;
         height: calc(var(--toolbar-height) - 1px); /* for progress bar */
+        background-color: var(--primary-bg-color);
       }
       .navbar-button {
         min-width: 35px;
@@ -76,6 +77,7 @@ the License.
       }
       #files {
         flex-grow: 1;
+        background-color: var(--primary-bg-color);
       }
       #detailsPane {
         min-width: var(--details-pane-width);
@@ -100,7 +102,7 @@ the License.
       }
       #breadcrumb div a {
         display: block;
-        background: var(--primary-bg-color);
+        background-color: var(--primary-bg-color);
         text-decoration: none;
         position: relative;
         line-height: 46px;

--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.html
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.html
@@ -49,6 +49,9 @@ the License.
         /* 1 breadcrumb bar + 1 progress bar */
         height: calc(100% - var(--toolbar-height) - 1px);
       }
+      #sessions {
+        background-color: var(--primary-bg-color);
+      }
       paper-progress {
         width: 100%;
         height: 1px;

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
@@ -1,0 +1,35 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
+
+<link rel="import" href="../../bower_components/paper-radio-group/paper-radio-group.html">
+<link rel="import" href="../../bower_components/paper-input/paper-input.html">
+
+<dom-module id="datalab-settings">
+  <template>
+    <style include="datalab-shared-styles">
+    </style>
+
+    <!--Theme-->
+    <div>Theme:</div>
+    <paper-radio-group selected="{{theme}}" on-paper-radio-group-changed="_themeChanged">
+      <paper-radio-button name="light">Light</paper-radio-button>
+      <paper-radio-button name="dark">Dark</paper-radio-button>
+    </paper-radio-group>
+
+  </template>
+</dom-module>
+
+<script src="datalab-settings.js"></script>

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
@@ -20,14 +20,23 @@ the License.
 <dom-module id="datalab-settings">
   <template>
     <style include="datalab-shared-styles">
+      paper-radio-button {
+        --paper-radio-button-checked-color: var(--selection-fg-color);
+      }
+      .setting {
+        padding: 15px;
+        border-bottom: 1px solid var(--border-color);
+      }
     </style>
 
     <!--Theme-->
-    <div>Theme:</div>
-    <paper-radio-group selected="{{theme}}" on-paper-radio-group-changed="_themeChanged">
-      <paper-radio-button name="light">Light</paper-radio-button>
-      <paper-radio-button name="dark">Dark</paper-radio-button>
-    </paper-radio-group>
+    <div class="setting">
+      <div>Theme:</div>
+      <paper-radio-group selected="{{theme}}" on-paper-radio-group-changed="_themeChanged">
+        <paper-radio-button name="light">Light</paper-radio-button>
+        <paper-radio-button name="dark">Dark</paper-radio-button>
+      </paper-radio-group>
+    </div>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -13,18 +13,11 @@
  */
 
 /**
- * CustomEvent that gets dispatched when the theme setting is changed by the user.
- */
-class ThemeChangedEvent extends CustomEvent {
-  detail: {
-    theme: string
-  }
-}
-
-/**
  * Settings element for Datalab.
  * This element shows a settings panel for Datalab that contains different user settings,
  * and uses the ApiManager to read and update those settings.
+ * On changing the selected theme, this element will trigger an event on the document
+ * element to signal the change, which can be handled by the host.
  */
 class SettingsElement extends Polymer.Element {
 
@@ -43,9 +36,14 @@ class SettingsElement extends Polymer.Element {
     }
   }
 
+  /**
+   * Called when element is attached to DOM. Gets the user settings and sets
+   * the visible ones to element properties.
+   */
   ready() {
     super.ready();
 
+    // TODO: add a cache for user/app settings and call it here instead.
     ApiManager.getUserSettings()
       .then((settings: common.UserSettings) => {
         this.theme = settings.theme;
@@ -54,13 +52,7 @@ class SettingsElement extends Polymer.Element {
 
   _themeChanged() {
     return ApiManager.setUserSetting('theme', this.theme)
-      .then(() => {
-        const cssElement = <HTMLLinkElement>document.querySelector('#themeStylesheet');
-        if (cssElement) {
-          const sheetAddress = cssElement.href + "?v=" + Date.now()
-          cssElement.setAttribute('href', sheetAddress);
-        }
-      });
+      .then(() => document.dispatchEvent(new Event('ThemeChanged')));
   }
 
 }

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -13,6 +13,15 @@
  */
 
 /**
+ * CustomEvent that gets dispatched when the theme setting is changed by the user.
+ */
+class ThemeChangedEvent extends CustomEvent {
+  detail: {
+    theme: string
+  }
+}
+
+/**
  * Settings element for Datalab.
  * This element shows a settings panel for Datalab that contains different user settings,
  * and uses the ApiManager to read and update those settings.
@@ -44,7 +53,14 @@ class SettingsElement extends Polymer.Element {
   }
 
   _themeChanged() {
-    return ApiManager.setUserSetting('theme', this.theme);
+    return ApiManager.setUserSetting('theme', this.theme)
+      .then(() => {
+        const cssElement = <HTMLLinkElement>document.querySelector('#themeStylesheet');
+        if (cssElement) {
+          const sheetAddress = cssElement.href + "?v=" + Date.now()
+          cssElement.setAttribute('href', sheetAddress);
+        }
+      });
   }
 
 }

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Settings element for Datalab.
+ * This element shows a settings panel for Datalab that contains different user settings,
+ * and uses the ApiManager to read and update those settings.
+ */
+class SettingsElement extends Polymer.Element {
+
+  /**
+   * Current selected theme.
+   */
+  public theme: string;
+
+  static get is() { return "datalab-settings"; }
+
+  static get properties() {
+    return {
+      theme: {
+        type: String,
+      }
+    }
+  }
+
+  ready() {
+    super.ready();
+
+    ApiManager.getUserSettings()
+      .then((settings: common.UserSettings) => {
+        this.theme = settings.theme;
+      });
+  }
+
+  _themeChanged() {
+    return ApiManager.setUserSetting('theme', this.theme);
+  }
+
+}
+
+customElements.define(SettingsElement.is, SettingsElement);
+

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -13,6 +13,7 @@ the License.
 -->
 
 <link rel="import" href="../../components/auth-panel/auth-panel.html">
+<link rel="import" href="../../components/datalab-settings/datalab-settings.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 
 <link rel="import" href="../../bower_components/app-layout/app-header/app-header.html">
@@ -115,7 +116,9 @@ the License.
     <!--Settings dialog. This shows centered in the middle of the window-->
     <paper-dialog id="settingsDialog" class="dialog" with-backdrop>
       <div class="dialog-title">Settings</div>
-      <div class="dialog-content"></div>
+      <div class="dialog-content">
+        <datalab-settings></datalab-settings>
+      </div>
       <hr>
       <div>
         <paper-button dialog-dismiss raised>Close</paper-button>

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -25,6 +25,7 @@ the License.
         --primary-text-color : var(--primary-fg-color);
       }
       *, *::after, *::before {
+        /* Animate the color changes for when themes are switched. */
         transition: border-color var(--app-animation-duration),
                     color var(--app-animation-duration),
                     background-color var(--app-animation-duration);

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -22,6 +22,7 @@ the License.
         --app-animation-duration: 0.3s;
         --app-content-font-size: 13px;
         --app-content-font-family: 'Roboto', 'Noto', sans-serif;
+        --primary-text-color : var(--primary-fg-color);
       }
       hr {
         border-left: none;

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -24,6 +24,11 @@ the License.
         --app-content-font-family: 'Roboto', 'Noto', sans-serif;
         --primary-text-color : var(--primary-fg-color);
       }
+      *, *::after, *::before {
+        transition: border-color var(--app-animation-duration),
+                    color var(--app-animation-duration),
+                    background-color var(--app-animation-duration);
+      }
       hr {
         border-left: none;
         border-right: none;

--- a/sources/web/datalab/polymer/index.html
+++ b/sources/web/datalab/polymer/index.html
@@ -45,6 +45,16 @@ the License.
         min-width: 470px;
       }
     </style>
+    <script>
+      document.addEventListener('ThemeChanged', () => {
+        // Change the style element's href to trigger the browser to reload it.
+        const cssElement = document.querySelector('#themeStylesheet');
+        if (cssElement) {
+          const sheetAddress = cssElement.href + "?v=" + Date.now()
+          cssElement.setAttribute('href', sheetAddress);
+        }
+      });
+    </script>
     <datalab-app></datalab-app>
   </body>
 </html>

--- a/sources/web/datalab/polymer/index.html
+++ b/sources/web/datalab/polymer/index.html
@@ -27,7 +27,7 @@ the License.
     </script>
     <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script>
     <link rel="import" href="components/datalab-app/datalab-app.html">
-    <link rel="stylesheet" href="index.css">
+    <link id="themeStylesheet" rel="stylesheet" href="index.css">
   </head>
   <body>
     <style is="custom-style">

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -263,6 +263,18 @@ class ApiManager {
     return ApiManager._xhrAsync('/_settings');
   }
 
+  /**
+   * Sets a user setting.
+   * @param setting name of the setting to change.
+   * @param value new setting value.
+   */
+  static setUserSetting(setting: string, value: string) {
+    const xhrOptions: XhrOptions = {
+      method: 'POST',
+    };
+    return ApiManager._xhrAsync('/_settings?key=' + setting + '&value=' + value, xhrOptions);
+  }
+
   /*
    * Copies an item from source to destination. Item name collisions at the destination
    * are handled by Jupyter.

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -281,7 +281,8 @@ class ApiManager {
     const xhrOptions: XhrOptions = {
       method: 'POST',
     };
-    return ApiManager._xhrAsync('/_settings?key=' + setting + '&value=' + value, xhrOptions);
+    const requestUrl = '/_settings?key=' + setting + '&value=' + value;
+    return ApiManager._sendRequestAsync(requestUrl, xhrOptions);
   }
 
   /*


### PR DESCRIPTION
This change adds a settings panel element, and adds the first setting to it for switching themes.

Note that settings are now loaded twice from the backend, so next we'll need a centralized cache for user and app settings. I'll do that as a separate change.

![image](https://user-images.githubusercontent.com/1424661/27756482-b6a91b50-5dac-11e7-9895-bed2cf2dd69f.png)
