### PR TITLE
Add initial BigQuery API access.

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -16,6 +16,8 @@
 /// <reference path="../input-dialog/input-dialog.ts" />
 /// <reference path="../item-list/item-list.ts" />
 
+type HttpResponse<T> = gapi.client.HttpResponse<T>;
+
 interface Collection {
   name: string;
   status: string;
@@ -135,11 +137,11 @@ class DataElement extends Polymer.Element {
     const sampleDataset = 'samples';
     const emptyFilter = '';
     GapiManager.listBigQueryProjects()
-        .then((response: gapi.client.bigquery.ListProjectsResponse) => console.log('== projects: ', response));
+        .then((response: HttpResponse<gapi.client.bigquery.ListProjectsResponse>) => console.log('== projects: ', response));
     GapiManager.listBigQueryDatasets(sampleProject, emptyFilter)
-        .then((response: gapi.client.bigquery.ListDatasetsResponse) => console.log('== datasets: ', response));
+        .then((response: HttpResponse<gapi.client.bigquery.ListDatasetsResponse>) => console.log('== datasets: ', response));
     GapiManager.listBigQueryTables(sampleProject, sampleDataset, emptyFilter)
-        .then((response: gapi.client.bigquery.ListTablesResponse) => console.log('== tables: ', response));
+        .then((response: HttpResponse<gapi.client.bigquery.ListTablesResponse>) => console.log('== tables: ', response));
   }
 
   /**

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -12,6 +12,7 @@
  * the License.
  */
 
+/// <reference path="../../modules/GapiManager.ts" />
 /// <reference path="../input-dialog/input-dialog.ts" />
 /// <reference path="../item-list/item-list.ts" />
 
@@ -125,6 +126,20 @@ class DataElement extends Polymer.Element {
   /** Reads the user's query values, queries for tables, and updates the results. */
   _search() {
     this._collectionsList = this._generateFakeCollectionsListForTesting();
+    this._debugCallBigQuery();   // For debugging, make some BigQuery calls
+  }
+
+  // Make some calls to the BigQuery API and log the results to the console.
+  _debugCallBigQuery() {
+    const sampleProject = 'bigquery-public-data';
+    const sampleDataset = 'samples';
+    const emptyFilter = '';
+    GapiManager.listBigQueryProjects()
+        .then((response: gapi.client.bigquery.ListProjectsResponse) => console.log('== projects: ', response));
+    GapiManager.listBigQueryDatasets(sampleProject, emptyFilter)
+        .then((response: gapi.client.bigquery.ListDatasetsResponse) => console.log('== datasets: ', response));
+    GapiManager.listBigQueryTables(sampleProject, sampleDataset, emptyFilter)
+        .then((response: gapi.client.bigquery.ListTablesResponse) => console.log('== tables: ', response));
   }
 
   /**

--- a/sources/web/datalab/polymer/modules/GapiManager.ts
+++ b/sources/web/datalab/polymer/modules/GapiManager.ts
@@ -35,6 +35,8 @@ class GapiManager {
 
   /**
    * Loads the gapi module and the auth2 modules.
+   * @param signInChangedCallback callback to be called when the signed-in state changes
+   * @returns a promise that completes when the load is done or has failed
    */
   public static loadGapi(signInChangedCallback: (signedIn: boolean) => void) {
     // Loads the gapi client library and the auth2 library together for efficiency.

--- a/sources/web/datalab/polymer/modules/GapiManager.ts
+++ b/sources/web/datalab/polymer/modules/GapiManager.ts
@@ -38,7 +38,7 @@ class GapiManager {
    * @param signInChangedCallback callback to be called when the signed-in state changes
    * @returns a promise that completes when the load is done or has failed
    */
-  public static loadGapi(signInChangedCallback: (signedIn: boolean) => void) {
+   public static loadGapi(signInChangedCallback: (signedIn: boolean) => void): Promise<void> {
     // Loads the gapi client library and the auth2 library together for efficiency.
     // Loading the auth2 library is optional here since `gapi.client.init` function will load
     // it if not already loaded. Loading it upfront can save one network request.
@@ -56,20 +56,20 @@ class GapiManager {
    * appear momentarily before automatically closing. If the doPrompt flag is set, then
    * the user will be prompted as if authorization has not previously been provided.
    */
-  public static signIn(doPrompt: boolean) {
+   public static signIn(doPrompt: boolean): Promise<gapi.auth2.GoogleUser> {
     const rePromptOptions = 'login consent select_account';
     const promptFlags = doPrompt ? rePromptOptions : '';
     const options = {
       prompt: promptFlags,
     };
-    gapi.auth2.getAuthInstance().signIn(options);
+    return gapi.auth2.getAuthInstance().signIn(options);
   }
 
   /**
    * Signs the user out using gapi.
    */
-  public static signOut() {
-    gapi.auth2.getAuthInstance().signOut();
+   public static signOut(): Promise<void> {
+    return gapi.auth2.getAuthInstance().signOut();
   }
 
   /** Returns the signed-in user's email address. */

--- a/sources/web/datalab/polymer/modules/GapiManager.ts
+++ b/sources/web/datalab/polymer/modules/GapiManager.ts
@@ -13,6 +13,7 @@
  */
 
 /// <reference path="./ApiManager.ts" />
+/// <reference path="../../../../../third_party/externs/ts/gapi/bigquery.d.ts" />
 /// <reference path="../../../../../third_party/externs/ts/gapi/gapi.d.ts" />
 /// <reference path="../../common.d.ts" />
 
@@ -21,9 +22,14 @@
  */
 class GapiManager {
 
-  public static DISCOVERYDOCS = ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'];
-  public static SCOPES = 'https://www.googleapis.com/auth/drive.metadata.readonly ' +
-      'https://www.googleapis.com/auth/devstorage.full_control';
+  public static DISCOVERYDOCS = [
+    'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest',
+    'https://www.googleapis.com/discovery/v1/apis/bigquery/v2/rest'
+  ];
+  public static SCOPES =
+      'https://www.googleapis.com/auth/drive.metadata.readonly ' +
+      'https://www.googleapis.com/auth/devstorage.full_control ' +
+      'https://www.googleapis.com/auth/bigquery';
 
   private static _clientId = '';   // Gets set by _loadClientId()
 
@@ -34,7 +40,8 @@ class GapiManager {
     // Loads the gapi client library and the auth2 library together for efficiency.
     // Loading the auth2 library is optional here since `gapi.client.init` function will load
     // it if not already loaded. Loading it upfront can save one network request.
-    GapiManager._loadClientId()
+    console.log('== loading gapi');
+    return GapiManager._loadClientId()
       .then(() => gapi.load('client:auth2', this._initClient.bind(this, signInChangedCallback)))
       .catch((e: Error) => console.log('Failed to get client ID: ', e));
   }
@@ -68,6 +75,30 @@ class GapiManager {
     return gapi.auth2.getAuthInstance().currentUser.get().getBasicProfile().getEmail();
   }
 
+  /** Gets the list of BigQuery projects, returns a Promise. */
+  public static listBigQueryProjects(): gapi.client.HttpRequest<gapi.client.bigquery.ListProjectsResponse> {
+    return GapiManager._loadBigQuery().then(() => gapi.client.bigquery.projects.list());
+  }
+
+  /** Gets the list of BigQuery datasets in the specified project, returns a Promise. */
+  public static listBigQueryDatasets(projectId: string, filter: string): gapi.client.HttpRequest<gapi.client.bigquery.ListDatasetsResponse> {
+    const request = {
+      filter,
+      projectId,
+    };
+    return GapiManager._loadBigQuery().then(() => gapi.client.bigquery.datasets.list(request));
+  }
+
+  /** Gets the list of BigQuery tables in the specified project and dataset, returns a Promise. */
+  public static listBigQueryTables(projectId: string, datasetId: string, filter: string): gapi.client.HttpRequest<gapi.client.bigquery.ListTablesResponse> {
+    const request = {
+      datasetId,
+      filter,
+      projectId,
+    };
+    return GapiManager._loadBigQuery().then(() => gapi.client.bigquery.tables.list(request));
+  }
+
   private static _initClient(signInChangedCallback: (signedIn: boolean) => void) {
     // Initialize the client with API key and People API, and initialize OAuth with an
     // OAuth 2.0 client ID and scopes (space delimited string) to request access.
@@ -82,6 +113,9 @@ class GapiManager {
           this._signInChanged(signInChangedCallback));
       // Initialize with current signed-in state
       this._signInChanged(signInChangedCallback);
+      console.log('== gapi loaded and listening for auth');
+    }, (errorReason) => {
+      console.log('Error in gapi auth: ' + errorReason.result.error.message);
     });
   }
 
@@ -103,5 +137,9 @@ class GapiManager {
           throw new Error('No oauth2ClientId found in user settings');
         }
       });
+  }
+
+  private static _loadBigQuery(): Promise<void> {
+    return gapi.client.load('bigquery', 'v2');
   }
 }

--- a/third_party/externs/ts/gapi/bigquery.d.ts
+++ b/third_party/externs/ts/gapi/bigquery.d.ts
@@ -36,12 +36,10 @@ declare namespace gapi.client {
     }
 
     interface ListDatasetsResponse {
-      /*
       kind: string;   // Should always be "bigquery#datasetList"
       etag: string;
       nextPageToken: string;
       datasets: Array<DatasetResource>;
-      */
     }
 
     // https://cloud.google.com/bigquery/docs/reference/rest/v2/projects/list
@@ -51,13 +49,11 @@ declare namespace gapi.client {
     }
 
     interface ListProjectsResponse {
-      /*
       kind: string;   // Should always be "bigquery#projectList"
       etag: string;
       nextPageToken: string;
       projects: Array<ProjectResource>;
       totalItems: number;
-      */
     }
 
     interface ListTablesRequest {

--- a/third_party/externs/ts/gapi/bigquery.d.ts
+++ b/third_party/externs/ts/gapi/bigquery.d.ts
@@ -1,0 +1,85 @@
+declare namespace gapi.client {
+  export module bigquery {
+    const datasets: {
+      list: (request?: ListDatasetsRequest) => HttpRequest<ListDatasetsResponse>;
+    }
+
+    const projects: {
+      list: (request?: ListProjectsRequest) => HttpRequest<ListProjectsResponse>;
+    }
+
+    const tables: {
+      list: (request?: ListTablesRequest) => HttpRequest<ListTablesResponse>;
+    }
+
+    interface DatasetReference {
+      datasetId: string;
+      projectId: string;
+    }
+
+    interface DatasetResource {
+      kind: string;   // Should always be "bigquery#dataset"
+      id: string;
+      datasetReference: DatasetReference;
+      labels: Object;
+      friendlyName: string;
+    }
+
+    // https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list
+    interface ListDatasetsRequest {
+      projectId: string;
+      all?: boolean;    // true to list all datasets, including hidden ones
+      filter?: string;  // syntax: "labels.<name>[:<value>]"
+            // multiple filters can be ANDed by connecting with a space
+      maxResults?: number  // (unsigned int)
+      pageToken?: string  // page token as returned by a previous call
+    }
+
+    interface ListDatasetsResponse {
+      /*
+      kind: string;   // Should always be "bigquery#datasetList"
+      etag: string;
+      nextPageToken: string;
+      datasets: Array<DatasetResource>;
+      */
+    }
+
+    // https://cloud.google.com/bigquery/docs/reference/rest/v2/projects/list
+    interface ListProjectsRequest {
+      maxResults?: number  // (unsigned int)
+      pageToken?: string  // page token as returned by a previous call
+    }
+
+    interface ListProjectsResponse {
+      /*
+      kind: string;   // Should always be "bigquery#projectList"
+      etag: string;
+      nextPageToken: string;
+      projects: Array<ProjectResource>;
+      totalItems: number;
+      */
+    }
+
+    interface ListTablesRequest {
+      projectId: string;
+    }
+
+    interface ListTablesResponse {
+    }
+
+    interface ProjectReference {
+      projectId: string;
+    }
+
+    interface ProjectResource {
+      kind: string;   // Should always be "biqquery#project"
+      id: string;
+      numericId: number;    // unsigned long
+      projectReference: ProjectReference;
+      friendlyName: string;
+    }
+
+    interface TableResource {
+    }
+  }
+}

--- a/third_party/externs/ts/gapi/gapi.d.ts
+++ b/third_party/externs/ts/gapi/gapi.d.ts
@@ -9,12 +9,24 @@ declare module gapi.client {
     scope?: string;
   }): Promise<void>;
 
+  export function load(name: string, version: string): Promise<void>;
+
   interface RequestOptions {
     path: string;
     params?: any;
   }
 
   export function request(args: RequestOptions): Promise<any>;
+
+  interface HttpResponse<T> {
+    body: string;
+    headers: Array<Object>;
+    result: T;
+    status: number;
+    statusText: string;
+  }
+
+  export class HttpRequest<T> extends Promise<HttpResponse<T>> {}
 }
 
 declare module gapi.auth2 {

--- a/third_party/externs/ts/gapi/gapi.d.ts
+++ b/third_party/externs/ts/gapi/gapi.d.ts
@@ -11,13 +11,6 @@ declare module gapi.client {
 
   export function load(name: string, version: string): Promise<void>;
 
-  interface RequestOptions {
-    path: string;
-    params?: any;
-  }
-
-  export function request(args: RequestOptions): Promise<any>;
-
   interface HttpResponse<T> {
     body: string;
     headers: Array<Object>;


### PR DESCRIPTION
This PR implements some basic API calls to BigQuery. At the moment, these are only used from a sample debugging call that gets executed when the Search button is pressed, and which just logs to the console. The next step is to figure out how the user can supply the values that are passed to these functions, and how to display the results.