### PR TITLE
[Polymer UI] Notification element, reuse in Editor

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -15,8 +15,8 @@ the License.
 <link rel="import" href="../../bower_components/app-route/app-location.html">
 <link rel="import" href="../../bower_components/app-route/app-route.html">
 <link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
-<link rel="import" href="../../bower_components/paper-toast/paper-toast.html">
 
+<link rel="import" href="../../components/datalab-notification/datalab-notification.html">
 <link rel="import" href="../../components/datalab-sidebar/datalab-sidebar.html">
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
 
@@ -79,7 +79,7 @@ the License.
       </div>
     </div>
 
-    <paper-toast id="notificationToast"></paper-toast>
+    <datalab-notification></datalab-notification>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -12,6 +12,8 @@
  * the License.
  */
 
+/// <reference path="../datalab-notification/datalab-notification.ts" />
+
 /**
  * Shell element for Datalab.
  * It contains a <datalab-toolbar> element at the top, a <datalab-sidebar>
@@ -54,21 +56,14 @@ class DatalabAppElement extends Polymer.Element {
     window.addEventListener('resize', this._boundResizeHandler, true);
 
     ApiManager.disconnectedHandler = () => {
-      this.showNotification('Failed to connect to the server.', true /*sticky*/);
+      this.dispatchEvent(new NotificationEvent('Failed to connect to the server.',
+                                               true /* show */,
+                                               true /* sticky */));
     };
 
     ApiManager.connectedHandler = () => {
-      this.hideNotification();
+      this.dispatchEvent(new NotificationEvent('', false /* show */));
     };
-
-    // Handle notification events bubbled up from children.
-    this.addEventListener('notification', (e: NotificationEvent) => {
-      if (e.detail.show) {
-        this.showNotification(e.detail.message, e.detail.sticky);
-      } else {
-        this.hideNotification();
-      }
-    });
   }
 
   static get is() { return 'datalab-app'; }
@@ -178,29 +173,6 @@ class DatalabAppElement extends Polymer.Element {
     const selectedPage = this.$.pages.selectedItem;
     if (selectedPage && selectedPage._focusHandler) {
       selectedPage._focusHandler();
-    }
-  }
-
-  /**
-   * Shows a notification toast at the bottom of the page with the given message.
-   * @param message message to show in the notification toast
-   * @param sticky whether the toast should stick around until explicitly dismissed in code
-   */
-  showNotification(message: string, sticky?: boolean) {
-    this.$.notificationToast.close();
-    this.$.notificationToast.text = message;
-    if (sticky) {
-      this.$.notificationToast.duration = 0;
-    }
-    this.$.notificationToast.open();
-  }
-
-  /**
-   * Hides the notification toast if it's open.
-   */
-  hideNotification() {
-    if (this.$.notificationToast.opened) {
-      this.$.notificationToast.close();
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.html
+++ b/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.html
@@ -15,6 +15,7 @@ the License.
 <link rel="import" href="../../bower_components/iron-icons/editor-icons.html">
 <link rel="import" href="../../bower_components/paper-progress/paper-progress.html">
 
+<link rel="import" href="../../components/datalab-notification/datalab-notification.html">
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 
@@ -109,6 +110,8 @@ the License.
       </paper-button>
     </div>
     <div id="editorContainer"></div>
+
+    <datalab-notification></datalab-notification>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.ts
+++ b/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.ts
@@ -12,6 +12,8 @@
  * the License.
  */
 
+/// <reference path="../datalab-notification/datalab-notification.ts" />
+
 /**
  * Type declarations for CodeMirror
  * TODO: Get these from DefinitelyTyped
@@ -138,8 +140,9 @@ class DatalabEditorElement extends Polymer.Element {
         path: dirPath,
         type: this._file.type,
       };
-      return ApiManager.saveJupyterFile(model);
-      // TODO: Handle save success/failure here.
+      return ApiManager.saveJupyterFile(model)
+        .then(() => this.dispatchEvent(new NotificationEvent('Saved.')));
+      // TODO: Handle save failure here.
     } else {
       return Promise.resolve(null);
     }

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -16,6 +16,7 @@
 /// <reference path="../../modules/Utils.ts" />
 /// <reference path="../item-list/item-list.ts" />
 /// <reference path="../input-dialog/input-dialog.ts" />
+/// <reference path="../datalab-notification/datalab-notification.ts" />
 /// <reference path="../../../../datalab/common.d.ts" />
 
 /**

--- a/sources/web/datalab/polymer/components/datalab-notification/datalab-notification.html
+++ b/sources/web/datalab/polymer/components/datalab-notification/datalab-notification.html
@@ -1,0 +1,28 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../bower_components/paper-toast/paper-toast.html">
+
+<dom-module id="datalab-notification">
+  <template>
+
+    <style>
+    </style>
+
+    <paper-toast id="toast"></paper-toast>
+
+  </template>
+</dom-module>
+
+<script src="datalab-notification.js"></script>

--- a/sources/web/datalab/polymer/components/datalab-notification/datalab-notification.ts
+++ b/sources/web/datalab/polymer/components/datalab-notification/datalab-notification.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * A custom even class that signals a notification should be shown with a message,
+ * or hidden. The event can be fired on any element in the DOM tree, and will bubble up.
+ * @param message notification message to show
+ * @param show whether the notification toast should be shown or hidden. Default true.
+ * @param sticky whether the notification should stick around until dismissed. Default false.
+ */
+class NotificationEvent extends CustomEvent {
+  constructor(message = '', show = true, sticky = false) {
+
+    const eventInit = {
+      bubbles: true,
+      composed: true, // Needed to pierce the shadow DOM boundaries
+      detail: {
+        message,
+        show,
+        sticky,
+      },
+    };
+
+    super('notification', eventInit);
+  }
+}
+
+/**
+ * Notification element for Datalab.
+ * This element can be dropped in any DOM element, and it will listen for
+ * 'notification' events from its children elements, and show a toast with that
+ * notification message. The notification can be 'sticky', in which case it
+ * will not disappear automatically, and it will wait on another 'notification'
+ * event that explicitly dismisses it.
+ */
+class NotificationElement extends Polymer.Element {
+
+  private _nonstickyDuration = 3 * 1000;
+
+  static get is() { return 'datalab-notification'; }
+
+  ready() {
+    super.ready();
+
+    // Handle notification events bubbled up from other DOM elements.
+    const parent = this.parentNode;
+    if (parent) {
+      // Put the event listener on the parent element
+      (parent as ShadowRoot).host.addEventListener('notification', (e: NotificationEvent) => {
+        if (e.detail.show) {
+          this.show(e.detail.message, e.detail.sticky);
+        } else {
+          this.hide();
+        }
+      });
+    }
+
+  }
+
+  /**
+   * Opens the notification toast
+   * @param message string to show in the toast
+   * @param sticky whether the toast should not automatically close
+   */
+  show(message: string, sticky = false) {
+    this.$.toast.text = message;
+    this.$.toast.duration = sticky === true ? 0 : this._nonstickyDuration;
+    this.$.toast.open();
+  }
+
+  /**
+   * Closes the notification toast
+   */
+  hide() {
+    this.$.toast.close();
+  }
+
+}
+
+customElements.define(NotificationElement.is, NotificationElement);

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -140,27 +140,3 @@ class Utils {
   }
 
 }
-
-/**
- * A custom even class that signals a notification should be shown with a message,
- * or hidden. The event can be fired on any element in the DOM tree, and will bubble up.
- * @param message notification message to show
- * @param show whether the notification toast should be shown or hidden. Default true.
- * @param sticky whether the notification should stick around until dismissed. Default false.
- */
-class NotificationEvent extends CustomEvent {
-  constructor(message = '', show = true, sticky = false) {
-
-    const eventInit = {
-      bubbles: true,
-      composed: true, // Needed to pierce the shadow DOM boundaries
-      detail: {
-        message,
-        show,
-        sticky,
-      },
-    };
-
-    super('notification', eventInit);
-  }
-}


### PR DESCRIPTION
This PR moves the markup and logic for the notification toast into a reusable element, and drops it in datalab-editor too, and uses it for the save functionality.