### PR TITLE
Skip reverse proxy requests from static handler

### DIFF
--- a/sources/web/datalab/reverseProxy.ts
+++ b/sources/web/datalab/reverseProxy.ts
@@ -20,6 +20,7 @@
 import http = require('http');
 import httpProxy = require('http-proxy');
 import logging = require('./logging');
+import url = require('url');
 
 var appSettings: common.AppSettings;
 var proxy: httpProxy.ProxyServer = httpProxy.createProxyServer(null);
@@ -39,6 +40,14 @@ function getPort(url: string) {
     }
   }
   return null;
+}
+
+/**
+ * Returns true iff the request should be served by the reverse proxy.
+ */
+export function isReverseProxyRequest(request: http.ServerRequest) {
+  var urlpath = url.parse(request.url, true).pathname;
+  return !!getRequestPort(request, urlpath);
 }
 
 /**

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -275,7 +275,7 @@ function uncheckedRequestHandler(request: http.ServerRequest, response: http.Ser
       urlpath.indexOf('/oauthcallback') == 0) {
     // Start or return from auth flow.
     auth.handleAuthFlow(request, response, parsed_url, appSettings);
-  } else if (isStaticResource(urlpath)) {
+  } else if (!reverseProxy.isReverseProxyRequest(request) && isStaticResource(urlpath)) {
     staticHandler(request, response);
   } else {
     handleRequest(request, response, urlpath);

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -109,10 +109,6 @@ function handleRequest(request: http.ServerRequest,
     loadedSettings = settings_.loadUserSettings(userId);
   }
 
-  // All requests below are logged, while the ones above aren't, to avoid generating noise
-  // into the log.
-  logging.logRequest(request, response);
-
   // If Jupyter is not initialized, do it as early as possible after authentication.
   startInitializationForUser(request);
 
@@ -142,12 +138,6 @@ function handleRequest(request: http.ServerRequest,
     }
     response.setHeader('Location', redirectUrl);
     response.end();
-    return;
-  }
-
-  var targetPort: string = reverseProxy.getRequestPort(request, requestPath);
-  if (targetPort) {
-    reverseProxy.handleRequest(request, response, targetPort);
     return;
   }
 
@@ -271,11 +261,18 @@ function isStaticResource(urlpath: string) {
 function uncheckedRequestHandler(request: http.ServerRequest, response: http.ServerResponse) {
   var parsed_url = url.parse(request.url, true);
   var urlpath = parsed_url.pathname;
+
+  logging.logRequest(request, response);
+
+  var reverseProxyPort: string = reverseProxy.getRequestPort(request, urlpath);
+
   if (urlpath.indexOf('/signin') == 0 || urlpath.indexOf('/signout') == 0 ||
       urlpath.indexOf('/oauthcallback') == 0) {
     // Start or return from auth flow.
     auth.handleAuthFlow(request, response, parsed_url, appSettings);
-  } else if (!reverseProxy.isReverseProxyRequest(request) && isStaticResource(urlpath)) {
+  } else if (reverseProxyPort) {
+    reverseProxy.handleRequest(request, response, reverseProxyPort);
+  } else if (isStaticResource(urlpath)) {
     staticHandler(request, response);
   } else {
     handleRequest(request, response, urlpath);


### PR DESCRIPTION
Fixes #1507.

Note this also moves handling the reverse proxy requests separately from other requests.