### PR TITLE
[Polymer UI] Add tslint to the build

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -46,6 +46,11 @@ function install_typescript() {
   npm install -g typescript
 }
 
+function install_tslint() {
+  echo "Installing tslint"
+  npm install -g tslint
+}
+
 function install_git() {
   echo "Updating apt repository"
   apt-get update -y -qq
@@ -66,6 +71,7 @@ function install_prereqs() {
   # Use -v instead of -h to test npm installation, since -h returns non-zero
   npm -v >/dev/null 2>&1 || install_node
   tsc -h >/dev/null 2>&1  || install_typescript
+  tslint -h >/dev/null 2>&1  || install_tslint
   bower -h >/dev/null 2>&1  || install_bower
   polymer -h >/dev/null 2>&1  || install_polyer_cli
   source ./tools/initenv.sh

--- a/sources/web/build.sh
+++ b/sources/web/build.sh
@@ -32,6 +32,7 @@ mkdir -p $WEB_DIR
 # Experimental UI build step
 cd datalab/polymer
 bower --allow-root install
+tslint *.ts components/**/*.ts modules/*.ts
 tsc
 polymer build
 rsync -avpq ./build/experimental/ ../static/experimental

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -315,9 +315,9 @@ class ApiManager {
   public static deleteItem(path: string) {
     path = ApiManager.contentApiUrl + '/' + path;
     const xhrOptions: XhrOptions = {
+      failureCodes: [400],
       method: 'DELETE',
       successCode: 204,
-      failureCodes: [400],
     };
 
     return ApiManager.sendRequestAsync(path, xhrOptions);

--- a/sources/web/datalab/polymer/tslint.json
+++ b/sources/web/datalab/polymer/tslint.json
@@ -1,5 +1,5 @@
 {
-  "defaultSeverity": "warning",
+  "defaultSeverity": "error",
   "extends": ["tslint:recommended"],
   "rules": {
     "array-type": [true,
@@ -27,7 +27,7 @@
     "new-parens": true,
     "no-angle-bracket-type-assertion": true,
     "no-arg": true,
-    "no-console": true,
+    "no-console": {"severity": "warning"},
     "no-construct": true,
     "no-debugger": true,
     "no-default-export": true,


### PR DESCRIPTION
This adds `tslint` as a build step, the build will fail on errors from the linter.

Note you'll see a few warnings about using `console.log`, we should work on removing those shortly, then convert the `tslint` rule to error severity.