### PR TITLE
[Polymer UI] Add optional input box to directory picker

### DIFF
--- a/sources/web/datalab/polymer/components/base-dialog/base-dialog.html
+++ b/sources/web/datalab/polymer/components/base-dialog/base-dialog.html
@@ -24,8 +24,8 @@ the License.
         flex-direction: column;
       }
       .dialog-big--true {
-        width: 40%;
-        height: 40%;
+        width: 60%;
+        height: 60%;
       }
       .dialog-big--false {
         min-width: 300px;

--- a/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.html
+++ b/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.html
@@ -27,10 +27,10 @@ the License.
       .files {
         flex: 1 1 auto;
       }
-      .input {
+      .fileName {
         flex: 0 0 auto;
       }
-      #inputBox {
+      #fileNameBox {
         width: 300px;
         margin: 10px auto;
         /*Disable input underline animation*/
@@ -45,9 +45,9 @@ the License.
       <div class="files">
         <datalab-files id="filePicker" small></datalab-files>
       </div>
-      <div class="input" hidden$={{!withFileName}}>
+      <div class="fileName" hidden$={{!withFileName}}>
         <hr>
-        <paper-input id="inputBox" label="File name" spellcheck=false autofocus
+        <paper-input id="fileNameBox" label="File name" spellcheck=false autofocus
                     value="{{fileName}}" no-label-float>
         </paper-input>
       </div>

--- a/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.html
+++ b/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.html
@@ -14,13 +14,45 @@ the License.
 
 <link rel="import" href="../datalab-files/datalab-files.html">
 
+<link rel="import" href="../../bower_components/paper-input/paper-input.html">
+
 <dom-module id="directory-picker-dialog">
   <template>
+
     <style include="datalab-shared-styles">
+      .container {
+        display: flex;
+        flex-direction: column;
+      }
+      .files {
+        flex: 1 1 auto;
+      }
+      .input {
+        flex: 0 0 auto;
+      }
+      #inputBox {
+        width: 300px;
+        margin: 10px auto;
+        /*Disable input underline animation*/
+        --paper-input-container-underline-focus: {
+          display: none;
+        };
+        --primary-text-color: var(--primary-fg-color);
+      }
     </style>
-    <div class="files">
-      <datalab-files id="filePicker" small></datalab-files>
+
+    <div class="container">
+      <div class="files">
+        <datalab-files id="filePicker" small></datalab-files>
+      </div>
+      <div class="input" hidden$={{!withInput}}>
+        <hr>
+        <paper-input id="inputBox" label="File name" spellcheck=false autofocus
+                    value="{{inputValue}}" no-label-float>
+        </paper-input>
+      </div>
     </div>
+
   </template>
 </dom-module>
 

--- a/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.html
+++ b/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.html
@@ -45,10 +45,10 @@ the License.
       <div class="files">
         <datalab-files id="filePicker" small></datalab-files>
       </div>
-      <div class="input" hidden$={{!withInput}}>
+      <div class="input" hidden$={{!withFileName}}>
         <hr>
         <paper-input id="inputBox" label="File name" spellcheck=false autofocus
-                    value="{{inputValue}}" no-label-float>
+                    value="{{fileName}}" no-label-float>
         </paper-input>
       </div>
     </div>

--- a/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.ts
+++ b/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.ts
@@ -38,23 +38,23 @@ class DirectoryPickerDialogElement extends BaseDialogElement {
   /**
    * Initial value of input box.
    */
-  public inputValue: string;
+  public fileName: string;
 
   /**
    * Whether to include an input box under the file picker.
    */
-  public withInput: boolean;
+  public withFileName: boolean;
 
   static get is() { return 'directory-picker-dialog'; }
 
   static get properties() {
     return {
       ...super.properties,
-      inputValue: {
+      fileName: {
         type: String,
         value: '',
       },
-      withInput: {
+      withFileName: {
         type: Boolean,
         value: false,
       },
@@ -79,7 +79,7 @@ class DirectoryPickerDialogElement extends BaseDialogElement {
   getCloseResult() {
     return {
       directoryPath: this.$.filePicker.currentPath,
-      fileName: this.withInput ? this.$.inputBox.value : undefined,
+      fileName: this.withFileName ? this.$.inputBox.value : undefined,
     };
   }
 

--- a/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.ts
+++ b/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.ts
@@ -20,6 +20,7 @@
  */
 interface DirectoryPickerDialogCloseResult extends BaseDialogCloseResult {
   directoryPath: string;
+  fileName?: string;
 }
 
 /**
@@ -34,7 +35,31 @@ class DirectoryPickerDialogElement extends BaseDialogElement {
 
   private static _memoizedTemplate: PolymerTemplate;
 
+  /**
+   * Initial value of input box.
+   */
+  public inputValue: string;
+
+  /**
+   * Whether to include an input box under the file picker.
+   */
+  public withInput: boolean;
+
   static get is() { return 'directory-picker-dialog'; }
+
+  static get properties() {
+    return {
+      ...super.properties,
+      inputValue: {
+        type: String,
+        value: '',
+      },
+      withInput: {
+        type: Boolean,
+        value: false,
+      },
+    };
+  }
 
   /**
    * This template is calculated once in run time based on the template of  the
@@ -54,6 +79,7 @@ class DirectoryPickerDialogElement extends BaseDialogElement {
   getCloseResult() {
     return {
       directoryPath: this.$.filePicker.currentPath,
+      fileName: this.withInput ? this.$.inputBox.value : undefined,
     };
   }
 

--- a/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.ts
+++ b/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.ts
@@ -79,7 +79,7 @@ class DirectoryPickerDialogElement extends BaseDialogElement {
   getCloseResult() {
     return {
       directoryPath: this.$.filePicker.currentPath,
-      fileName: this.withFileName ? this.$.inputBox.value : undefined,
+      fileName: this.withFileName ? this.$.fileNameBox.value : undefined,
     };
   }
 


### PR DESCRIPTION
I'll use this for the editor's new file save functionality. We could also choose to use it for copying/moving files with a new name.

Note the screenshot is only to show how it looks like with the feature enabled, but the default directory picker for copying/moving files does not have it on by default.
![image](https://user-images.githubusercontent.com/1424661/28448991-2cf0f96a-6d91-11e7-9706-344fd61ded95.png)
