### PR TITLE
Comment out broken --idle-timeout command line option.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -280,6 +280,7 @@ def flags(parser):
         default=_DATALAB_DEFAULT_DISK_SIZE_GB,
         help='size of the persistent disk in GB.')
 
+    """ Broken due to changes to the notebook server, disable until we fix it.
     parser.add_argument(
         '--idle-timeout',
         dest='idle_timeout',
@@ -290,6 +291,7 @@ def flags(parser):
             'You can specify a mix of days, hours, minutes and seconds\n'
             'using those names or d, h, m and s, for example "1h 30m".\n'
             'Specify 0s to disable.'))
+    """
 
     parser.add_argument(
         '--machine-type',

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -22,8 +22,6 @@ import connect
 import utils
 
 
-defaultIdleTimeout = '0s'   # Default for now is disabled
-
 description = ("""`{0} {1}` creates a new Datalab instances running in a Google
 Compute Engine VM.
 
@@ -199,8 +197,6 @@ spec:
           value: '{{"enableAutoGCSBackups": {1}, "consoleLogLevel": "{2}" }}'
         - name: DATALAB_GIT_AUTHOR
           value: '{3}'
-        - name: DATALAB_IDLE_TIMEOUT
-          value: '{4}'
       volumeMounts:
         - name: content
           mountPath: /content
@@ -279,19 +275,6 @@ def flags(parser):
         dest='disk_size_gb',
         default=_DATALAB_DEFAULT_DISK_SIZE_GB,
         help='size of the persistent disk in GB.')
-
-    """ Broken due to changes to the notebook server, disable until we fix it.
-    parser.add_argument(
-        '--idle-timeout',
-        dest='idle_timeout',
-        default=defaultIdleTimeout,
-        help=(
-            'interval after which an idle Datalab instance will shut down.'
-            '\n\n'
-            'You can specify a mix of days, hours, minutes and seconds\n'
-            'using those names or d, h, m and s, for example "1h 30m".\n'
-            'Specify 0s to disable.'))
-    """
 
     parser.add_argument(
         '--machine-type',
@@ -597,7 +580,6 @@ def run(args, gcloud_compute, gcloud_repos,
 
     enable_backups = "false" if args.no_backups else "true"
     console_log_level = args.log_level or "warn"
-    idle_timeout = args.idle_timeout or defaultIdleTimeout
     user_email = args.for_user or email
     service_account = args.service_account or "default"
     # We have to escape the user's email before using it in the YAML template.
@@ -615,7 +597,7 @@ def run(args, gcloud_compute, gcloud_repos,
             manifest_file.write(
                 _DATALAB_CONTAINER_SPEC.format(
                     args.image_name, enable_backups,
-                    console_log_level, escaped_email, idle_timeout))
+                    console_log_level, escaped_email))
             manifest_file.close()
             for_user_file.write(user_email)
             for_user_file.close()


### PR DESCRIPTION
The --idle-timeout command line option got broken after some recent code changes. This PR disables this command line option for now until we figure out how we want to fix it.