### PR TITLE
[Polymer UI] Actually lazy load datalab page elements

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -15,12 +15,8 @@ the License.
 <link rel="import" href="../../bower_components/app-route/app-location.html">
 <link rel="import" href="../../bower_components/app-route/app-route.html">
 <link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
-<link rel="import" href="../../bower_components/polymer/polymer.html">
 
-<link rel="import" href="../../components/datalab-files/datalab-files.html">
-<link rel="import" href="../../components/datalab-sessions/datalab-sessions.html">
 <link rel="import" href="../../components/datalab-sidebar/datalab-sidebar.html">
-<link rel="import" href="../../components/datalab-terminal/datalab-terminal.html">
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
 
 <dom-module id="datalab-app">
@@ -84,5 +80,6 @@ the License.
   </template>
 </dom-module>
 
+<script src="../../modules/ApiManager.js"></script>
 <script src="../../modules/SettingsManager.js"></script>
 <script src="datalab-app.js"></script>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -16,8 +16,8 @@
  * Shell element for Datalab.
  * It contains a <datalab-toolbar> element at the top, a <datalab-sidebar>
  * element beneath that to the left, and a paged view to switch between
- * different pages. It holds references to <datalab-files> and
- * <datalab-sessions>, and uses a local router element to switch between
+ * different pages. It holds references to the different datalab page
+ * elements, and uses a local router element to switch between
  * these according to the current page location.
  * All pages referenced by this element should be named following the
  * convention `datalab-element/datalab-element.html`.

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -317,5 +317,4 @@ the License.
 </dom-module>
 
 <script src="../../modules/Utils.js"></script>
-<script src="../../modules/ApiManager.js"></script>
 <script src="datalab-files.js"></script>

--- a/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.ts
+++ b/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.ts
@@ -45,24 +45,20 @@ class TerminalElement extends Polymer.Element {
 
   ready() {
     super.ready();
+    // Use the size helper element to get the height and width of a character. This
+    // makes changing the style simpler, instead of hard-coding these values.
+    this._charHeight = this.$.sizeHelper.clientHeight;
+    this._charWidth = this.$.sizeHelper.clientWidth / 10; // The element has 10 characters.
 
-    // Will be called after the custom element is done rendering.
-    window.addEventListener('WebComponentsReady', () => {
-      // Use the size helper element to get the height and width of a character. This
-      // makes changing the style simpler, instead of hard-coding these values.
-      this._charHeight = this.$.sizeHelper.clientHeight;
-      this._charWidth = this.$.sizeHelper.clientWidth / 10; // The element has 10 characters.
-
-      // Get the first terminal instance by calling the Jupyter API. If none are returned,
-      // start a new one.
-      ApiManager.listTerminalsAsync()
-        .then((terminals: [JupyterTerminal]) => {
-          return terminals.length === 0 ? ApiManager.startTerminalAsync() : terminals[0];
-        })
-        .then((terminal: JupyterTerminal) => {
-          this._initTerminal(terminal.name);
-        });
-    });
+    // Get the first terminal instance by calling the Jupyter API. If none are returned,
+    // start a new one.
+    ApiManager.listTerminalsAsync()
+      .then((terminals: [JupyterTerminal]) => {
+        return terminals.length === 0 ? ApiManager.startTerminalAsync() : terminals[0];
+      })
+      .then((terminal: JupyterTerminal) => {
+        this._initTerminal(terminal.name);
+      });
   }
 
   /**

--- a/sources/web/datalab/polymer/polymer.json
+++ b/sources/web/datalab/polymer/polymer.json
@@ -2,10 +2,11 @@
   "entrypoint": "index.html",
   "shell": "components/datalab-app/datalab-app.html",
   "fragments": [
-    "components/datalab-toolbar/datalab-toolbar.html",
-    "components/datalab-sidebar/datalab-sidebar.html",
     "components/datalab-files/datalab-files.html",
-    "components/datalab-sessions/datalab-sessions.html"
+    "components/datalab-sessions/datalab-sessions.html",
+    "components/datalab-sidebar/datalab-sidebar.html",
+    "components/datalab-terminal/datalab-terminal.html",
+    "components/datalab-toolbar/datalab-toolbar.html"
   ],
   "sources": [
     "modules/**/*.js",


### PR DESCRIPTION
Datalab pages were not lazy loaded up till now, they were immediately imported in the `datalab-app` element. This PR changes that to make sure heavy elements aren't loaded unnecessarily.

This also fixes the terminal issue where size was being calculated too early, which was related to the element not being lazy loaded.