### PR TITLE
[Polymer UI] Add skeleton Data pane with dummy data.

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -69,6 +69,7 @@ the License.
         <div class="datalab-main-content">
           <iron-pages id="pages" selected="{{page}}" attr-for-selected="name"
                       fallback-selection="files">
+            <datalab-data name="data"></datalab-data>
             <datalab-files name="files"></datalab-files>
             <datalab-sessions name="sessions"></datalab-sessions>
             <datalab-terminal name="terminal"></datalab-terminal>

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -80,7 +80,7 @@ the License.
     <!--Toolbar with action buttons -->
     <div id="toolbar">
       <paper-button class="toolbar-button" on-click="_search">
-        <iron-icon icon="refresh"></iron-icon>
+        <iron-icon icon="search"></iron-icon>
         <span>Search</span>
       </paper-button>
     </div>
@@ -93,7 +93,7 @@ the License.
         <div>
           Collections Filter:
             <paper-input id="collectionsFilterBox" label="Optional filter value" spellcheck=false autofocus
-                         value="{{collectionsFilterValue}}" no-label-float>
+                         value="{{_collectionsFilterValue}}" no-label-float>
             </paper-input>
         </div>
         <!-- list of collections -->
@@ -107,7 +107,7 @@ the License.
         <div>
           Tables Filter:
             <paper-input id="tablesFilterBox" label="Optional filter value" spellcheck=false autofocus
-                         value="{{tablesFilterValue}}" no-label-float>
+                         value="{{_tablesFilterValue}}" no-label-float>
             </paper-input>
         </div>
         <!-- list of tables -->

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -1,0 +1,135 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../components/item-list/item-list.html">
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
+
+<dom-module id="datalab-data">
+  <template>
+    <style include="datalab-shared-styles">
+      :host {
+        --data-style: {
+          font-family: monospace;
+          font-size: 14px;
+        }
+      }
+      div {
+        font-family: var(--app-content-font-family);
+        font-size: var(--app-content-font-size);
+        color: var(--app-primary-color);
+      }
+      div.datasetDrillDown {
+        display: flex;
+        margin: 15px;
+      }
+      .collectionsColumn {
+        width: 33%;
+      }
+      .datasetsColumn {
+        width: 33%;
+      }
+      .filteredColumn {
+        margin: 10px;
+      }
+      detailsColumn {
+        width: 33%;
+      }
+      #toolbar {
+        height: calc(var(--toolbar-height) - 1px); /* for border-bottom */
+        width: 100%;
+        background-color: var(--app-secondary-color);
+        border-bottom: 1px solid #eee;
+      }
+      .toolbar-button {
+        color: var(--app-primary-color);
+        margin: 4px;
+        font-weight: normal;
+        border-radius: 0px;
+      }
+      .toolbar-button > iron-icon {
+        width: 20px;
+        padding-right: 5px;
+      }
+      .collections-container {
+        height: 100%;
+        display: flex;
+      }
+      .datasets-container {
+        height: 100%;
+        display: flex;
+      }
+      #collections {
+        flex-grow: 1;
+      }
+      #datasets {
+        flex-grow: 1;
+      }
+    </style>
+
+    <!--Toolbar with action buttons -->
+    <div id="toolbar">
+      <paper-button class="toolbar-button" on-click="_search">
+        <iron-icon icon="refresh"></iron-icon>
+        <span>Search</span>
+      </paper-button>
+    </div>
+
+    <!-- Multi-column layout: collections (BQ datasets), datasets (BQ tables) -->
+    <div class="datasetDrillDown">
+
+      <!-- Collections (BQ datasets) -->
+      <div class="collectionsColumn filteredColumn">
+        <div>
+          Project:
+            <paper-input id="projectBox" label="Select a project" spellcheck=false autofocus
+                         value="{{projectValue}}" no-label-float>
+            </paper-input>
+        </div>
+        <div>
+          Collections Filter:
+            <paper-input id="collectionsFilterBox" label="Optional filter value" spellcheck=false autofocus
+                         value="{{collectionsFilterValue}}" no-label-float>
+            </paper-input>
+        </div>
+        <!-- list of collections -->
+        <div class='collections-container'>
+          <item-list id="collections" hide-header="true"></item-list>
+        </div>
+      </div>
+
+      <!-- Datasets (BQ tables) -->
+      <div class="datasetsColumn filteredColumn">
+        <div>
+          Datasets Filter:
+            <paper-input id="datasetsFilterBox" label="Optional filter value" spellcheck=false autofocus
+                         value="{{datasetsFilterValue}}" no-label-float>
+            </paper-input>
+        </div>
+        <!-- list of datasets (tables) -->
+        <div class='datasets-container'>
+          <item-list id="datasets" hide-header="true"></item-list>
+        </div>
+      </div>
+
+      <!-- Details pane -->
+      <div class="detailsColumn">
+        <div id="detailsPane"></div>
+      </div>
+
+    </div>
+
+  </template>
+</dom-module>
+
+<script src="datalab-data.js"></script>

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -21,7 +21,7 @@ the License.
       :host {
         --data-style: {
           font-family: monospace;
-          font-size: 14px;
+          font-size: var(--app-content-font-size);
         }
       }
       div {
@@ -29,14 +29,14 @@ the License.
         font-size: var(--app-content-font-size);
         color: var(--app-primary-color);
       }
-      div.datasetDrillDown {
+      div.tableDrillDown {
         display: flex;
         margin: 15px;
       }
       .collectionsColumn {
         width: 33%;
       }
-      .datasetsColumn {
+      .tablesColumn {
         width: 33%;
       }
       .filteredColumn {
@@ -49,7 +49,7 @@ the License.
         height: calc(var(--toolbar-height) - 1px); /* for border-bottom */
         width: 100%;
         background-color: var(--app-secondary-color);
-        border-bottom: 1px solid #eee;
+        border-bottom: 1px solid var(--border-color);
       }
       .toolbar-button {
         color: var(--app-primary-color);
@@ -65,14 +65,14 @@ the License.
         height: 100%;
         display: flex;
       }
-      .datasets-container {
+      .tables-container {
         height: 100%;
         display: flex;
       }
       #collections {
         flex-grow: 1;
       }
-      #datasets {
+      #tables {
         flex-grow: 1;
       }
     </style>
@@ -85,17 +85,11 @@ the License.
       </paper-button>
     </div>
 
-    <!-- Multi-column layout: collections (BQ datasets), datasets (BQ tables) -->
-    <div class="datasetDrillDown">
+    <!-- Multi-column layout: collections (BQ datasets), tables -->
+    <div class="tableDrillDown">
 
       <!-- Collections (BQ datasets) -->
       <div class="collectionsColumn filteredColumn">
-        <div>
-          Project:
-            <paper-input id="projectBox" label="Select a project" spellcheck=false autofocus
-                         value="{{projectValue}}" no-label-float>
-            </paper-input>
-        </div>
         <div>
           Collections Filter:
             <paper-input id="collectionsFilterBox" label="Optional filter value" spellcheck=false autofocus
@@ -108,17 +102,17 @@ the License.
         </div>
       </div>
 
-      <!-- Datasets (BQ tables) -->
-      <div class="datasetsColumn filteredColumn">
+      <!-- Tables -->
+      <div class="tablesColumn filteredColumn">
         <div>
-          Datasets Filter:
-            <paper-input id="datasetsFilterBox" label="Optional filter value" spellcheck=false autofocus
-                         value="{{datasetsFilterValue}}" no-label-float>
+          Tables Filter:
+            <paper-input id="tablesFilterBox" label="Optional filter value" spellcheck=false autofocus
+                         value="{{tablesFilterValue}}" no-label-float>
             </paper-input>
         </div>
-        <!-- list of datasets (tables) -->
-        <div class='datasets-container'>
-          <item-list id="datasets" hide-header="true"></item-list>
+        <!-- list of tables -->
+        <div class='tables-container'>
+          <item-list id="tables" hide-header="true"></item-list>
         </div>
       </div>
 

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/// <reference path="../input-dialog/input-dialog.ts" />
+/// <reference path="../item-list/item-list.ts" />
+
+interface Collection {
+  name : string;
+  status : string;
+  datasets? : Array<Dataset>;
+}
+
+interface Dataset {
+  name : string;
+  status : string;
+}
+
+/**
+ * Data element for Datalab.
+ * Contains a form for initial user input, and a list of datasets.
+ */
+class DataElement extends Polymer.Element {
+
+  public projectValue : string;
+  public collectionsFilterValue : string;
+  public datasetsFilterValue : string;
+
+  private _collectionsList : Array<Collection>;
+  private _datasetsList : Array<Dataset>;
+
+  static get is() { return "datalab-data"; }
+
+  static get properties() {
+    return {
+      projectValue: {
+        type: String,
+        value: 'fake-project',
+      },
+      collectionsFilterValue: {
+        type: String,
+        value: 'no-filter',
+      },
+      datasetsFilterValue: {
+        type: String,
+        value: 'no-filter',
+      },
+    };
+  }
+
+  ready() {
+    super.ready();
+
+    this._collectionsList = [];
+    const collectionsElement = this.shadowRoot.querySelector('#collections')
+    if (collectionsElement) {
+      collectionsElement.addEventListener('itemDoubleClick',
+                                    this._collectionsDoubleClicked.bind(this));
+      collectionsElement.addEventListener('selected-indices-changed',
+                                    this._collectionsSelectionChanged.bind(this));
+    }
+
+    this._datasetsList = [];
+    const datasetsElement = this.shadowRoot.querySelector('#datasets')
+    if (datasetsElement) {
+      datasetsElement.addEventListener('itemDoubleClick',
+                                    this._datasetsDoubleClicked.bind(this));
+      datasetsElement.addEventListener('selected-indices-changed',
+                                    this._datasetsSelectionChanged.bind(this));
+    }
+  }
+
+  _generateFakeCollectionsListForTesting() {
+    const collectionsList = [];
+    const count = Math.floor(Math.random() * 20);
+    for (let i=0; i < count; i++) {
+      collectionsList.push(this._generateFakeCollectionForTesting());
+    }
+    return collectionsList;
+  }
+
+  _generateFakeCollectionForTesting() {
+    const fakeCollection = {
+      name: 'fakeCollection' + Math.floor(Math.random() * 1000000),
+      status: 'fake',
+    };
+    return fakeCollection;
+  }
+
+  _generateFakeDatasetsListForTesting() {
+    const datasetsList = [];
+    const count = Math.floor(Math.random() * 20);
+    for (let i=0; i < count; i++) {
+      datasetsList.push(this._generateFakeDatasetForTesting());
+    }
+    return datasetsList;
+  }
+
+  _generateFakeDatasetForTesting() {
+    const fakeDataset = {
+      name: 'fakeDataset' + Math.floor(Math.random() * 1000000),
+      status: 'fake',
+    };
+    return fakeDataset;
+  }
+
+  /** Reads the user's query values, queries for datasets, and updates the results. */
+  _search() {
+    this._collectionsList = this._generateFakeCollectionsListForTesting();
+    this._renderCollectionsList();
+  }
+
+  /**
+   * Creates a new ItemListRow object for each entry in the collections list, and sends
+   * the created list to the item-list to render.
+   */
+  _renderCollectionsList() {
+    this.$.collections.rows = this._collectionsList.map(collection => {
+      return {
+        firstCol: collection.name,
+        secondCol: collection.status,
+        icon: 'folder',
+        selected: false
+      };
+    });
+  }
+
+  _showDatasetsForCollection(collection: Collection) {
+    console.log('== collection selected:', collection);
+    if (!collection.datasets) {
+      collection.datasets = this._generateFakeDatasetsListForTesting();
+    }
+    this._datasetsList = collection.datasets;
+    this._renderDatasetsList();
+  }
+
+  _clearDatasetsList() {
+    this._datasetsList = [];
+    this._renderDatasetsList();
+  }
+
+  _showDetailsForDataset(dataset: Dataset) {
+    this.$.detailsPane.innerHTML = 'Selected dataset: ' + dataset.name;
+  }
+
+  _clearDatasetDetails() {
+    this.$.detailsPane.innerHTML = '';
+  }
+
+  /**
+   * Creates a new ItemListRow object for each entry in the collections list, and sends
+   * the created list to the item-list to render.
+   */
+  _renderDatasetsList() {
+    this.$.datasets.rows = this._datasetsList.map(dataset => {
+      return {
+        firstCol: dataset.name,
+        secondCol: dataset.status,
+        icon: 'file',
+        selected: false
+      };
+    });
+  }
+
+  _collectionsDoubleClicked() {
+    console.log('== collection double-clicked');
+  }
+
+  _collectionsSelectionChanged() {
+    console.log('== collection selection changed');
+      const selectedIndices = (<ItemListElement>this.$.collections).selectedIndices;
+    if (selectedIndices.length == 1) {
+      this._showDatasetsForCollection(this._collectionsList[selectedIndices[0]]);
+    } else {
+      this._clearDatasetsList();
+    }
+  }
+
+  _datasetsDoubleClicked() {
+    console.log('== dataset double-clicked');
+  }
+
+  _datasetsSelectionChanged() {
+    console.log('== dataset selection changed');
+    const selectedIndices = (<ItemListElement>this.$.datasets).selectedIndices;
+    if (selectedIndices.length == 1) {
+      this._showDetailsForDataset(this._datasetsList[selectedIndices[0]]);
+    } else {
+      this._clearDatasetDetails();
+    }
+  }
+
+  /**
+   * Called when the element is detached from the DOM. Cleans up event listeners.
+   */
+  disconnectedCallback() {
+  }
+}
+
+customElements.define(DataElement.is, DataElement);

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -18,42 +18,50 @@
 interface Collection {
   name : string;
   status : string;
-  datasets? : Array<Dataset>;
+  tables? : Array<Table>;
 }
 
-interface Dataset {
+interface Table {
   name : string;
   status : string;
 }
 
 /**
  * Data element for Datalab.
- * Contains a form for initial user input, and a list of datasets.
+ * Contains a form for initial user input, and a list of tables.
  */
 class DataElement extends Polymer.Element {
 
-  public projectValue : string;
+  /** The value the user can enter to filter the collections. */
   public collectionsFilterValue : string;
-  public datasetsFilterValue : string;
+
+  /** The value the user can enter to filter the tables. */
+  public tablesFilterValue : string;
 
   private _collectionsList : Array<Collection>;
-  private _datasetsList : Array<Dataset>;
+  private _tablesList : Array<Table>;
 
   static get is() { return "datalab-data"; }
 
   static get properties() {
     return {
-      projectValue: {
-        type: String,
-        value: 'fake-project',
-      },
       collectionsFilterValue: {
         type: String,
         value: 'no-filter',
       },
-      datasetsFilterValue: {
+      tablesFilterValue: {
         type: String,
         value: 'no-filter',
+      },
+      _collectionsList: {
+        type: Array,
+        value: () => [],
+        observer: '_renderCollectionsList',
+      },
+      _tablesList: {
+        type: Array,
+        value: () => [],
+        observer: '_renderTablesList',
       },
     };
   }
@@ -62,7 +70,7 @@ class DataElement extends Polymer.Element {
     super.ready();
 
     this._collectionsList = [];
-    const collectionsElement = this.shadowRoot.querySelector('#collections')
+    const collectionsElement = <ItemListElement>this.$.collections;
     if (collectionsElement) {
       collectionsElement.addEventListener('itemDoubleClick',
                                     this._collectionsDoubleClicked.bind(this));
@@ -70,13 +78,13 @@ class DataElement extends Polymer.Element {
                                     this._collectionsSelectionChanged.bind(this));
     }
 
-    this._datasetsList = [];
-    const datasetsElement = this.shadowRoot.querySelector('#datasets')
-    if (datasetsElement) {
-      datasetsElement.addEventListener('itemDoubleClick',
-                                    this._datasetsDoubleClicked.bind(this));
-      datasetsElement.addEventListener('selected-indices-changed',
-                                    this._datasetsSelectionChanged.bind(this));
+    this._tablesList = [];
+    const tablesElement = <ItemListElement>this.$.tables;
+    if (tablesElement) {
+      tablesElement.addEventListener('itemDoubleClick',
+                                    this._tablesDoubleClicked.bind(this));
+      tablesElement.addEventListener('selected-indices-changed',
+                                    this._tablesSelectionChanged.bind(this));
     }
   }
 
@@ -97,27 +105,26 @@ class DataElement extends Polymer.Element {
     return fakeCollection;
   }
 
-  _generateFakeDatasetsListForTesting() {
-    const datasetsList = [];
+  _generateFakeTablesListForTesting() {
+    const tablesList = [];
     const count = Math.floor(Math.random() * 20);
     for (let i=0; i < count; i++) {
-      datasetsList.push(this._generateFakeDatasetForTesting());
+      tablesList.push(this._generateFakeTableForTesting());
     }
-    return datasetsList;
+    return tablesList;
   }
 
-  _generateFakeDatasetForTesting() {
-    const fakeDataset = {
-      name: 'fakeDataset' + Math.floor(Math.random() * 1000000),
+  _generateFakeTableForTesting() {
+    const fakeTable = {
+      name: 'fakeTable' + Math.floor(Math.random() * 1000000),
       status: 'fake',
     };
-    return fakeDataset;
+    return fakeTable;
   }
 
-  /** Reads the user's query values, queries for datasets, and updates the results. */
+  /** Reads the user's query values, queries for tables, and updates the results. */
   _search() {
     this._collectionsList = this._generateFakeCollectionsListForTesting();
-    this._renderCollectionsList();
   }
 
   /**
@@ -135,25 +142,23 @@ class DataElement extends Polymer.Element {
     });
   }
 
-  _showDatasetsForCollection(collection: Collection) {
+  _showTablesForCollection(collection: Collection) {
     console.log('== collection selected:', collection);
-    if (!collection.datasets) {
-      collection.datasets = this._generateFakeDatasetsListForTesting();
+    if (!collection.tables) {
+      collection.tables = this._generateFakeTablesListForTesting();
     }
-    this._datasetsList = collection.datasets;
-    this._renderDatasetsList();
+    this._tablesList = collection.tables;
   }
 
-  _clearDatasetsList() {
-    this._datasetsList = [];
-    this._renderDatasetsList();
+  _clearTablesList() {
+    this._tablesList = [];
   }
 
-  _showDetailsForDataset(dataset: Dataset) {
-    this.$.detailsPane.innerHTML = 'Selected dataset: ' + dataset.name;
+  _showDetailsForTable(table: Table) {
+    this.$.detailsPane.innerHTML = 'Selected table: ' + table.name;
   }
 
-  _clearDatasetDetails() {
+  _clearTableDetails() {
     this.$.detailsPane.innerHTML = '';
   }
 
@@ -161,11 +166,11 @@ class DataElement extends Polymer.Element {
    * Creates a new ItemListRow object for each entry in the collections list, and sends
    * the created list to the item-list to render.
    */
-  _renderDatasetsList() {
-    this.$.datasets.rows = this._datasetsList.map(dataset => {
+  _renderTablesList() {
+    this.$.tables.rows = this._tablesList.map(table => {
       return {
-        firstCol: dataset.name,
-        secondCol: dataset.status,
+        firstCol: table.name,
+        secondCol: table.status,
         icon: 'file',
         selected: false
       };
@@ -180,30 +185,24 @@ class DataElement extends Polymer.Element {
     console.log('== collection selection changed');
       const selectedIndices = (<ItemListElement>this.$.collections).selectedIndices;
     if (selectedIndices.length == 1) {
-      this._showDatasetsForCollection(this._collectionsList[selectedIndices[0]]);
+      this._showTablesForCollection(this._collectionsList[selectedIndices[0]]);
     } else {
-      this._clearDatasetsList();
+      this._clearTablesList();
     }
   }
 
-  _datasetsDoubleClicked() {
-    console.log('== dataset double-clicked');
+  _tablesDoubleClicked() {
+    console.log('== table double-clicked');
   }
 
-  _datasetsSelectionChanged() {
-    console.log('== dataset selection changed');
-    const selectedIndices = (<ItemListElement>this.$.datasets).selectedIndices;
+  _tablesSelectionChanged() {
+    console.log('== table selection changed');
+    const selectedIndices = (<ItemListElement>this.$.tables).selectedIndices;
     if (selectedIndices.length == 1) {
-      this._showDetailsForDataset(this._datasetsList[selectedIndices[0]]);
+      this._showDetailsForTable(this._tablesList[selectedIndices[0]]);
     } else {
-      this._clearDatasetDetails();
+      this._clearTableDetails();
     }
-  }
-
-  /**
-   * Called when the element is detached from the DOM. Cleans up event listeners.
-   */
-  disconnectedCallback() {
   }
 }
 

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -33,10 +33,10 @@ interface Table {
 class DataElement extends Polymer.Element {
 
   /** The value the user can enter to filter the collections. */
-  public collectionsFilterValue : string;
+  //private _collectionsFilterValue : string;   //TODO(jimmc): uncomment when ready to use
 
   /** The value the user can enter to filter the tables. */
-  public tablesFilterValue : string;
+  //private _tablesFilterValue : string;    //TODO(jimmc): uncomment when ready to use
 
   private _collectionsList : Array<Collection>;
   private _tablesList : Array<Table>;
@@ -45,11 +45,11 @@ class DataElement extends Polymer.Element {
 
   static get properties() {
     return {
-      collectionsFilterValue: {
+      _collectionsFilterValue: {
         type: String,
         value: 'no-filter',
       },
-      tablesFilterValue: {
+      _tablesFilterValue: {
         type: String,
         value: 'no-filter',
       },

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
@@ -80,7 +80,8 @@ the License.
       <div class="sidebar-button"></div>
       <iron-selector class="container" attr-for-selected="id" selected={{page}}
                      class="drawer-list" role="navigation">
-        <a href="/data" id="data" hidden$="{{!_showDataTab}}">
+        <!-- uncomment this once we have the data tab working satisfactorily
+        <a href="/data" id="data">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="av:library-books"></iron-icon>
@@ -88,6 +89,7 @@ the License.
             </div>
           </paper-button>
         </a>
+        -->
         <a href="/files" id="files">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
@@ -80,6 +80,14 @@ the License.
       <div class="sidebar-button"></div>
       <iron-selector class="container" attr-for-selected="id" selected={{page}}
                      class="drawer-list" role="navigation">
+        <a href="/data" id="data" hidden$="{{!_showDataTab}}">
+          <paper-button class="sidebar-button">
+            <div class="sidebar-button-container">
+              <iron-icon class="sidebar-button-icon" icon="av:library-books"></iron-icon>
+              <div class="sidebar-button-title">Data</div>
+            </div>
+          </paper-button>
+        </a>
         <a href="/files" id="files">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
@@ -24,6 +24,8 @@ class SidebarElement extends Polymer.Element {
    */
   public page: string;
 
+  private _showDataTab: boolean;
+
   static get is() { return "datalab-sidebar"; }
 
   static get properties() {
@@ -31,10 +33,18 @@ class SidebarElement extends Polymer.Element {
       page: {
         type: String,
         value: "files",
+      },
+      _showDataTab: {
+        value: false
       }
     }
   }
 
+  ready() {
+    super.ready();
+    //TODO(jimmc): For now, only show the Data screen selection icon when in the Data screen
+    this._showDataTab = location.pathname.endsWith('/data');
+  }
 }
 
 customElements.define(SidebarElement.is, SidebarElement);

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
@@ -24,8 +24,6 @@ class SidebarElement extends Polymer.Element {
    */
   public page: string;
 
-  private _showDataTab: boolean;
-
   static get is() { return "datalab-sidebar"; }
 
   static get properties() {
@@ -34,16 +32,7 @@ class SidebarElement extends Polymer.Element {
         type: String,
         value: "files",
       },
-      _showDataTab: {
-        value: false
-      }
     }
-  }
-
-  ready() {
-    super.ready();
-    //TODO(jimmc): For now, only show the Data screen selection icon when in the Data screen
-    this._showDataTab = location.pathname.endsWith('/data');
   }
 }
 

--- a/sources/web/datalab/polymer/polymer.json
+++ b/sources/web/datalab/polymer/polymer.json
@@ -2,6 +2,7 @@
   "entrypoint": "index.html",
   "shell": "components/datalab-app/datalab-app.html",
   "fragments": [
+    "components/datalab-data/datalab-data.html",
     "components/datalab-files/datalab-files.html",
     "components/datalab-sessions/datalab-sessions.html",
     "components/datalab-sidebar/datalab-sidebar.html",

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -174,6 +174,7 @@ export function isExperimentalResource(pathname: string) {
   }
   const experimentalUiEnabled = process.env.DATALAB_EXPERIMENTAL_UI;
   return experimentalUiEnabled === 'true' && (
+      pathname.indexOf('/data') === 0 ||
       pathname.indexOf('/files') === 0 ||
       pathname.indexOf('/sessions') === 0 ||
       pathname.indexOf('/terminal') === 0 ||
@@ -208,7 +209,10 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
       response.end();
       return;
     }
-    if (pathname === '/files' || pathname === '/sessions' || pathname === '/terminal') {
+    if (pathname === '/data' ||
+        pathname === '/files' ||
+        pathname === '/sessions' ||
+        pathname === '/terminal') {
       pathname = '/index.html';
     }
     if (pathname === '/index.css') {


### PR DESCRIPTION
This PR implements an initial Data pane. The intent of this pane is to provide easy browsing of BigQuery tables and eventually other data. At the moment, this data pane includes only dummy data.
Clicking the Search button populates the Collections list. Clicking on a Collection populates the Datasets list. Clicking on a Dataset populates the Details pane on the right.
For now, the Data button in the left nav bar only appears when showing the Data pane, so for now you must enter the URL to get to that pane.
![datatab](https://user-images.githubusercontent.com/116825/28041005-9843b878-657c-11e7-95d7-3e3e42e814be.png)

