### PR TITLE
[Polymer UI] Fix broken /files/path for download

### DIFF
--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -175,7 +175,9 @@ export function isExperimentalResource(pathname: string) {
   const experimentalUiEnabled = process.env.DATALAB_EXPERIMENTAL_UI;
   return experimentalUiEnabled === 'true' && (
       pathname.indexOf('/data') === 0 ||
-      pathname === '/files' || // /files/path?download=true is used to download files from Jupyter
+      pathname === '/files' ||
+      // /files/path?download=true is used to download files from Jupyter
+      // TODO: use a different API to download files when we have a content service.
       pathname.indexOf('/sessions') === 0 ||
       pathname.indexOf('/terminal') === 0 ||
       pathname.indexOf('/editor') === 0 ||

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -175,7 +175,7 @@ export function isExperimentalResource(pathname: string) {
   const experimentalUiEnabled = process.env.DATALAB_EXPERIMENTAL_UI;
   return experimentalUiEnabled === 'true' && (
       pathname.indexOf('/data') === 0 ||
-      pathname.indexOf('/files') === 0 ||
+      pathname === '/files' || // /files/path?download=true is used to download files from Jupyter
       pathname.indexOf('/sessions') === 0 ||
       pathname.indexOf('/terminal') === 0 ||
       pathname.indexOf('/editor') === 0 ||


### PR DESCRIPTION
Fixes https://github.com/googledatalab/datalab/issues/1442.

With this change, `/files` and `/files/path/to/file` are entirely different APIs. The first is just a view on the datalab shell entry point, the second is a file content service that's needed by Jupyter to download files. We might want to replace this for other backends than Jupyter.