### PR TITLE
Report warnings from gcloud

### DIFF
--- a/tools/cli/commands/utils.py
+++ b/tools/cli/commands/utils.py
@@ -84,6 +84,10 @@ def call_gcloud_quietly(args, gcloud_surface, cmd, report_errors=True):
                 print(stdout.read())
                 sys.stderr.write(stderr.read())
             raise
+        stderr.seek(0)
+        gcloud_stderr = stderr.read()
+        if 'WARNING' in gcloud_stderr:
+            sys.stderr.write(gcloud_stderr)
     return
 
 


### PR DESCRIPTION
This change extends the `call_gcloud_quietly` method so that it
checks if gcloud reported any warnings, and if so cascades them
up to the user.

This prevents us from accidentally obscuring warnings about things
like calling gcloud in a way that is deprecated.