### PR TITLE
[Polymer UI] Enable multi-selection with modifier keys, (Un)Select All

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -174,7 +174,7 @@ class FilesElement extends Polymer.Element {
     }
 
     // For a small file/directory picker, we don't need to show the status.
-    this.$.files.columns = this.small ? ['Name'] : ['Name', 'Status'];
+    (<ItemListElement>this.$.files).columns = this.small ? ['Name'] : ['Name', 'Status'];
   }
 
   disconnectedCallback() {
@@ -262,7 +262,7 @@ class FilesElement extends Polymer.Element {
    * the created list to the item-list to render.
    */
   _drawFileList() {
-    this.$.files.rows = this._fileList.map(file => {
+    (<ItemListElement>this.$.files).rows = this._fileList.map(file => {
       return {
         firstCol: file.name,
         secondCol: file.status,
@@ -301,8 +301,7 @@ class FilesElement extends Polymer.Element {
    * is selected, sets the selectedFile property to the selected file object.
    */
   _handleSelectionChanged() {
-    const list = <ItemListElement>this.$.files;
-    const selectedIndices = list.selectedIndices;
+    const selectedIndices = (<ItemListElement>this.$.files).selectedIndices;
     if (selectedIndices.length === 1) {
       this.selectedFile = this._fileList[selectedIndices[0]];
     } else {
@@ -531,7 +530,7 @@ class FilesElement extends Polymer.Element {
    */
   _renameSelectedItem() {
 
-    const selectedIndices = this.$.files.selectedIndices;
+    const selectedIndices = (<ItemListElement>this.$.files).selectedIndices;
     if (selectedIndices.length === 1) {
       const i = selectedIndices[0];
       const selectedObject = this._fileList[i];
@@ -570,7 +569,7 @@ class FilesElement extends Polymer.Element {
    */
   _deleteSelectedItems() {
 
-    const selectedIndices = this.$.files.selectedIndices;
+    const selectedIndices = (<ItemListElement>this.$.files).selectedIndices;
     if (selectedIndices.length) {
       // Build friendly title and body messages that adapt to the number of items.
       const num = selectedIndices.length;
@@ -650,7 +649,8 @@ class FilesElement extends Polymer.Element {
    * TODO: Consider allowing multiple items to be copied.
    */
   _copySelectedItem() {
-    const selectedIndices = this.$.files.selectedIndices;
+
+    const selectedIndices = (<ItemListElement>this.$.files).selectedIndices;
 
     if (selectedIndices.length === 1) {
       const i = selectedIndices[0];
@@ -683,7 +683,8 @@ class FilesElement extends Polymer.Element {
    * TODO: Consider allowing multiple items to be copied.
    */
   _moveSelectedItem() {
-    const selectedIndices = this.$.files.selectedIndices;
+
+    const selectedIndices = (<ItemListElement>this.$.files).selectedIndices;
 
     if (selectedIndices.length === 1) {
       const i = selectedIndices[0];

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -169,7 +169,7 @@ class FilesElement extends Polymer.Element {
     if (filesElement) {
       filesElement.addEventListener('itemDoubleClick',
                                     this._handleDoubleClicked.bind(this));
-      filesElement.addEventListener('itemSelectionChanged',
+      filesElement.addEventListener('selected-elements-changed',
                                     this._handleSelectionChanged.bind(this));
     }
 

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -169,7 +169,7 @@ class FilesElement extends Polymer.Element {
     if (filesElement) {
       filesElement.addEventListener('itemDoubleClick',
                                     this._handleDoubleClicked.bind(this));
-      filesElement.addEventListener('selected-elements-changed',
+      filesElement.addEventListener('selected-indices-changed',
                                     this._handleSelectionChanged.bind(this));
     }
 
@@ -301,9 +301,10 @@ class FilesElement extends Polymer.Element {
    * is selected, sets the selectedFile property to the selected file object.
    */
   _handleSelectionChanged() {
-    const selectedItems = this.$.files.getSelectedIndices();
-    if (selectedItems.length === 1) {
-      this.selectedFile = this._fileList[selectedItems[0]];
+    const list = <ItemListElement>this.$.files;
+    const selectedIndices = list.selectedIndices;
+    if (selectedIndices.length === 1) {
+      this.selectedFile = this._fileList[selectedIndices[0]];
     } else {
       this.selectedFile = null;
     }
@@ -530,7 +531,7 @@ class FilesElement extends Polymer.Element {
    */
   _renameSelectedItem() {
 
-    const selectedIndices = this.$.files.getSelectedIndices();
+    const selectedIndices = this.$.files.selectedIndices;
     if (selectedIndices.length === 1) {
       const i = selectedIndices[0];
       const selectedObject = this._fileList[i];
@@ -569,7 +570,7 @@ class FilesElement extends Polymer.Element {
    */
   _deleteSelectedItems() {
 
-    const selectedIndices = this.$.files.getSelectedIndices();
+    const selectedIndices = this.$.files.selectedIndices;
     if (selectedIndices.length) {
       // Build friendly title and body messages that adapt to the number of items.
       const num = selectedIndices.length;
@@ -649,7 +650,7 @@ class FilesElement extends Polymer.Element {
    * TODO: Consider allowing multiple items to be copied.
    */
   _copySelectedItem() {
-    const selectedIndices = this.$.files.getSelectedIndices();
+    const selectedIndices = this.$.files.selectedIndices;
 
     if (selectedIndices.length === 1) {
       const i = selectedIndices[0];
@@ -682,7 +683,7 @@ class FilesElement extends Polymer.Element {
    * TODO: Consider allowing multiple items to be copied.
    */
   _moveSelectedItem() {
-    const selectedIndices = this.$.files.getSelectedIndices();
+    const selectedIndices = this.$.files.selectedIndices;
 
     if (selectedIndices.length === 1) {
       const i = selectedIndices[0];

--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
@@ -61,7 +61,7 @@ class SessionsElement extends Polymer.Element {
   ready() {
     super.ready();
 
-    this.$.sessions.columns = ['Session Path', 'Status'];
+    (<ItemListElement>this.$.sessions).columns = ['Session Path', 'Status'];
 
     // load session list initially
     this._fetchSessionList();
@@ -73,7 +73,7 @@ class SessionsElement extends Polymer.Element {
 
     const sessionsElement = this.shadowRoot.querySelector('#sessions')
     if (sessionsElement) {
-      sessionsElement.addEventListener('itemSelectionChanged',
+      sessionsElement.addEventListener('selected-indices-changed',
                                     this._handleSelectionChanged.bind(this));
     }
   }
@@ -88,7 +88,7 @@ class SessionsElement extends Polymer.Element {
       return;
     }
 
-    this.$.sessions.rows = this._sessionList.map(session => {
+    (<ItemListElement>this.$.sessions).rows = this._sessionList.map(session => {
       return {
         firstCol: session.notebook.path,
         secondCol: 'running',
@@ -132,7 +132,7 @@ class SessionsElement extends Polymer.Element {
    * Calls the ApiManager to terminate the selected sessions.
    */
   _shutdownSelectedSessions() {
-    const selectedIndices = this.$.sessions.getSelectedIndices();
+    const selectedIndices = (<ItemListElement>this.$.sessions).selectedIndices;
     if (selectedIndices.length) {
       const shutdownPromises = selectedIndices.map((i: number) => {
         return ApiManager.shutdownSessionAsync(this._sessionList[i].id);
@@ -153,7 +153,7 @@ class SessionsElement extends Polymer.Element {
    * is selected, sets the selectedSession property to the selected session object.
    */
   _handleSelectionChanged() {
-    const selectedItems = this.$.sessions.getSelectedIndices();
+    const selectedItems = (<ItemListElement>this.$.sessions).selectedIndices;
     if (selectedItems.length === 1) {
       this.selectedSession = this._sessionList[selectedItems[0]];
     } else {

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -87,7 +87,10 @@ the License.
     <!--Need this extra div because #header has a display modifier, cannot set hidden-->
     <div hidden$="{{hideHeader}}">
       <div id="header">
-        <div class="checkbox-col"></div>
+        <div class="checkbox-col">
+          <paper-checkbox checked={{_isAllSelected}} checkedChanged="_selectAllChanged">
+          </paper-checkbox>
+        </div>
         <div class="first-col"><strong>{{columns.0}}</strong></div>
         <div class="second-col"><strong>{{columns.1}}</strong></div>
       </div>

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -32,7 +32,7 @@ the License.
         line-height: calc(var(--toolbar-height) - 1px);
         border-bottom: 1px solid var(--border-color);
       }
-      #list-container {
+      #listContainer {
         overflow: auto;
       }
       .list-container-hide-header--false {
@@ -94,7 +94,7 @@ the License.
     </div>
 
     <!--Item list-->
-    <div id="list-container" class$="list-container-hide-header--{{hideHeader}}">
+    <div id="listContainer" class$="list-container-hide-header--{{hideHeader}}">
       <template is="dom-repeat" id="list" items="{{rows}}" as="row">
         <paper-item class="row" selected$={{row.selected}} on-click="_rowClicked"
                     on-dblclick="_rowDoubleClicked">

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -88,7 +88,8 @@ the License.
     <div hidden$="{{hideHeader}}">
       <div id="header">
         <div class="checkbox-col">
-          <paper-checkbox checked={{_isAllSelected}} checkedChanged="_selectAllChanged">
+          <paper-checkbox id="selectAllCheckbox" on-checked-changed="_selectAllChanged"
+                          checked={{_isAllSelected}}>
           </paper-checkbox>
         </div>
         <div class="first-col"><strong>{{columns.0}}</strong></div>
@@ -102,8 +103,7 @@ the License.
         <paper-item class="row" selected$={{row.selected}} on-click="_rowClicked"
                     on-dblclick="_rowDoubleClicked">
           <div class="checkbox-col">
-            <paper-checkbox checked={{row.selected}} checkedChanged="_rowClicked"
-                            hidden$="{{disableSelection}}">
+            <paper-checkbox checked={{row.selected}} hidden$="{{disableSelection}}">
             </paper-checkbox>
           </div>
           <div class="first-col">

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -32,7 +32,7 @@ the License.
         line-height: calc(var(--toolbar-height) - 1px);
         border-bottom: 1px solid var(--border-color);
       }
-      #listContainer {
+      #list-container {
         overflow: auto;
       }
       .list-container-hide-header--false {
@@ -98,7 +98,7 @@ the License.
     </div>
 
     <!--Item list-->
-    <div id="listContainer" class$="list-container-hide-header--{{hideHeader}}">
+    <div id="list-container" class$="list-container-hide-header--{{hideHeader}}">
       <template is="dom-repeat" id="list" items="{{rows}}" as="row">
         <paper-item class="row" selected$={{row.selected}} on-click="_rowClicked"
                     on-dblclick="_rowDoubleClicked">

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -164,6 +164,14 @@ class ItemListElement extends Polymer.Element {
     }
   }
 
+  _selectAllChanged() {
+    if (this.$.selectAllCheckbox.checked === true) {
+      this._selectAll();
+    } else {
+      this._unselectAll();
+    }
+  }
+
   /**
    * On row click, checks the click target, if it's the checkbox, adds it to
    * the selected rows, otherwise selects it only.

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -67,7 +67,7 @@ class ItemListElement extends Polymer.Element {
    */
   public disableSelection: boolean;
 
-  private _selectedElements: Array<HTMLElement>;
+  private selectedElements: Array<HTMLElement>;
   private _lastSelectedIndex: number;
   private _isAllSelected: boolean;
 
@@ -92,9 +92,10 @@ class ItemListElement extends Polymer.Element {
         type: Boolean,
         value: false,
       },
-      _selectedElements: {
+      selectedElements: {
         type: Array,
         value: () => [],
+        notify: true,
       },
       _isAllSelected: {
         type: Boolean,
@@ -109,14 +110,14 @@ class ItemListElement extends Polymer.Element {
    * opposite is not directly possible.
    */
   getSelectedElements() {
-    return this.disableSelection ? [] : this._selectedElements;
+    return this.disableSelection ? [] : this.selectedElements;
   }
 
   /**
    * Returns list of indices for the currently selected elements.
    */
   getSelectedIndices() {
-    return this.disableSelection ? [] : this._selectedElements.map(element => {
+    return this.disableSelection ? [] : this.selectedElements.map(element => {
       return this.$.list.indexForElement(element);
     });
   }
@@ -126,30 +127,28 @@ class ItemListElement extends Polymer.Element {
    * list of rows is refreshed.
    */
   _rowsChanged() {
-    this._selectedElements = [];
+    this.selectedElements = [];
     this._lastSelectedIndex = -1;
-    const ev = new ItemClickEvent('itemSelectionChanged', { detail: {} });
-    this.dispatchEvent(ev);
   }
 
   _selectItem(index: number) {
     const element = this.$.listContainer.children[index];
-    const i = this._selectedElements.indexOf(element);
+    const i = this.selectedElements.indexOf(element);
     if (i === -1) {
-      this.push('_selectedElements', element);
+      this.push('selectedElements', element);
     }
     this.set('rows.' + index + '.selected', true);
-    this._isAllSelected = this._selectedElements.length === this.rows.length;
+    this._isAllSelected = this.selectedElements.length === this.rows.length;
   }
 
   _unselectItem(index: number) {
     const element = this.$.listContainer.children[index];
-    const i = this._selectedElements.indexOf(element);
+    const i = this.selectedElements.indexOf(element);
     if (i > -1) {
-      this.splice('_selectedElements', i, 1);
+      this.splice('selectedElements', i, 1);
     }
     this.set('rows.' + index+ '.selected', false);
-    this._isAllSelected = this._selectedElements.length === this.rows.length;
+    this._isAllSelected = this.selectedElements.length === this.rows.length;
   }
 
   _selectAll() {
@@ -175,7 +174,7 @@ class ItemListElement extends Polymer.Element {
   /**
    * On row click, checks the click target, if it's the checkbox, adds it to
    * the selected rows, otherwise selects it only.
-   * This method also maintains the _selectedElements list.
+   * This method also maintains the selectedElements list.
    */
   _rowClicked(e: MouseEvent) {
     if (this.disableSelection) {
@@ -219,8 +218,6 @@ class ItemListElement extends Polymer.Element {
     }
 
     this._lastSelectedIndex = index;
-    const ev = new ItemClickEvent('itemSelectionChanged', { detail: {index: index} });
-    this.dispatchEvent(ev);
   }
 
   /**

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -119,7 +119,7 @@ class ItemListElement extends Polymer.Element {
       if (row.selected) {
         selected.push(i);
       }
-    })
+    });
     return selected;
   }
 
@@ -128,7 +128,7 @@ class ItemListElement extends Polymer.Element {
    * all items in the list are selected.
    */
   _computeIsAllSelected() {
-    return this.selectedIndices.length === this.rows.length;
+    return this.rows.length > 0 && this.rows.length === this.selectedIndices.length;
   }
 
   /**
@@ -207,15 +207,12 @@ class ItemListElement extends Polymer.Element {
       }
     }
     
-    // No modifier keys are pressed, proceed normally to select the item.
+    // No modifier keys are pressed, proceed normally to select/unselect the item.
     else {
-      // If the clicked element is the checkbox, we're done, the checkbox already
-      // toggles selection.
+      // If the clicked element is the checkbox, the checkbox already toggles selection in
+      // the UI, so change the item's selection state to match the checkbox's new value.
       // Otherwise, select this element, unselect all others.
-      if (target.tagName !== 'PAPER-CHECKBOX') {
-        this._unselectAll();
-        this._selectItem(index);
-      } else {
+      if (target.tagName === 'PAPER-CHECKBOX') {
         if (this.rows[index].selected === false) {
           // Remove this element from the selected elements list if it's being unselected
           this._unselectItem(index);
@@ -223,9 +220,13 @@ class ItemListElement extends Polymer.Element {
           // Add this element to the selected elements list if it's being selected,
           this._selectItem(index);
         }
+      } else {
+        this._unselectAll();
+        this._selectItem(index);
       }
     }
 
+    // Save this index to enable multi-selection using shift later.
     this._lastSelectedIndex = index;
   }
 

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -69,6 +69,7 @@ class ItemListElement extends Polymer.Element {
 
   private _selectedElements: Array<HTMLElement>;
   private _lastSelectedIndex: number;
+  private _isAllSelected: boolean;
 
   static get is() { return "item-list"; }
 
@@ -94,7 +95,11 @@ class ItemListElement extends Polymer.Element {
       _selectedElements: {
         type: Array,
         value: () => [],
-      }
+      },
+      _isAllSelected: {
+        type: Boolean,
+        value: false,
+      },
     }
   }
 
@@ -133,7 +138,8 @@ class ItemListElement extends Polymer.Element {
     if (i === -1) {
       this.push('_selectedElements', element);
     }
-    this.set('rows.' + i + '.selected', true);
+    this.set('rows.' + index + '.selected', true);
+    this._isAllSelected = this._selectedElements.length === this.rows.length;
   }
 
   _unselectItem(index: number) {
@@ -142,7 +148,8 @@ class ItemListElement extends Polymer.Element {
     if (i > -1) {
       this.splice('_selectedElements', i, 1);
     }
-    this.set('rows.' + i + '.selected', false);
+    this.set('rows.' + index+ '.selected', false);
+    this._isAllSelected = this._selectedElements.length === this.rows.length;
   }
 
   _selectAll() {
@@ -179,8 +186,12 @@ class ItemListElement extends Polymer.Element {
         this._selectItem(i);
       }
     } else if (e.ctrlKey) {
-      // If ctrl key is pressed, always add this item to the selected list.
-      this._selectItem(index);
+      // If ctrl key is pressed, toggle its selection.
+      if (this.rows[index].selected === false) {
+        this._selectItem(index);
+      } else {
+        this._unselectItem(index);
+      }
     } else {
       // If the clicked element is the checkbox, we're done, the checkbox already
       // toggles selection.


### PR DESCRIPTION
This PR adds the ability to select multiple items in the `item-list` element by clicking a select/unselect all button, or by using modifier keys: shift+click remembers the last selected item and selects all between that item and current selection, ctrl+click toggles selection of the current item, adding or removing it to the selected group.

The change also cleans up the code for `item-list` to move more things to Polymer's automatic event bindings, and avoid manual tracking of selected indices by using array mutation syntax.

Note that multi-selection is not currently useful yet, since toolbar buttons are activated on single-item selection, so this will be added next.

![image](https://user-images.githubusercontent.com/1424661/28003138-0484e99a-64f0-11e7-8cbe-27a56167a130.png)
