### PR TITLE
[Polymer UI] Add a settings cache

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -83,4 +83,5 @@ the License.
   </template>
 </dom-module>
 
+<script src="../../modules/SettingsManager.js"></script>
 <script src="datalab-app.js"></script>

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -135,7 +135,7 @@ class FilesElement extends Polymer.Element {
     super.ready();
 
     // Get the last startup path.
-    ApiManager.getUserSettings()
+    SettingsManager.getUserSettingsAsync(true /*forceRefresh*/)
       .then((settings: common.UserSettings) => {
         if (settings.startuppath) {
           let path = settings.startuppath;

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -44,14 +44,14 @@ class SettingsElement extends Polymer.Element {
     super.ready();
 
     // TODO: add a cache for user/app settings and call it here instead.
-    ApiManager.getUserSettings()
+    SettingsManager.getUserSettingsAsync(true /*forceRefresh*/)
       .then((settings: common.UserSettings) => {
         this.theme = settings.theme;
       });
   }
 
   _themeChanged() {
-    return ApiManager.setUserSetting('theme', this.theme)
+    return SettingsManager.setUserSettingAsync('theme', this.theme)
       .then(() => document.dispatchEvent(new Event('ThemeChanged')));
   }
 

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -123,6 +123,16 @@ class ApiManager {
   static readonly basepathApiUrl = '/api/basepath';
 
   /**
+   * URL for user settings
+   */
+  static readonly userSettingsUrl = '/_settings';
+
+  /**
+   * URL for app settings
+   */
+  static readonly appSettingsUrl = '/api/settings';
+
+  /**
    * A promise to return a basepath.
    */
   static _basepathPromise: Promise<string>;
@@ -139,7 +149,7 @@ class ApiManager {
     const xhrOptions: XhrOptions = {
       noCache: true,
     };
-    return <Promise<Session[]>>ApiManager. _sendRequestAsync(this.sessionsApiUrl, xhrOptions);
+    return <Promise<Session[]>>ApiManager.sendRequestAsync(this.sessionsApiUrl, xhrOptions);
   }
 
   /**
@@ -150,7 +160,7 @@ class ApiManager {
       method: 'DELETE',
       successCode: 204,
     };
-    return ApiManager._sendRequestAsync(ApiManager.sessionsApiUrl + '/' + sessionId, xhrOptions);
+    return ApiManager.sendRequestAsync(ApiManager.sessionsApiUrl + '/' + sessionId, xhrOptions);
   }
 
   /**
@@ -164,7 +174,7 @@ class ApiManager {
     const xhrOptions: XhrOptions = {
       noCache: true,
     };
-    return <Promise<JupyterFile>>ApiManager. _sendRequestAsync(this.contentApiUrl + '/' + path, xhrOptions);
+    return <Promise<JupyterFile>>ApiManager.sendRequestAsync(this.contentApiUrl + '/' + path, xhrOptions);
   }
 
   /**
@@ -214,7 +224,7 @@ class ApiManager {
         ext: 'ipynb'
       }),
     };
-    let createPromise = ApiManager. _sendRequestAsync(ApiManager.contentApiUrl, xhrOptions);
+    let createPromise = ApiManager.sendRequestAsync(ApiManager.contentApiUrl, xhrOptions);
 
     // If a path is provided for naming the new item, request the rename, and
     // delete it if failed.
@@ -248,7 +258,7 @@ class ApiManager {
       }),
     };
 
-    return ApiManager. _sendRequestAsync(oldPath, xhrOptions);
+    return ApiManager.sendRequestAsync(oldPath, xhrOptions);
   }
 
   /**
@@ -262,27 +272,7 @@ class ApiManager {
       successCode: 204,
     };
 
-    return ApiManager. _sendRequestAsync(path, xhrOptions);
-  }
-
-  /**
-   * Gets the user settings JSON from the server.
-   */
-  static getUserSettings() {
-    return ApiManager. _sendRequestAsync('/_settings');
-  }
-
-  /**
-   * Sets a user setting.
-   * @param setting name of the setting to change.
-   * @param value new setting value.
-   */
-  static setUserSetting(setting: string, value: string) {
-    const xhrOptions: XhrOptions = {
-      method: 'POST',
-    };
-    const requestUrl = '/_settings?key=' + setting + '&value=' + value;
-    return ApiManager._sendRequestAsync(requestUrl, xhrOptions);
+    return ApiManager.sendRequestAsync(path, xhrOptions);
   }
 
   /*
@@ -301,7 +291,7 @@ class ApiManager {
       })
     };
 
-    return ApiManager. _sendRequestAsync(destinationDirectory, xhrOptions);
+    return ApiManager.sendRequestAsync(destinationDirectory, xhrOptions);
   }
 
   /**
@@ -311,14 +301,14 @@ class ApiManager {
     const xhrOptions: XhrOptions = {
       method: 'POST',
     }
-    return ApiManager. _sendRequestAsync(ApiManager.terminalApiUrl, xhrOptions);
+    return ApiManager.sendRequestAsync(ApiManager.terminalApiUrl, xhrOptions);
   }
 
   /**
    * Returns a list of active terminal sessions.
    */
   static listTerminalsAsync() {
-    return ApiManager. _sendRequestAsync(ApiManager.terminalApiUrl);
+    return ApiManager.sendRequestAsync(ApiManager.terminalApiUrl);
   }
 
   /**
@@ -382,7 +372,7 @@ class ApiManager {
    * base path. This method returns immediately with a promise
    * that resolves with the parsed object when the request completes.
    */
-  static  _sendRequestAsync(url: string, options?: XhrOptions) {
+  static sendRequestAsync(url: string, options?: XhrOptions) {
     return ApiManager.getBasePath()
       .then((base:string) => ApiManager. _xhrJsonAsync(base + url, options));
   }

--- a/sources/web/datalab/polymer/modules/GapiManager.ts
+++ b/sources/web/datalab/polymer/modules/GapiManager.ts
@@ -92,7 +92,7 @@ class GapiManager {
    * This will change once we figure out how we want to do it.
    */
   static _loadClientId() {
-    return ApiManager.getUserSettings()
+    return SettingsManager.getUserSettingsAsync()
       .then((settings: common.UserSettings) => {
         if (settings.oauth2ClientId) {
           GapiManager.clientId = settings.oauth2ClientId;

--- a/sources/web/datalab/polymer/modules/SettingsManager.ts
+++ b/sources/web/datalab/polymer/modules/SettingsManager.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+let userSettings: common.UserSettings;
+let appSettings: common.AppSettings;
+
+class SettingsManager {
+
+  static getUserSettingsAsync(forceRefresh?: boolean) {
+    if (!userSettings || forceRefresh === true) {
+      return SettingsManager._getUserSettingsAsync()
+        .then((settings: common.UserSettings) => {
+          userSettings = settings;
+          return userSettings;
+        });
+    } else {
+      return Promise.resolve(userSettings);
+    }
+  }
+
+  static getAppSettingsAsync(forceRefresh?: boolean) {
+    if (!appSettings || forceRefresh === true) {
+      return SettingsManager._getAppSettingsAsync()
+        .then((settings: common.AppSettings) => {
+          appSettings = settings;
+          return appSettings;
+        });
+    } else {
+      return Promise.resolve(appSettings);
+    }
+  }
+
+  /**
+   * Sets a user setting.
+   * @param setting name of the setting to change.
+   * @param value new setting value.
+   */
+  static setUserSettingAsync(setting: string, value: string) {
+    const xhrOptions: XhrOptions = {
+      method: 'POST',
+    };
+    const requestUrl = ApiManager.userSettingsUrl + '?key=' + setting + '&value=' + value;
+    return ApiManager.sendRequestAsync(requestUrl, xhrOptions);
+  }
+
+  /**
+   * Gets the user settings JSON from the server.
+   */
+  static _getUserSettingsAsync() {
+    return ApiManager.sendRequestAsync(ApiManager.userSettingsUrl);
+  }
+
+
+  /**
+   * Gets the app settings JSON from the server.
+   */
+  static _getAppSettingsAsync() {
+    return ApiManager.sendRequestAsync(ApiManager.appSettingsUrl);
+  }
+
+
+}

--- a/sources/web/datalab/polymer/modules/SettingsManager.ts
+++ b/sources/web/datalab/polymer/modules/SettingsManager.ts
@@ -15,8 +15,16 @@
 let userSettings: common.UserSettings;
 let appSettings: common.AppSettings;
 
+/**
+ * Handles API calls related to app/user settings, and manages a local cached copy
+ * of the settings to avoid duplicate API calls.
+ */
 class SettingsManager {
 
+  /**
+   * Returns the user settings object, optionally after refreshing it from the backend
+   * @param forceRefresh whether the settings cache should be refreshed before returning
+   */
   static getUserSettingsAsync(forceRefresh?: boolean) {
     if (!userSettings || forceRefresh === true) {
       return SettingsManager._getUserSettingsAsync()
@@ -29,6 +37,10 @@ class SettingsManager {
     }
   }
 
+  /**
+   * Returns the app settings object, optionally after refreshing it from the backend
+   * @param forceRefresh whether the settings cache should be refreshed before returning
+   */
   static getAppSettingsAsync(forceRefresh?: boolean) {
     if (!appSettings || forceRefresh === true) {
       return SettingsManager._getAppSettingsAsync()
@@ -68,6 +80,5 @@ class SettingsManager {
   static _getAppSettingsAsync() {
     return ApiManager.sendRequestAsync(ApiManager.appSettingsUrl);
   }
-
 
 }


### PR DESCRIPTION
This PR adds a `SettingsManager` class that caches app and user settings so that duplicate API requests can be avoided.