### PR TITLE
[Polymer UI] Call resize handler on datalab-files ready

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -53,9 +53,6 @@ class DatalabAppElement extends Polymer.Element {
     this._boundResizeHandler = this._resizeHandler.bind(this);
     window.addEventListener('resize', this._boundResizeHandler, true);
 
-    // Will be called after the custom element is done rendering.
-    window.addEventListener('WebComponentsReady', this._boundResizeHandler, true);
-
     ApiManager.disconnectedHandler = () => {
       this.showNotification('Failed to connect to the server.', true /*sticky*/);
     }
@@ -101,7 +98,6 @@ class DatalabAppElement extends Polymer.Element {
   disconnectedCallback() {
     if (this._boundResizeHandler) {
       window.removeEventListener('resize', this._boundResizeHandler);
-      window.removeEventListener('WebComponentsReady', this._boundResizeHandler);
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -174,7 +174,9 @@ class FilesElement extends Polymer.Element {
     }
 
     // For a small file/directory picker, we don't need to show the status.
-    (<ItemListElement>this.$.files).columns = this.small ? ['Name'] : ['Name', 'Status'];
+    (this.$.files as ItemListElement).columns = this.small ? ['Name'] : ['Name', 'Status'];
+
+    this._resizeHandler();
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
We should avoid using the global `WebComponentsReady` event for these things. It's enough to use the element's `ready` callback.