### PR TITLE
Fix for the filter used to list source repositories

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -530,7 +530,7 @@ def ensure_repo_exists(args, gcloud_repos, repo_name):
       subprocess.CalledProcessError: If the `gcloud` command fails
     """
     list_cmd = ['list', '--quiet',
-                '--filter', 'name:{}'.format(repo_name),
+                '--filter', 'name:*/repos/{}'.format(repo_name),
                 '--format', 'value(name)']
     with tempfile.TemporaryFile() as tf:
         gcloud_repos(args, list_cmd, stdout=tf)


### PR DESCRIPTION
This change updates the filter used by the `datalab create` command
when calling `gcloud source repos list` so that the filter matches
the behavior documented by the `gcloud topics filters` command.

More specifically, a filter of the form `<KEY>:<PATTERN>` is documented
to match if the value associated with the key completely matches the
given pattern (meaning that the entire string is consumed by the pattern
match). However, prior to Cloud SDK version 162.0.0, the filter would
allow resources through if there was a *partial* match rather than
a total match.

The `datalab create` command was unintentionally dependent on this
behavior (which did not match the documented behavior), as the
filter passed to the `gcloud source repos list` command only matched
the repository name, and not the fully-qualified resource name (e.g.
`projects/my-project/repos/datalab-notebooks`).

When the Cloud SDK was updated to version 162.0.0, it changed the
behavior of the filter flag to match the documentation. At this
point, the behavior that `datalab create` relied upon no longer
matched the behavior that `gcloud source repos list` exhibited.

This mismatch caused issue #1499

This change fixes the `datalab create` command so that it uses
a pattern that will completely match the fully qualified resource
name.

This fix is compatible with both the new (corrected) and the old
(erroneous) behavior of the `--filter` flag.