### PR TITLE
[Polymer UI] Show an error toast on connection errors

### DIFF
--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -21,7 +21,8 @@
     "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.0",
     "polymer": "Polymer/polymer#^2.0.1",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.9",
-    "xterm.js": "^2.7.0"
+    "xterm.js": "^2.7.0",
+    "paper-toast": "PolymerElements/paper-toast#^2.0.0"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0"

--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -18,11 +18,11 @@
     "paper-item": "PolymerElements/paper-item#^2.0.0",
     "paper-progress": "PolymerElements/paper-progress#^2.0.0",
     "paper-radio-group": "PolymerElements/paper-radio-group#^2.0.0",
+    "paper-toast": "PolymerElements/paper-toast#^2.0.0",
     "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.0",
     "polymer": "Polymer/polymer#^2.0.1",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.9",
-    "xterm.js": "^2.7.0",
-    "paper-toast": "PolymerElements/paper-toast#^2.0.0"
+    "xterm.js": "^2.7.0"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0"

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -16,7 +16,6 @@ the License.
 <link rel="import" href="../../bower_components/app-route/app-route.html">
 <link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
 <link rel="import" href="../../bower_components/paper-toast/paper-toast.html">
-<link rel="import" href="../../bower_components/neon-animation/web-animations.html">
 
 <link rel="import" href="../../components/datalab-sidebar/datalab-sidebar.html">
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
@@ -84,8 +83,7 @@ the License.
       </div>
     </div>
 
-    <paper-toast id="toast2" class="fit-bottom error-toast" duration="0"
-                 text="This toast is red and fits bottom!"></paper-toast>
+    <paper-toast id="toast"></paper-toast>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -45,8 +45,8 @@ the License.
         width: calc(100% - var(--sidebar-width));
       }
       .error-toast {
-        --paper-toast-background-color: #330000;
-        --paper-toast-color: white;
+        --paper-toast-background-color: #000;
+        --paper-toast-color: #fff;
       }
       iron-pages {
         height: 100%;
@@ -88,6 +88,7 @@ the License.
   </template>
 </dom-module>
 
+<script src="../../modules/Utils.js"></script>
 <script src="../../modules/ApiManager.js"></script>
 <script src="../../modules/SettingsManager.js"></script>
 <script src="datalab-app.js"></script>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -79,7 +79,7 @@ the License.
       </div>
     </div>
 
-    <paper-toast id="connectionToast"></paper-toast>
+    <paper-toast id="notificationToast"></paper-toast>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -15,6 +15,8 @@ the License.
 <link rel="import" href="../../bower_components/app-route/app-location.html">
 <link rel="import" href="../../bower_components/app-route/app-route.html">
 <link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
+<link rel="import" href="../../bower_components/paper-toast/paper-toast.html">
+<link rel="import" href="../../bower_components/neon-animation/web-animations.html">
 
 <link rel="import" href="../../components/datalab-sidebar/datalab-sidebar.html">
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
@@ -42,6 +44,10 @@ the License.
         flex-grow: 1;
         box-shadow: -4px 0px 10px -3px rgba(0, 0, 0, 0.1);
         width: calc(100% - var(--sidebar-width));
+      }
+      .error-toast {
+        --paper-toast-background-color: #330000;
+        --paper-toast-color: white;
       }
       iron-pages {
         height: 100%;
@@ -77,6 +83,9 @@ the License.
         </div>
       </div>
     </div>
+
+    <paper-toast id="toast2" class="fit-bottom error-toast" duration="0"
+                 text="This toast is red and fits bottom!"></paper-toast>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -44,10 +44,6 @@ the License.
         box-shadow: -4px 0px 10px -3px rgba(0, 0, 0, 0.1);
         width: calc(100% - var(--sidebar-width));
       }
-      .error-toast {
-        --paper-toast-background-color: #000;
-        --paper-toast-color: #fff;
-      }
       iron-pages {
         height: 100%;
       }
@@ -83,7 +79,7 @@ the License.
       </div>
     </div>
 
-    <paper-toast id="toast"></paper-toast>
+    <paper-toast id="connectionToast"></paper-toast>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -55,6 +55,14 @@ class DatalabAppElement extends Polymer.Element {
 
     // Will be called after the custom element is done rendering.
     window.addEventListener('WebComponentsReady', this._boundResizeHandler, true);
+
+    ApiManager.disconnectedHandler = () => {
+      this.showNotification('Failed to connect to the server.', true /*sticky*/);
+    }
+    ApiManager.connectedHandler = () => {
+      this.hideNotification();
+    }
+
   }
 
   static get is() { return 'datalab-app'; }
@@ -131,20 +139,20 @@ class DatalabAppElement extends Polymer.Element {
    * @param sticky whether the toast should stick around until explicitly dismissed in code
    */
   showNotification(message: string, sticky?: boolean) {
-    this.$.connectionToast.close();
-    this.$.connectionToast.text = message;
+    this.$.notificationToast.close();
+    this.$.notificationToast.text = message;
     if (sticky) {
-      this.$.connectionToast.duration = 0;
+      this.$.notificationToast.duration = 0;
     }
-    this.$.connectionToast.open();
+    this.$.notificationToast.open();
   }
 
   /**
    * Hides the notification toast if it's open.
    */
   hideNotification() {
-    if (this.$.connectionToast.opened) {
-      this.$.connectionToast.close();
+    if (this.$.notificationToast.opened) {
+      this.$.notificationToast.close();
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -63,6 +63,14 @@ class DatalabAppElement extends Polymer.Element {
       this.hideNotification();
     }
 
+    // Handle notification events bubbled up from children.
+    this.addEventListener('notification', (e: NotificationEvent) => {
+      if (e.detail.show) {
+        this.showNotification(e.detail.message, e.detail.sticky);
+      } else {
+        this.hideNotification();
+      }
+    });
   }
 
   static get is() { return 'datalab-app'; }

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -125,6 +125,20 @@ class DatalabAppElement extends Polymer.Element {
     }
   }
 
+  showNotification(message: string, isError?: boolean, sticky?: boolean) {
+    this.$.toast.close();
+    this.$.toast.text = message;
+    this.$.toast.classList = isError ? ['error-toast'] : [];
+    if (sticky) {
+      this.$.toast.duration = 0;
+    }
+    this.$.toast.open();
+  }
+
+  hideNotification() {
+    this.$.toast.close();
+  }
+
 }
 
 customElements.define(DatalabAppElement.is, DatalabAppElement);

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -125,18 +125,27 @@ class DatalabAppElement extends Polymer.Element {
     }
   }
 
-  showNotification(message: string, isError?: boolean, sticky?: boolean) {
-    this.$.toast.close();
-    this.$.toast.text = message;
-    this.$.toast.classList = isError ? ['error-toast'] : [];
+  /**
+   * Shows a notification toast at the bottom of the page with the given message.
+   * @param message message to show in the notification toast
+   * @param sticky whether the toast should stick around until explicitly dismissed in code
+   */
+  showNotification(message: string, sticky?: boolean) {
+    this.$.connectionToast.close();
+    this.$.connectionToast.text = message;
     if (sticky) {
-      this.$.toast.duration = 0;
+      this.$.connectionToast.duration = 0;
     }
-    this.$.toast.open();
+    this.$.connectionToast.open();
   }
 
+  /**
+   * Hides the notification toast if it's open.
+   */
   hideNotification() {
-    this.$.toast.close();
+    if (this.$.connectionToast.opened) {
+      this.$.connectionToast.close();
+    }
   }
 
 }

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.html
@@ -317,5 +317,4 @@ the License.
   </template>
 </dom-module>
 
-<script src="../../modules/Utils.js"></script>
 <script src="datalab-files.js"></script>

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -229,11 +229,7 @@ class FilesElement extends Polymer.Element {
           this._fileList = newList;
           this._drawFileList();
         }
-      }, () => {
-        // TODO: [yebrahim] Add dummy data here when debugging is enabled to allow for
-        // fast UI iteration using `polymer serve`.
-        console.log('Error getting list of files.');
-      })
+      }, () => console.log('Error getting list of files.'))
       .then(() => {
         this._fetching = false;
       });

--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.html
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.html
@@ -59,7 +59,6 @@ the License.
     </style>
 
     <!--Toolbar with shutdown button-->
-    <!--TODO: [yebrahim] Make the shutdown button do stuff-->
     <div id="toolbar">
       <paper-button class="toolbar-button" on-click="_fetchSessionList">
         <iron-icon icon="refresh"></iron-icon>

--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
@@ -118,11 +118,7 @@ class SessionsElement extends Polymer.Element {
           self._sessionList = newList;
           this._drawSessionList();
         }
-      }, () => {
-        // TODO: [yebrahim] Add dummy data here when debugging is enabled to allow for
-        // fast UI iteration using `polymer serve`.
-        console.log('Error getting list of sessions.');
-      })
+      }, () => console.log('Error getting list of sessions.'))
       .then(() => {
         this._fetching = false;
       });

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -25,12 +25,6 @@ the License.
         --app-content-font-family: 'Roboto', 'Noto', sans-serif;
         --primary-text-color : var(--primary-fg-color);
       }
-      *, *::after, *::before {
-        /* Animate the color changes for when themes are switched. */
-        transition: border-color var(--app-animation-duration),
-                    color var(--app-animation-duration),
-                    background-color var(--app-animation-duration);
-      }
       hr {
         border-left: none;
         border-right: none;

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -152,8 +152,8 @@ class ApiManager {
    * Handlers for connected/disconnected status. These will be called when the
    * isConnected property changes value.
    */
-  static connectedHandler: Function;
-  static disconnectedHandler: Function;
+  static connectedHandler: () => void;
+  static disconnectedHandler: () => void;
 
   /**
    * Returns a list of currently running sessions, each implementing the Session interface

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -94,6 +94,7 @@ interface XhrOptions {
   errorCallback?: Function,
   parameters?: string | FormData,
   successCode?: number,
+  failureCodes?: number[],
   noCache?: boolean,
 }
 
@@ -240,6 +241,7 @@ class ApiManager {
     const xhrOptions: XhrOptions = {
       method: 'POST',
       successCode: 201,
+      failureCodes: [409],
       parameters: JSON.stringify({
         type: type,
         ext: 'ipynb'
@@ -274,6 +276,7 @@ class ApiManager {
     oldPath = ApiManager.contentApiUrl + '/' + oldPath;
     const xhrOptions: XhrOptions = {
       method: 'PATCH',
+      failureCodes: [409],
       parameters: JSON.stringify({
         path: newPath
       }),
@@ -307,6 +310,7 @@ class ApiManager {
     const xhrOptions: XhrOptions = {
       method: 'POST',
       successCode: 201,
+      failureCodes: [409],
       parameters: JSON.stringify({
         copy_from: itemPath
       })
@@ -421,17 +425,22 @@ class ApiManager {
     const successCode = options.successCode || 200;
     const request = new XMLHttpRequest();
     const noCache = options.noCache || false;
+    const failureCodes = options.failureCodes;
 
     return new Promise((resolve, reject) => {
       request.onreadystatechange = () => {
         if (request.readyState === 4) {
           if (request.status === successCode) {
+            Utils.connectionSucceeded();
             try {
               resolve(request.responseText);
             } catch (e) {
               reject(e);
             }
           } else {
+            if (!failureCodes || failureCodes.indexOf(request.readyState) > -1) {
+              Utils.connectionFailed();
+            }
             reject(request.responseText);
           }
         }

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -112,20 +112,4 @@ class Utils {
     }
   }
 
-  /**
-   * Called when an API call fails, so that a connection error message can be shown.
-   */
-  static connectionFailed() {
-    const host = <DatalabAppElement>document.querySelector('datalab-app');
-    host.showNotification('Failed to connect to the server.', true /*sticky*/);
-  }
-
-  /**
-   * Called when an API call succeeds, so that the connection error message can be hidden.
-   */
-  static connectionSucceeded() {
-    const host = <DatalabAppElement>document.querySelector('datalab-app');
-    host.hideNotification();
-  }
- 
 }

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -112,11 +112,17 @@ class Utils {
     }
   }
 
+  /**
+   * Called when an API call fails, so that a connection error message can be shown.
+   */
   static connectionFailed() {
     const host = <DatalabAppElement>document.querySelector('datalab-app');
-    host.showNotification('Failed to connect to the server.', true /*isError*/, true /*sticky*/);
+    host.showNotification('Failed to connect to the server.', true /*sticky*/);
   }
 
+  /**
+   * Called when an API call succeeds, so that the connection error message can be hidden.
+   */
   static connectionSucceeded() {
     const host = <DatalabAppElement>document.querySelector('datalab-app');
     host.hideNotification();

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -112,4 +112,14 @@ class Utils {
     }
   }
 
+  static connectionFailed() {
+    const host = <DatalabAppElement>document.querySelector('datalab-app');
+    host.showNotification('Failed to connect to the server.', true /*isError*/, true /*sticky*/);
+  }
+
+  static connectionSucceeded() {
+    const host = <DatalabAppElement>document.querySelector('datalab-app');
+    host.hideNotification();
+  }
+ 
 }

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -113,3 +113,27 @@ class Utils {
   }
 
 }
+
+/**
+ * A custom even class that signals a notification should be shown with a message,
+ * or hidden. The event can be fired on any element in the DOM tree, and will bubble up.
+ * @param message notification message to show
+ * @param show whether the notification toast should be shown or hidden. Default true.
+ * @param sticky whether the notification should stick around until dismissed. Default false.
+ */
+class NotificationEvent extends CustomEvent {
+  constructor(message: string = '', show: boolean = true, sticky: boolean = false) {
+
+    const eventInit = {
+      bubbles: true,
+      composed: true, // Needed to pierce the shadow DOM boundaries
+      detail: {
+        show: show,
+        sticky: sticky,
+        message: message,
+      },
+    }
+
+    super('notification', eventInit);
+  }
+}


### PR DESCRIPTION
This PR adds a paper-toast element that shows a connection error message whenever an XHR request fails with an unexpected code. The notification is dismissed whenever requests succeed.

A new custom even `NotificationEvent` can be fired on any child element, and is handled by the shell element `datalab-app` to show/hide the notification toast. Note this is currently not used anywhere, but it's part of this PR to open the discussion about the design of notifications.

![image](https://user-images.githubusercontent.com/1424661/28295621-d7d756da-6b16-11e7-8743-7b75d7fce76a.png)
