### PR TITLE
[Polymer UI] Make design more responsive with screen width

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -71,7 +71,8 @@ the License.
           <datalab-sidebar page={{page}}></datalab-sidebar>
         </div>
         <div class="datalab-main-content">
-          <iron-pages selected="{{page}}" attr-for-selected="name" fallback-selection="files">
+          <iron-pages id="pages" selected="{{page}}" attr-for-selected="name"
+                      fallback-selection="files">
             <datalab-files name="files"></datalab-files>
             <datalab-sessions name="sessions"></datalab-sessions>
             <datalab-terminal name="terminal"></datalab-terminal>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -50,7 +50,7 @@ the License.
       iron-pages {
         height: 100%;
       }
-      @media only screen and (max-width: 970px) {
+      @media only screen and (max-width: 800px) {
         .datalab-sidebar {
           width: 60px;
         }

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -42,11 +42,21 @@ class DatalabAppElement extends Polymer.Element {
    */
   public routeData: Object;
 
+  private _boundResizeHandler: EventListenerObject;
+
   constructor() {
     super();
 
     // Set the pattern once to be the current document pathname.
     this.rootPattern = (new URL(this.rootPath)).pathname;
+
+    this._boundResizeHandler = this._resizeHandler.bind(this);
+    window.addEventListener('resize', this._boundResizeHandler, true);
+
+    // Will be called after the custom element is done rendering.
+    window.addEventListener('WebComponentsReady', () => {
+      this._resizeHandler();
+    });
   }
 
   static get is() { return 'datalab-app'; }
@@ -72,6 +82,15 @@ class DatalabAppElement extends Polymer.Element {
   }
 
   /**
+   * Called when the element is detached from the DOM. Cleans up event listeners.
+   */
+  disconnectedCallback() {
+    if (this._boundResizeHandler) {
+      window.removeEventListener('resize', this._boundResizeHandler);
+    }
+  }
+
+  /**
    * On changes to the current route, explicitly sets the page property
    * so it can be used by other elements.
    */
@@ -94,6 +113,13 @@ class DatalabAppElement extends Polymer.Element {
     Polymer.importHref(resolvedPageUrl, undefined, undefined, true);
 
     // If the new page has a resize handler, call it.
+    this._resizeHandler();
+  }
+
+  /**
+   * If the selected page has a resize handler, calls it.
+   */
+  _resizeHandler() {
     const selectedPage = this.$.pages.selectedItem;
     if (selectedPage && selectedPage._resizeHandler) {
       selectedPage._resizeHandler();

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -54,9 +54,7 @@ class DatalabAppElement extends Polymer.Element {
     window.addEventListener('resize', this._boundResizeHandler, true);
 
     // Will be called after the custom element is done rendering.
-    window.addEventListener('WebComponentsReady', () => {
-      this._resizeHandler();
-    });
+    window.addEventListener('WebComponentsReady', this._boundResizeHandler, true);
   }
 
   static get is() { return 'datalab-app'; }
@@ -87,6 +85,7 @@ class DatalabAppElement extends Polymer.Element {
   disconnectedCallback() {
     if (this._boundResizeHandler) {
       window.removeEventListener('resize', this._boundResizeHandler);
+      window.removeEventListener('WebComponentsReady', this._boundResizeHandler);
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -92,6 +92,12 @@ class DatalabAppElement extends Polymer.Element {
     const subpath = 'datalab-' + page
     const resolvedPageUrl = this.resolveUrl('../' + subpath + '/' + subpath + '.html');
     Polymer.importHref(resolvedPageUrl, undefined, undefined, true);
+
+    // If the new page has a resize handler, call it.
+    const selectedPage = this.$.pages.selectedItem;
+    if (selectedPage && selectedPage._resizeHandler) {
+      selectedPage._resizeHandler();
+    }
   }
 
 }

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -40,13 +40,13 @@ the License.
         background-color: var(--secondary-bg-color);
         border-bottom: 1px solid var(--border-color);
       }
-      #altAddToolbarToggle, #altFileOpsToolbarToggle {
+      #altAddToolbarToggle, #altUpdateToolbarToggle {
         display: none;
       }
-      #altAddToolbarContainer, #altFileOpsToolbarContainer {
+      #altAddToolbarContainer, #altUpdateToolbarContainer {
         position: relative;
       }
-      #altAddToolbar, #altFileOpsToolbar {
+      #altAddToolbar, #altUpdateToolbar {
         display: flex;
         flex-direction: column;
         align-items: flex-start;
@@ -59,7 +59,7 @@ the License.
         min-width: 150px;
         box-shadow: -3px 3px 10px -3px rgba(0, 0, 0, 0.3);
       }
-      #altAddToolbar > *, #altFileOpsToolbar > * {
+      #altAddToolbar > *, #altUpdateToolbar > * {
         padding: 10px 0px;
         margin: 0px;
         width: 100%;
@@ -224,8 +224,8 @@ the License.
         </paper-dialog>
       </span>
 
-      <!--Default File Operations toolbar, contains buttons to interact with files/folders-->
-      <span id="fileOpsToolbar">
+      <!--Default Update toolbar, contains buttons to modify files/folders-->
+      <span id="updateToolbar">
         <paper-button class="toolbar-button">
           <iron-icon icon="file-upload"></iron-icon>
           <span>Upload</span>
@@ -255,13 +255,13 @@ the License.
         </paper-button>
       </span>
 
-      <!--Alternative File Operations toolbar, shows up when toolbar is too small-->
-      <span id="altFileOpsToolbarContainer">
-        <paper-button id="altFileOpsToolbarToggle" class="toolbar-button"
-                      on-click="_toggleAltFileOpsToolbar">
+      <!--Alternative Update toolbar, shows up when toolbar is too small-->
+      <span id="altUpdateToolbarContainer">
+        <paper-button id="altUpdateToolbarToggle" class="toolbar-button"
+                      on-click="_toggleAltUpdateToolbar">
           <iron-icon icon="more-horiz"></iron-icon>
         </paper-button>
-        <paper-dialog id="altFileOpsToolbar">
+        <paper-dialog id="altUpdateToolbar">
         </paper-dialog>
       </span>
 

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -71,7 +71,8 @@ the License.
         border-radius: 0px;
       }
       .toolbar-button > iron-icon {
-        width: 20px;
+        min-width: 20px;
+        max-width: 20px;
         padding-right: 5px;
       }
       .toolbar-button > span {
@@ -112,10 +113,15 @@ the License.
         background-color: var(--primary-bg-color);
       }
       #detailsPane {
-        min-width: var(--details-pane-width);
-        max-width: var(--details-pane-width);
         background-color: var(--secondary-bg-color);
         box-shadow: inset 4px 0px 10px -3px rgba(0, 0, 0, 0.1);
+        transition: width var(--app-animation-duration);
+      }
+      .details-pane-enabled--true {
+        width: var(--details-pane-width);
+      }
+      .details-pane-enabled--false {
+        width: 0px;
       }
       .vseparator {
         display: inline;
@@ -296,8 +302,8 @@ the License.
       <!--File listing-->
       <div class="files-container">
         <item-list id="files" hide-header$="{{small}}" disable-selection$="{{small}}"></item-list>
-        <details-pane id="detailsPane" file="{{selectedFile}}"
-                      hidden="{{!_isDetailsPaneEnabled}}" active="{{_isDetailsPaneEnabled}}">
+        <details-pane id="detailsPane" file="{{selectedFile}}" active="{{_isDetailsPaneEnabled}}"
+                      class$="details-pane-enabled--{{_isDetailsPaneEnabled}}">
         </details-pane>
         </div>
       </div>

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -21,6 +21,7 @@ the License.
 
 <link rel="import" href="../../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../../bower_components/iron-icons/editor-icons.html">
+<link rel="import" href="../../bower_components/iron-icons/hardware-icons.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../bower_components/paper-progress/paper-progress.html">
 
@@ -39,6 +40,26 @@ the License.
         background-color: var(--secondary-bg-color);
         border-bottom: 1px solid var(--border-color);
       }
+      #altAddToolbarToggle, #fileOpsDropdownToggle {
+        display: none;
+      }
+      #altAddToolbar, #fileOpsDropdown {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        background-color: var(--primary-bg-color);
+        color: var(--primary-fg-color);
+        position: absolute;
+        margin: 0px;
+        padding: 10px;
+        min-width: 150px;
+        box-shadow: -3px 3px 10px -3px rgba(0, 0, 0, 0.3);
+      }
+      #altAddToolbar > *, #fileOpsDropdown > * {
+        padding: 10px 0px;
+        margin: 0px;
+        width: 100%;
+      }
       .toolbar-button {
         color: var(--primary-fg-color);
         margin: 4px;
@@ -48,6 +69,9 @@ the License.
       .toolbar-button > iron-icon {
         width: 20px;
         padding-right: 5px;
+      }
+      .toolbar-button > span {
+        width: 70%;
       }
       .toolbar-button[disabled] {
         color: var(--disabled-fg-color);
@@ -162,18 +186,30 @@ the License.
     <!--Toolbar with buttons such as +Notebook, +Folder... etc-->
     <!--TODO: [yebrahim] Make these buttons do stuff-->
     <div id="toolbar" hidden$="{{small}}">
-      <paper-button class="toolbar-button" on-click="_createNewNotebook">
-        <iron-icon icon="add-box"></iron-icon>
-        <span>Notebook</span>
-      </paper-button>
-      <paper-button class="toolbar-button" on-click="_createNewFile">
-        <iron-icon icon="add-box"></iron-icon>
-        <span>File</span>
-      </paper-button>
-      <paper-button class="toolbar-button" on-click="_createNewDirectory">
-        <iron-icon icon="add-box"></iron-icon>
-        <span>Folder</span>
-      </paper-button>
+      <span>
+        <paper-button id="altAddToolbarToggle" class="toolbar-button"
+                      on-click="_toggleAltAddToolbar">
+          <iron-icon icon="add-box"></iron-icon>
+          <span>New</span>
+          <iron-icon icon="hardware:keyboard-arrow-down"></iron-icon>
+        </paper-button>
+        <paper-dialog id="altAddToolbar">
+        </paper-dialog>
+      </span>
+      <span id="addToolbar">
+        <paper-button class="toolbar-button" on-click="_createNewNotebook">
+          <iron-icon icon="add-box"></iron-icon>
+          <span>Notebook</span>
+        </paper-button>
+        <paper-button class="toolbar-button" on-click="_createNewFile">
+          <iron-icon icon="add-box"></iron-icon>
+          <span>File</span>
+        </paper-button>
+        <paper-button class="toolbar-button" on-click="_createNewDirectory">
+          <iron-icon icon="add-box"></iron-icon>
+          <span>Folder</span>
+        </paper-button>
+      </span>
       <paper-button class="toolbar-button">
         <iron-icon icon="file-upload"></iron-icon>
         <span>Upload</span>

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -40,22 +40,26 @@ the License.
         background-color: var(--secondary-bg-color);
         border-bottom: 1px solid var(--border-color);
       }
-      #altAddToolbarToggle, #fileOpsDropdownToggle {
+      #altAddToolbarToggle, #altFileOpsToolbarToggle {
         display: none;
       }
-      #altAddToolbar, #fileOpsDropdown {
+      #altAddToolbarContainer, #altFileOpsToolbarContainer {
+        position: relative;
+      }
+      #altAddToolbar, #altFileOpsToolbar {
         display: flex;
         flex-direction: column;
         align-items: flex-start;
         background-color: var(--primary-bg-color);
         color: var(--primary-fg-color);
         position: absolute;
+        left: 0px;
         margin: 0px;
         padding: 10px;
         min-width: 150px;
         box-shadow: -3px 3px 10px -3px rgba(0, 0, 0, 0.3);
       }
-      #altAddToolbar > *, #fileOpsDropdown > * {
+      #altAddToolbar > *, #altFileOpsToolbar > * {
         padding: 10px 0px;
         margin: 0px;
         width: 100%;
@@ -183,19 +187,9 @@ the License.
       }
     </style>
 
-    <!--Toolbar with buttons such as +Notebook, +Folder... etc-->
-    <!--TODO: [yebrahim] Make these buttons do stuff-->
     <div id="toolbar" hidden$="{{small}}">
-      <span>
-        <paper-button id="altAddToolbarToggle" class="toolbar-button"
-                      on-click="_toggleAltAddToolbar">
-          <iron-icon icon="add-box"></iron-icon>
-          <span>New</span>
-          <iron-icon icon="hardware:keyboard-arrow-down"></iron-icon>
-        </paper-button>
-        <paper-dialog id="altAddToolbar">
-        </paper-dialog>
-      </span>
+
+      <!--Default Add toolbar, contains Add buttons for notebook, file, and folder-->
       <span id="addToolbar">
         <paper-button class="toolbar-button" on-click="_createNewNotebook">
           <iron-icon icon="add-box"></iron-icon>
@@ -210,33 +204,60 @@ the License.
           <span>Folder</span>
         </paper-button>
       </span>
-      <paper-button class="toolbar-button">
-        <iron-icon icon="file-upload"></iron-icon>
-        <span>Upload</span>
-      </paper-button>
-      <paper-button class="toolbar-button" on-click="_copySelectedItem"
-                    disabled$={{!selectedFile}}>
-        <iron-icon icon="content-copy"></iron-icon>
-        <span>Copy</span>
-      </paper-button>
-      <paper-button class="toolbar-button" on-click="_moveSelectedItem"
-                    disabled$={{!selectedFile}}>
-        <iron-icon icon="redo"></iron-icon>
-        <span>Move</span>
-      </paper-button>
-      <paper-button class="toolbar-button" on-click="_renameSelectedItem"
-                    disabled$={{!selectedFile}}>
-        <iron-icon icon="editor:border-color"></iron-icon>
-        <span>Rename</span>
-      </paper-button>
-      <!--TODO: Delete operation supports deleting multiple files, but we'll
-      only enable the button when one file is selected for now, until we get
-      the group moving/copying functionality too-->
-      <paper-button class="toolbar-button" on-click="_deleteSelectedItems"
-                    disabled$={{!selectedFile}}>
-        <iron-icon icon="delete"></iron-icon>
-        <span>Delete</span>
-      </paper-button>
+
+      <!--Alternative Add toolbar, shows up when toolbar is too small-->
+      <span id="altAddToolbarContainer">
+        <paper-button id="altAddToolbarToggle" class="toolbar-button"
+                      on-click="_toggleAltAddToolbar">
+          <iron-icon icon="add-box"></iron-icon>
+          <span>New</span>
+          <iron-icon icon="hardware:keyboard-arrow-down"></iron-icon>
+        </paper-button>
+        <paper-dialog id="altAddToolbar">
+        </paper-dialog>
+      </span>
+
+      <!--Default File Operations toolbar, contains buttons to interact with files/folders-->
+      <span id="fileOpsToolbar">
+        <paper-button class="toolbar-button">
+          <iron-icon icon="file-upload"></iron-icon>
+          <span>Upload</span>
+        </paper-button>
+        <paper-button class="toolbar-button" on-click="_copySelectedItem"
+                      disabled$={{!selectedFile}}>
+          <iron-icon icon="content-copy"></iron-icon>
+          <span>Copy</span>
+        </paper-button>
+        <paper-button class="toolbar-button" on-click="_moveSelectedItem"
+                      disabled$={{!selectedFile}}>
+          <iron-icon icon="redo"></iron-icon>
+          <span>Move</span>
+        </paper-button>
+        <paper-button class="toolbar-button" on-click="_renameSelectedItem"
+                      disabled$={{!selectedFile}}>
+          <iron-icon icon="editor:border-color"></iron-icon>
+          <span>Rename</span>
+        </paper-button>
+        <!--TODO: Delete operation supports deleting multiple files, but we'll
+        only enable the button when one file is selected for now, until we get
+        the group moving/copying functionality too-->
+        <paper-button class="toolbar-button" on-click="_deleteSelectedItems"
+                      disabled$={{!selectedFile}}>
+          <iron-icon icon="delete"></iron-icon>
+          <span>Delete</span>
+        </paper-button>
+      </span>
+
+      <!--Alternative File Operations toolbar, shows up when toolbar is too small-->
+      <span id="altFileOpsToolbarContainer">
+        <paper-button id="altFileOpsToolbarToggle" class="toolbar-button"
+                      on-click="_toggleAltFileOpsToolbar">
+          <iron-icon icon="more-horiz"></iron-icon>
+        </paper-button>
+        <paper-dialog id="altFileOpsToolbar">
+        </paper-dialog>
+      </span>
+
     </div>
 
     <div id="file-picker" class$="file-picker-small--{{small}}">

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -50,7 +50,7 @@ the License.
         display: flex;
         flex-direction: column;
         align-items: flex-start;
-        background-color: var(--primary-bg-color);
+        background-color: var(--secondary-bg-color);
         color: var(--primary-fg-color);
         position: absolute;
         left: 0px;

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -155,6 +155,7 @@ the License.
         border: none;
       }
       #breadcrumb div a:before, #breadcrumb div a:after {
+        color: var(--primary-bg-color);
         content: "";
         position: absolute;
         border: 0 solid var(--primary-bg-color);

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -62,7 +62,6 @@ class FilesElement extends Polymer.Element {
   private _fileListRefreshIntervalHandle: number;
   private _currentCrumbs: Array<string>;
   private _isDetailsPaneToggledOn: Boolean;
-  private _boundResizeHandler: EventListenerObject;
 
   static readonly _deleteListLimit = 10;
 
@@ -172,14 +171,6 @@ class FilesElement extends Polymer.Element {
 
     // For a small file/directory picker, we don't need to show the status.
     this.$.files.columns = this.small ? ['Name'] : ['Name', 'Status'];
-
-    this._boundResizeHandler = this._resizeHandler.bind(this);
-    window.addEventListener('resize', this._boundResizeHandler, true);
-
-    // Will be called after the custom element is done rendering.
-    window.addEventListener('WebComponentsReady', () => {
-      this._resizeHandler();
-    });
   }
 
   disconnectedCallback() {

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -625,7 +625,7 @@ class FilesElement extends Polymer.Element {
       this.$.altAddToolbar.close();
     }
 
-    // Collapse the file operations buttons on the toolbar
+    // Collapse the update buttons on the toolbar
     if (width < this._updateToolbarCollapseThreshold) {
       Utils.moveElementChildren(this.$.updateToolbar, this.$.altUpdateToolbar);
       this.$.altUpdateToolbarToggle.style.display = "inline-flex";

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -62,6 +62,9 @@ class FilesElement extends Polymer.Element {
   private _fileListRefreshIntervalHandle: number;
   private _currentCrumbs: Array<string>;
   private _isDetailsPaneToggledOn: Boolean;
+  private _addToolbarCollapseThreshold = 800;
+  private _updateToolbarCollapseThreshold = 600;
+  private _detailsPaneCollapseThreshold = 600;
 
   static readonly _deleteListLimit = 10;
 
@@ -602,8 +605,8 @@ class FilesElement extends Polymer.Element {
     this.$.altAddToolbar.toggle();
   }
 
-  _toggleAltFileOpsToolbar() {
-      this.$.altFileOpsToolbar.toggle();
+  _toggleAltUpdateToolbar() {
+    this.$.altUpdateToolbar.toggle();
   }
 
   /**
@@ -613,7 +616,7 @@ class FilesElement extends Polymer.Element {
   _resizeHandler() {
     const width = this.$.toolbar.clientWidth;
     // Collapse the add buttons on the toolbar
-    if (width < 800) {
+    if (width < this._addToolbarCollapseThreshold) {
       Utils.moveElementChildren(this.$.addToolbar, this.$.altAddToolbar);
       this.$.altAddToolbarToggle.style.display = "inline-flex";
     } else {
@@ -623,17 +626,17 @@ class FilesElement extends Polymer.Element {
     }
 
     // Collapse the file operations buttons on the toolbar
-    if (width < 600) {
-      Utils.moveElementChildren(this.$.fileOpsToolbar, this.$.altFileOpsToolbar);
-      this.$.altFileOpsToolbarToggle.style.display = "inline-flex";
+    if (width < this._updateToolbarCollapseThreshold) {
+      Utils.moveElementChildren(this.$.updateToolbar, this.$.altUpdateToolbar);
+      this.$.altUpdateToolbarToggle.style.display = "inline-flex";
     } else {
-      Utils.moveElementChildren(this.$.altFileOpsToolbar, this.$.fileOpsToolbar);
-      this.$.altFileOpsToolbarToggle.style.display = "none";
-      this.$.altFileOpsToolbar.close();
+      Utils.moveElementChildren(this.$.altUpdateToolbar, this.$.updateToolbar);
+      this.$.altUpdateToolbarToggle.style.display = "none";
+      this.$.altUpdateToolbar.close();
     }
 
     // Collapse the details pane
-    if (width < 600) {
+    if (width < this._detailsPaneCollapseThreshold) {
       this._isDetailsPaneToggledOn = false;
     }
   }

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -62,6 +62,7 @@ class FilesElement extends Polymer.Element {
   private _fileListRefreshIntervalHandle: number;
   private _currentCrumbs: Array<string>;
   private _isDetailsPaneToggledOn: Boolean;
+  private _boundResizeHandler: EventListenerObject;
 
   static readonly _deleteListLimit = 10;
 
@@ -171,6 +172,11 @@ class FilesElement extends Polymer.Element {
 
     // For a small file/directory picker, we don't need to show the status.
     this.$.files.columns = this.small ? ['Name'] : ['Name', 'Status'];
+
+    this._boundResizeHandler = this._resizeHandler.bind(this);
+    window.addEventListener('resize', this._boundResizeHandler, true);
+
+    this._resizeHandler();
   }
 
   disconnectedCallback() {
@@ -595,6 +601,29 @@ class FilesElement extends Polymer.Element {
         });
     } else {
       return Promise.resolve(null);
+    }
+  }
+
+  _toggleAltAddToolbar() {
+    this.$.altAddToolbar.toggle();
+  }
+
+  _toggleAltFileOpsToolbar() {
+      this.$.altFileOpsToolbar.toggle();
+  }
+
+  _resizeHandler() {
+    const width = this.$.toolbar.clientWidth;
+    if (width < 800) {
+      while (this.$.addToolbar.firstChild) {
+        this.$.altAddToolbar.appendChild(this.$.addToolbar.firstChild);
+      }
+      this.$.altAddToolbarToggle.style.display = "inline-flex";
+    } else {
+      while (this.$.altAddToolbar.firstChild) {
+        this.$.addToolbar.appendChild(this.$.altAddToolbar.firstChild);
+      }
+      this.$.altAddToolbarToggle.style.display = "none";
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -623,6 +623,7 @@ class FilesElement extends Polymer.Element {
     } else {
       Utils.moveElementChildren(this.$.altAddToolbar, this.$.addToolbar);
       this.$.altAddToolbarToggle.style.display = "none";
+      this.$.altAddToolbar.close();
     }
 
     if (width < 600) {
@@ -631,6 +632,7 @@ class FilesElement extends Polymer.Element {
     } else {
       Utils.moveElementChildren(this.$.altFileOpsToolbar, this.$.fileOpsToolbar);
       this.$.altFileOpsToolbarToggle.style.display = "none";
+      this.$.altFileOpsToolbar.close();
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -606,8 +606,13 @@ class FilesElement extends Polymer.Element {
       this.$.altFileOpsToolbar.toggle();
   }
 
+  /**
+   * Called on window.resize, collapses elements to keep the element usable
+   * on small screens.
+   */
   _resizeHandler() {
     const width = this.$.toolbar.clientWidth;
+    // Collapse the add buttons on the toolbar
     if (width < 800) {
       Utils.moveElementChildren(this.$.addToolbar, this.$.altAddToolbar);
       this.$.altAddToolbarToggle.style.display = "inline-flex";
@@ -617,6 +622,7 @@ class FilesElement extends Polymer.Element {
       this.$.altAddToolbar.close();
     }
 
+    // Collapse the file operations buttons on the toolbar
     if (width < 600) {
       Utils.moveElementChildren(this.$.fileOpsToolbar, this.$.altFileOpsToolbar);
       this.$.altFileOpsToolbarToggle.style.display = "inline-flex";
@@ -624,6 +630,11 @@ class FilesElement extends Polymer.Element {
       Utils.moveElementChildren(this.$.altFileOpsToolbar, this.$.fileOpsToolbar);
       this.$.altFileOpsToolbarToggle.style.display = "none";
       this.$.altFileOpsToolbar.close();
+    }
+
+    // Collapse the details pane
+    if (width < 600) {
+      this._isDetailsPaneToggledOn = false;
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -176,7 +176,10 @@ class FilesElement extends Polymer.Element {
     this._boundResizeHandler = this._resizeHandler.bind(this);
     window.addEventListener('resize', this._boundResizeHandler, true);
 
-    this._resizeHandler();
+    // Will be called after the custom element is done rendering.
+    window.addEventListener('WebComponentsReady', () => {
+      this._resizeHandler();
+    });
   }
 
   disconnectedCallback() {
@@ -615,15 +618,19 @@ class FilesElement extends Polymer.Element {
   _resizeHandler() {
     const width = this.$.toolbar.clientWidth;
     if (width < 800) {
-      while (this.$.addToolbar.firstChild) {
-        this.$.altAddToolbar.appendChild(this.$.addToolbar.firstChild);
-      }
+      Utils.moveElementChildren(this.$.addToolbar, this.$.altAddToolbar);
       this.$.altAddToolbarToggle.style.display = "inline-flex";
     } else {
-      while (this.$.altAddToolbar.firstChild) {
-        this.$.addToolbar.appendChild(this.$.altAddToolbar.firstChild);
-      }
+      Utils.moveElementChildren(this.$.altAddToolbar, this.$.addToolbar);
       this.$.altAddToolbarToggle.style.display = "none";
+    }
+
+    if (width < 600) {
+      Utils.moveElementChildren(this.$.fileOpsToolbar, this.$.altFileOpsToolbar);
+      this.$.altFileOpsToolbarToggle.style.display = "inline-flex";
+    } else {
+      Utils.moveElementChildren(this.$.altFileOpsToolbar, this.$.fileOpsToolbar);
+      this.$.altFileOpsToolbarToggle.style.display = "none";
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
@@ -68,7 +68,7 @@ the License.
       .iron-selected > .sidebar-button > * {
         color: var(--selection-fg-color);
       }
-      @media only screen and (max-width: 970px) {
+      @media only screen and (max-width: 800px) {
         .sidebar-button-title {
           opacity: 0;
         }

--- a/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.ts
+++ b/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.ts
@@ -38,7 +38,6 @@ class TerminalElement extends Polymer.Element {
 
   private _xterm: Terminal;
   private _wsConnection: WebSocket;
-  private _boundResizeHandler: EventListenerObject;
   private _charHeight: number;
   private _charWidth: number;
 
@@ -53,9 +52,6 @@ class TerminalElement extends Polymer.Element {
       // makes changing the style simpler, instead of hard-coding these values.
       this._charHeight = this.$.sizeHelper.clientHeight;
       this._charWidth = this.$.sizeHelper.clientWidth / 10; // The element has 10 characters.
-
-      this._boundResizeHandler = this._resizeHandler.bind(this);
-      window.addEventListener('resize', this._boundResizeHandler, true);
 
       // Get the first terminal instance by calling the Jupyter API. If none are returned,
       // start a new one.
@@ -107,15 +103,6 @@ class TerminalElement extends Polymer.Element {
       this._xterm.open(this.$.theTerminal, true);
       this._resizeHandler();
     };
-  }
-
-  /**
-   * Called when the element is detached from the DOM. Cleans up event listeners.
-   */
-  disconnectedCallback() {
-    if (this._boundResizeHandler) {
-      window.removeEventListener('resize', this._boundResizeHandler);
-    }
   }
 
   /**

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -99,5 +99,16 @@ class Utils {
 
     return stampedTemplate;
   }
+
+  /**
+   * Moves all child elements from one element to another.
+   * @param from element whose children to move
+   * @param to destination elements where children will be moved to
+   */
+  static moveElementChildren(from: HTMLElement, to: HTMLElement) {
+    while (from.firstChild) {
+      to.appendChild(from.firstChild);
+    }
+  }
  
 }


### PR DESCRIPTION
This change adds some responsiveness to the `datalab-files` element, by splitting the toolbar into two sets of buttons: Add buttons, and File Operations buttons. Each set collapses separately into a dropdown to save space when the screen is too narrow.

To do this, the parent `datalab-app` element now listens for window size changes, and calls resize handlers on the currently active page. Currently `datalab-files` and `datalab-terminal` have handlers that make use of this event.
The actual collapsing is done in javascript because it moves the buttons dynamically to an alternative dropdown element. I could not get a similar effect just using CSS, let me know if you have any ideas here.

This is what it looks like with the Add toolbar collapsed:
![image](https://user-images.githubusercontent.com/1424661/27875707-0a007ce8-6169-11e7-82bb-107d8d056d92.png)

This is when both toolbars are collapsed:
![image](https://user-images.githubusercontent.com/1424661/27875888-bd60c81a-6169-11e7-8c67-89e7dedf56a9.png)
