### PR TITLE
use tf 1.2.0 in the container. 

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -84,9 +84,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir crcmod==1.7 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir pillow==3.4.1 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir google-cloud-dataflow==2.0.0 && \
-    pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow==1.0.1 && \
-    # Setting protobuf to 3.1.0 to workaround a tensorflow 1.0 issue in tcmalloc
-    pip install -U --upgrade-strategy only-if-needed --no-cache-dir protobuf==3.1.0 && \
+    pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow==1.2.0 && \
     find /usr/local/lib/python2.7 -type d -name tests | xargs rm -rf && \
 
 # Python 3

--- a/containers/base/Dockerfile.py2
+++ b/containers/base/Dockerfile.py2
@@ -132,9 +132,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     cd /
 
 # Install TensorFlow
-# Setting protobuf to 3.1.0 to workaround a tensorflow 1.0 issue in tcmalloc
-RUN pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow==1.0 && \
-    pip install -U --upgrade-strategy only-if-needed --no-cache-dir protobuf==3.1.0
+RUN pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow==1.2.0 &&
 
 ADD config/ipython.py /etc/ipython/ipython_config.py
 ADD config/nbconvert.py /etc/jupyter/jupyter_notebook_config.py

--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -90,8 +90,8 @@ if [[ $LIVE_MODE == 1 ]]; then
 fi
 
 docker run -it --entrypoint=$ENTRYPOINT \
-  -p 127.0.0.1:8083:8080 \
-  -v "$CONTENT:/content/datalab" \
+  -p 127.0.0.1:8081:8080 \
+  -v "$CONTENT/datalab:/content/datalab" \
   $PYDATALAB_MOUNT_OPT \
   ${DEVROOT_DOCKER_OPTION} \
   -e "PROJECT_ID=$PROJECT_ID" \

--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -90,8 +90,8 @@ if [[ $LIVE_MODE == 1 ]]; then
 fi
 
 docker run -it --entrypoint=$ENTRYPOINT \
-  -p 127.0.0.1:8081:8080 \
-  -v "$CONTENT/datalab:/content/datalab" \
+  -p 127.0.0.1:8083:8080 \
+  -v "$CONTENT:/content/datalab" \
   $PYDATALAB_MOUNT_OPT \
   ${DEVROOT_DOCKER_OPTION} \
   -e "PROJECT_ID=$PROJECT_ID" \


### PR DESCRIPTION
pydatalab changes will come.

protobuf is now whatever TF wants.

This PR almost fixes #1479. When pydatalab is updated, then that issue can be closed.