### PR TITLE
[Polymer UI] Add timeout interval setting

### DIFF
--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -8,6 +8,7 @@
     "iron-pages": "PolymerElements/iron-pages#^2.0.0",
     "iron-selector": "PolymerElements/iron-selector#^2.0.0",
     "marked": "^0.3.6",
+    "neon-animation": "PolymerElements/neon-animation#^2.0.1",
     "paper-button": "PolymerElements/paper-button#^2.0.0",
     "paper-checkbox": "PolymerElements/paper-checkbox#^2.0.0",
     "paper-dialog": "PolymerElements/paper-dialog#^2.0.0",
@@ -16,11 +17,10 @@
     "paper-item": "PolymerElements/paper-item#^2.0.0",
     "paper-progress": "PolymerElements/paper-progress#^2.0.0",
     "paper-radio-group": "PolymerElements/paper-radio-group#^2.0.0",
+    "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.0",
     "polymer": "Polymer/polymer#^2.0.1",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.9",
-    "xterm.js": "^2.7.0",
-    "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.0",
-    "neon-animation": "PolymerElements/neon-animation#^2.0.1"
+    "xterm.js": "^2.7.0"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0"

--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -19,7 +19,8 @@
     "polymer": "Polymer/polymer#^2.0.1",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.9",
     "xterm.js": "^2.7.0",
-    "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.0"
+    "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.0",
+    "neon-animation": "PolymerElements/neon-animation#^2.0.1"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0"

--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -18,7 +18,8 @@
     "paper-radio-group": "PolymerElements/paper-radio-group#^2.0.0",
     "polymer": "Polymer/polymer#^2.0.1",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.9",
-    "xterm.js": "^2.7.0"
+    "xterm.js": "^2.7.0",
+    "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.0"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0"

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
@@ -14,8 +14,10 @@ the License.
 
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 
-<link rel="import" href="../../bower_components/paper-radio-group/paper-radio-group.html">
+<link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../../bower_components/paper-input/paper-input.html">
+<link rel="import" href="../../bower_components/paper-radio-group/paper-radio-group.html">
+<link rel="import" href="../../bower_components/paper-tooltip/paper-tooltip.html">
 
 <dom-module id="datalab-settings">
   <template>
@@ -27,6 +29,28 @@ the License.
         padding: 15px;
         border-bottom: 1px solid var(--border-color);
       }
+      .input-container {
+        display: flex;
+        height: 35px;
+      }
+      .input-container > * {
+        margin-right: 10px;
+      }
+      .input-box {
+        width: 150px;
+        --primary-text-color: var(--primary-fg-color);
+      }
+      .super-info {
+        width: 18px;
+        height: 18px;
+        color: #888;
+        padding: 0px;
+      }
+      #idleTimeoutTooltip {
+        --paper-tooltip: {
+          font-size: 13px;
+        }
+      }
     </style>
 
     <!--Theme-->
@@ -36,6 +60,23 @@ the License.
         <paper-radio-button name="light">Light</paper-radio-button>
         <paper-radio-button name="dark">Dark</paper-radio-button>
       </paper-radio-group>
+    </div>
+
+    <!--Auto Shutdown-->
+    <div class="setting">
+      <div>Auto Shutdown:</div>
+      <div class="input-container">
+        <paper-input class="input-box" spellcheck=false value="{{idleTimeoutInterval}}"
+                    no-label-float></paper-input>
+        <paper-button raised>Update</paper-button>
+        <paper-icon-button class="super-info" icon="help-outline" id="idleTimeoutHelp">
+        </paper-icon-button>
+        <paper-tooltip id="idleTimeoutTooltip" for="idleTimeoutHelp">
+          The VM will shut down after being idle for this long.
+          <br>
+          Example values: 90m, 1h 30m, 2d 12h. Set to 0 to disable.
+        </paper-tooltip>
+      </div>
     </div>
 
   </template>

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
@@ -15,7 +15,6 @@ the License.
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 
 <link rel="import" href="../../bower_components/neon-animation/web-animations.html">
-<link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../../bower_components/paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../../bower_components/paper-tooltip/paper-tooltip.html">

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
@@ -18,10 +18,17 @@ the License.
 <link rel="import" href="../../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../../bower_components/paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../../bower_components/paper-tooltip/paper-tooltip.html">
+<link rel="import" href="../../bower_components/paper-progress/paper-progress.html">
 
 <dom-module id="datalab-settings">
   <template>
     <style include="datalab-shared-styles">
+      paper-progress {
+        width: 100%;
+        height: 1px;
+        --paper-progress-active-color: var(--selection-fg-color);
+        --paper-progress-container-color: var(--border-color);
+      }
       paper-radio-button {
         --paper-radio-button-checked-color: var(--selection-fg-color);
       }
@@ -52,6 +59,9 @@ the License.
         }
       }
     </style>
+
+    <!--Thin progress bar that shows until files are loaded-->
+    <paper-progress id="progressBar" indeterminate disabled={{!_busy}}></paper-progress>
 
     <!--Theme-->
     <div class="setting">

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
@@ -16,9 +16,9 @@ the License.
 
 <link rel="import" href="../../bower_components/neon-animation/web-animations.html">
 <link rel="import" href="../../bower_components/paper-input/paper-input.html">
+<link rel="import" href="../../bower_components/paper-progress/paper-progress.html">
 <link rel="import" href="../../bower_components/paper-radio-group/paper-radio-group.html">
 <link rel="import" href="../../bower_components/paper-tooltip/paper-tooltip.html">
-<link rel="import" href="../../bower_components/paper-progress/paper-progress.html">
 
 <dom-module id="datalab-settings">
   <template>
@@ -60,7 +60,7 @@ the License.
       }
     </style>
 
-    <!--Thin progress bar that shows until files are loaded-->
+    <!--Thin progress bar that shows when busy->
     <paper-progress id="progressBar" indeterminate disabled={{!_busy}}></paper-progress>
 
     <!--Theme-->

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
@@ -14,6 +14,7 @@ the License.
 
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 
+<link rel="import" href="../../bower_components/neon-animation/web-animations.html">
 <link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../../bower_components/paper-input/paper-input.html">
 <link rel="import" href="../../bower_components/paper-radio-group/paper-radio-group.html">
@@ -68,9 +69,8 @@ the License.
       <div class="input-container">
         <paper-input class="input-box" spellcheck=false value="{{idleTimeoutInterval}}"
                     no-label-float></paper-input>
-        <paper-button raised>Update</paper-button>
-        <paper-icon-button class="super-info" icon="help-outline" id="idleTimeoutHelp">
-        </paper-icon-button>
+        <paper-button raised on-click="_idleTimoutIntervalChanged">Update</paper-button>
+        <iron-icon icon="help-outline" class="super-info" id="idleTimeoutHelp"></iron-icon>
         <paper-tooltip id="idleTimeoutTooltip" for="idleTimeoutHelp">
           The VM will shut down after being idle for this long.
           <br>

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -65,7 +65,7 @@ class SettingsElement extends Polymer.Element {
 
   _idleTimoutIntervalChanged() {
     // TODO: Show success/error status to user
-    return ApiManager.setUserSetting('idleTimeoutInterval', this.idleTimeoutInterval)
+    return SettingsManager.setUserSettingAsync('idleTimeoutInterval', this.idleTimeoutInterval)
       .catch((e: Error) => console.log('Error updating idle timeout interval: ', e));
   }
 

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -13,15 +13,6 @@
  */
 
 /**
- * CustomEvent that gets dispatched when the theme setting is changed by the user.
- */
-class ThemeChangedEvent extends CustomEvent {
-  detail: {
-    theme: string
-  }
-}
-
-/**
  * Settings element for Datalab.
  * This element shows a settings panel for Datalab that contains different user settings,
  * and uses the ApiManager to read and update those settings.

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -43,7 +43,6 @@ class SettingsElement extends Polymer.Element {
   ready() {
     super.ready();
 
-    // TODO: add a cache for user/app settings and call it here instead.
     SettingsManager.getUserSettingsAsync(true /*forceRefresh*/)
       .then((settings: common.UserSettings) => {
         this.theme = settings.theme;

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -26,13 +26,21 @@ class SettingsElement extends Polymer.Element {
    */
   public theme: string;
 
+  /**
+   * Idle timeout interval.
+   */
+  public idleTimeoutInterval: string;
+
   static get is() { return "datalab-settings"; }
 
   static get properties() {
     return {
       theme: {
         type: String,
-      }
+      },
+      idleTimeoutInterval: {
+        type: String,
+      },
     }
   }
 
@@ -46,6 +54,7 @@ class SettingsElement extends Polymer.Element {
     SettingsManager.getUserSettingsAsync(true /*forceRefresh*/)
       .then((settings: common.UserSettings) => {
         this.theme = settings.theme;
+        this.idleTimeoutInterval = settings.idleTimeoutInterval;
       });
   }
 

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -63,6 +63,12 @@ class SettingsElement extends Polymer.Element {
       .then(() => document.dispatchEvent(new Event('ThemeChanged')));
   }
 
+  _idleTimoutIntervalChanged() {
+    // TODO: Show success/error status to user
+    return ApiManager.setUserSetting('idleTimeoutInterval', this.idleTimeoutInterval)
+      .catch((e: Error) => console.log('Error updating idle timeout interval: ', e));
+  }
+
 }
 
 customElements.define(SettingsElement.is, SettingsElement);

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -13,6 +13,15 @@
  */
 
 /**
+ * CustomEvent that gets dispatched when the theme setting is changed by the user.
+ */
+class ThemeChangedEvent extends CustomEvent {
+  detail: {
+    theme: string
+  }
+}
+
+/**
  * Settings element for Datalab.
  * This element shows a settings panel for Datalab that contains different user settings,
  * and uses the ApiManager to read and update those settings.

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -65,6 +65,8 @@ the License.
       }
       .dialog-content {
         flex-grow: 1;
+        margin: 0px;
+        padding: 0px;
       }
       .account-dropdown {
         background-color: var(--primary-bg-color);
@@ -117,7 +119,7 @@ the License.
     <paper-dialog id="settingsDialog" class="dialog" with-backdrop>
       <div class="dialog-title">Settings</div>
       <div class="dialog-content">
-        <datalab-settings></datalab-settings>
+        <datalab-settings id="settingsElement"></datalab-settings>
       </div>
       <hr>
       <div class="dialog-buttons">

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -108,7 +108,7 @@ the License.
       <div class="dialog-title">Info</div>
       <div class="dialog-content"></div>
       <hr>
-      <div>
+      <div class="dialog-buttons">
         <paper-button dialog-dismiss raised>Close</paper-button>
       </div>
     </paper-dialog>
@@ -120,7 +120,7 @@ the License.
         <datalab-settings></datalab-settings>
       </div>
       <hr>
-      <div>
+      <div class="dialog-buttons">
         <paper-button dialog-dismiss raised>Close</paper-button>
       </div>
     </paper-dialog>

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
@@ -53,6 +53,7 @@ class ToolbarElement extends Polymer.Element {
    */
   _settingsClicked() {
     this.$.settingsDialog.open();
+    this.$.settingsElement.loadSettings();
   }
 }
 

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -47,6 +47,9 @@ the License.
         margin: 0px;
         padding: 15px; /*Total height: 51px*/
       }
+      .dialog-buttons {
+        direction: rtl;
+      }
       a {
         color: var(--selection-fg-color);
       }

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -275,6 +275,18 @@ class ApiManager {
     return ApiManager.sendRequestAsync(path, xhrOptions);
   }
 
+  /**
+   * Sets a user setting.
+   * @param setting name of the setting to change.
+   * @param value new setting value.
+   */
+  static setUserSetting(setting: string, value: string) {
+    const xhrOptions: XhrOptions = {
+      method: 'POST',
+    };
+    return ApiManager._xhrAsync('/_settings?key=' + setting + '&value=' + value, xhrOptions);
+  }
+
   /*
    * Copies an item from source to destination. Item name collisions at the destination
    * are handled by Jupyter.

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -275,18 +275,6 @@ class ApiManager {
     return ApiManager.sendRequestAsync(path, xhrOptions);
   }
 
-  /**
-   * Sets a user setting.
-   * @param setting name of the setting to change.
-   * @param value new setting value.
-   */
-  static setUserSetting(setting: string, value: string) {
-    const xhrOptions: XhrOptions = {
-      method: 'POST',
-    };
-    return ApiManager._xhrAsync('/_settings?key=' + setting + '&value=' + value, xhrOptions);
-  }
-
   /*
    * Copies an item from source to destination. Item name collisions at the destination
    * are handled by Jupyter.


### PR DESCRIPTION
This change adds the timeout interval setting to the settings element, with a tooltip that explains its usage. (The tooltip shows on mouseover, the screen shot is a little misleading)

It also triggers loading settings every time the dialog is opened instead of only once.

![screenshot from 2017-07-05 15 31 59](https://user-images.githubusercontent.com/1424661/27887891-e6152c3c-6197-11e7-993e-61372e65f1e0.png)
