### PR TITLE
Re-implement --idle-timeout CLI option, clean up settings update.

### DIFF
--- a/sources/web/datalab/idleTimeout.ts
+++ b/sources/web/datalab/idleTimeout.ts
@@ -45,10 +45,25 @@ export function init() {
   }
   if (shutdownCommand) {
     let idleTimeoutStr = userSettings.idleTimeoutInterval;
-    logging.getLogger().debug('idleTimeoutStr from user settings: ' + idleTimeoutStr);
+    if (idleTimeoutStr === undefined) {
+      logging.getLogger().debug('idleTimeoutStr from user settings is undefined');
+    } else {
+      logging.getLogger().debug('idleTimeoutStr from user settings: ' + idleTimeoutStr);
+    }
     if (!idleTimeoutStr) {
       idleTimeoutStr = process.env.DATALAB_IDLE_TIMEOUT;
-      logging.getLogger().debug('idleTimeoutStr from env: ' + idleTimeoutStr);
+      if (idleTimeoutStr === undefined) {
+        logging.getLogger().debug('idleTimeoutStr from env is undefined');
+      } else {
+        logging.getLogger().debug('idleTimeoutStr from env: ' + idleTimeoutStr);
+      }
+    }
+    // For instances (actually, PDs) created before idle-timeout was implemented,
+    // the user's settings file may not have a value for idleTimeoutInterval.
+    // In this case, we set it to 0s to continue using the the no-idle-timeout
+    // behavior that was in place when that PD was created.
+    if (idleTimeoutStr === undefined) {
+      idleTimeoutStr = '0s';
     }
     setIdleTimeoutInterval(idleTimeoutStr);
   } else {

--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -136,11 +136,7 @@ function copyDefaultUserSettings(userId: string) {
 export function mergeUserSettings(defaultUserSettings: string, initialUserSettings: string): string {
   let parsedDefaultUserSettings;
   try {
-    if (defaultUserSettings) {
-      parsedDefaultUserSettings = JSON.parse(defaultUserSettings)
-    } else {
-      parsedDefaultUserSettings = {};
-    }
+    parsedDefaultUserSettings = JSON.parse(defaultUserSettings || '{}')
   } catch (e) {
     // File is corrupt, or a developer has updated the defaults file with an error
     console.log('Error parsing default user settings:', e);
@@ -152,11 +148,7 @@ export function mergeUserSettings(defaultUserSettings: string, initialUserSettin
 
   let parsedInitialUserSettings;
   try {
-    if (initialUserSettings) {
-      parsedInitialUserSettings = JSON.parse(initialUserSettings)
-    } else {
-      parsedInitialUserSettings = {}
-    }
+    parsedInitialUserSettings = JSON.parse(initialUserSettings || '{}')
   } catch (e) {
     // The user's initial settings are not valid, we will ignore them.
     console.log('Error parsing initial user settings:', e);

--- a/test/server-unit/settings_spec.js
+++ b/test/server-unit/settings_spec.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+const BASE = '../../build/web/nb/';
+const settings = require(BASE + 'settings');
+
+describe('Unit tests', function() {
+describe('settings', function() {
+
+  describe('mergeUserSettings', function() {
+    it('merges empty strings to empty object', function() {
+      const dflt = '';
+      const init = '';
+      const expected = '{}';
+      expect(settings.mergeUserSettings(dflt, init)).toBe(expected);
+    });
+
+    it('merges empty initial settings to unchanged default settings', function() {
+      const dflt = '{"a": 123, "b": "xyz"}';
+      const init = '';
+      const expected = '{"a":123,"b":"xyz"}';
+      expect(settings.mergeUserSettings(dflt, init)).toBe(expected);
+    });
+
+    it('overrides default settings with user initial settings', function() {
+      const dflt = '{"a": 123, "b": "xyz"}';
+      const init = '{"b": "PQRS"}';
+      const expected = '{"a":123,"b":"PQRS"}';
+      expect(settings.mergeUserSettings(dflt, init)).toBe(expected);
+    });
+  });
+
+});
+});

--- a/test/server-unit/settings_spec.js
+++ b/test/server-unit/settings_spec.js
@@ -33,6 +33,13 @@ describe('settings', function() {
       expect(settings.mergeUserSettings(dflt, init)).toBe(expected);
     });
 
+    it('merges empty default settings to unchanged initial settings', function() {
+      const dflt = '';
+      const init = '{"a": 123, "b": "xyz"}';
+      const expected = '{"a":123,"b":"xyz"}';
+      expect(settings.mergeUserSettings(dflt, init)).toBe(expected);
+    });
+
     it('overrides default settings with user initial settings', function() {
       const dflt = '{"a": 123, "b": "xyz"}';
       const init = '{"b": "PQRS"}';

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -598,7 +598,8 @@ def run(args, gcloud_compute, gcloud_repos,
     service_account = args.service_account or "default"
     # We have to escape the user's email before using it in the YAML template.
     escaped_email = user_email.replace("'", "''")
-    initial_user_settings = '{{"idleTimeoutInterval": "{0}"}}'.format(idle_timeout) if idle_timeout else ''
+    initial_user_settings = '{{"idleTimeoutInterval": "{0}"}}'\
+        .format(idle_timeout) if idle_timeout else ''
     with tempfile.NamedTemporaryFile(delete=False) as startup_script_file, \
             tempfile.NamedTemporaryFile(delete=False) as user_data_file, \
             tempfile.NamedTemporaryFile(delete=False) as manifest_file, \

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -197,6 +197,8 @@ spec:
           value: '{{"enableAutoGCSBackups": {1}, "consoleLogLevel": "{2}" }}'
         - name: DATALAB_GIT_AUTHOR
           value: '{3}'
+        - name: DATALAB_INITIAL_USER_SETTINGS
+          value: '{4}'
       volumeMounts:
         - name: content
           mountPath: /content
@@ -275,6 +277,17 @@ def flags(parser):
         dest='disk_size_gb',
         default=_DATALAB_DEFAULT_DISK_SIZE_GB,
         help='size of the persistent disk in GB.')
+
+    parser.add_argument(
+        '--idle-timeout',
+        dest='idle_timeout',
+        default=None,
+        help=(
+            'interval after which an idle Datalab instance will shut down.'
+            '\n\n'
+            'You can specify a mix of days, hours, minutes and seconds\n'
+            'using those names or d, h, m and s, for example "1h 30m".\n'
+            'Specify 0s to disable.'))
 
     parser.add_argument(
         '--machine-type',
@@ -579,11 +592,13 @@ def run(args, gcloud_compute, gcloud_repos,
         cmd.extend(['--zone', args.zone])
 
     enable_backups = "false" if args.no_backups else "true"
+    idle_timeout = args.idle_timeout
     console_log_level = args.log_level or "warn"
     user_email = args.for_user or email
     service_account = args.service_account or "default"
     # We have to escape the user's email before using it in the YAML template.
     escaped_email = user_email.replace("'", "''")
+    initial_user_settings = '{{"idleTimeoutInterval": "{0}"}}'.format(idle_timeout) if idle_timeout else ''
     with tempfile.NamedTemporaryFile(delete=False) as startup_script_file, \
             tempfile.NamedTemporaryFile(delete=False) as user_data_file, \
             tempfile.NamedTemporaryFile(delete=False) as manifest_file, \
@@ -597,7 +612,7 @@ def run(args, gcloud_compute, gcloud_repos,
             manifest_file.write(
                 _DATALAB_CONTAINER_SPEC.format(
                     args.image_name, enable_backups,
-                    console_log_level, escaped_email))
+                    console_log_level, escaped_email, initial_user_settings))
             manifest_file.close()
             for_user_file.write(user_email)
             for_user_file.close()

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -14,6 +14,7 @@
 
 """Methods for implementing the `datalab create` command."""
 
+import json
 import os
 import subprocess
 import tempfile
@@ -598,8 +599,8 @@ def run(args, gcloud_compute, gcloud_repos,
     service_account = args.service_account or "default"
     # We have to escape the user's email before using it in the YAML template.
     escaped_email = user_email.replace("'", "''")
-    initial_user_settings = '{{"idleTimeoutInterval": "{0}"}}'\
-        .format(idle_timeout) if idle_timeout else ''
+    initial_user_settings = json.dumps({"idleTimeoutInterval": idle_timeout}) \
+        if idle_timeout else ''
     with tempfile.NamedTemporaryFile(delete=False) as startup_script_file, \
             tempfile.NamedTemporaryFile(delete=False) as user_data_file, \
             tempfile.NamedTemporaryFile(delete=False) as manifest_file, \


### PR DESCRIPTION
This PR re-implements the --idle-timeout command line option in the "datalab create" command that was recently removed (before being released), as it was broken due to a change in the implementation of how the idle timeout initial value was handled.

The implementation in this PR includes code that allows for specifying initial values for any user setting, which are applied when the user settings file is created during initialization to override the default user settings values. At present, the --idle-timeout command line option is the only user setting that is managed this way, but it would be easy to allow other initial user settings to be done using the same mechanism in the future by adding additional command line options.

The --idle-timeout command line option implemented in this PR relies on new code in the Datalab image that is also in this PR. It will do nothing if used with an earlier Datalab image that does not include this code.

This PR also includes a few code changes to the user settings updateing code that I am hoping might help track down or eliminate an intermittent problem I have had in which sometimes my settings.json file becomes corrupt with a "}" in place of the "," immediately following the startuppath value.