### PR TITLE
[Polymer UI] <item-list> element tests

### DIFF
--- a/sources/web/build.sh
+++ b/sources/web/build.sh
@@ -31,10 +31,7 @@ mkdir -p $WEB_DIR
 
 # Experimental UI build step
 cd datalab/polymer
-bower --allow-root install
-tslint *.ts components/**/*.ts modules/*.ts
-tsc
-polymer build
+npm run build
 rsync -avpq ./build/experimental/ ../static/experimental
 cd ../..
 # End experimental UI build step

--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.html
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.html
@@ -37,7 +37,7 @@ the License.
       .infoLabel {
         display: block;
         padding-bottom: 10px;
-        bottom-margin: 5px;
+        margin-bottom: 5px;
       }
     </style>
 

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -32,13 +32,13 @@ the License.
         line-height: calc(var(--toolbar-height) - 1px);
         border-bottom: 1px solid var(--border-color);
       }
-      #list-container {
+      #listContainer {
         overflow: auto;
       }
-      .list-container-hide-header--false {
+      .listContainer-hide-header--false {
         height: calc(100% - var(--toolbar-height));
       }
-      .list-container-hide-header--true {
+      .listContainer-hide-header--true {
         height: 100%;
       }
       .row {
@@ -98,7 +98,7 @@ the License.
     </div>
 
     <!--Item list-->
-    <div id="list-container" class$="list-container-hide-header--{{hideHeader}}">
+    <div id="listContainer" class$="listContainer-hide-header--{{hideHeader}}">
       <template is="dom-repeat" id="list" items="{{rows}}" as="row">
         <paper-item class="row" selected$={{row.selected}} on-click="_rowClicked"
                     on-dblclick="_rowDoubleClicked">

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -12,7 +12,8 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
-<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/iron-icons/editor-icons.html">
+<link rel="import" href="../../bower_components/iron-icons/hardware-icons.html">
 <link rel="import" href="../../bower_components/paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../../bower_components/paper-item/paper-item.html">
 

--- a/sources/web/datalab/polymer/package.json
+++ b/sources/web/datalab/polymer/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "datalab-frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.html",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "tsc && polymer test -p -l chrome"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/chai": "^4.0.1",
+    "@types/mocha": "^2.2.41"
+  }
+}

--- a/sources/web/datalab/polymer/package.json
+++ b/sources/web/datalab/polymer/package.json
@@ -1,16 +1,18 @@
 {
   "name": "datalab-frontend",
-  "version": "1.0.0",
-  "description": "",
   "main": "index.html",
   "directories": {
     "test": "test"
   },
   "scripts": {
+    "pretranspile": "tslint *.ts components/**/*.ts module/*.ts",
+    "transpile": "tsc",
+
+    "prebuild": "npm install && bower --allow-root install",
+    "build": "npm run transpile && polymer build",
+
     "test": "tsc && polymer test -p -l chrome"
   },
-  "author": "",
-  "license": "ISC",
   "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/mocha": "^2.2.41"

--- a/sources/web/datalab/polymer/package.json
+++ b/sources/web/datalab/polymer/package.json
@@ -11,7 +11,7 @@
     "prebuild": "npm install && bower --allow-root install",
     "build": "npm run transpile && polymer build",
 
-    "test": "tsc && polymer test -p -l chrome"
+    "test": "tsc && polymer test"
   },
   "devDependencies": {
     "@types/chai": "^4.0.1",

--- a/sources/web/datalab/polymer/test/item-list-test.html
+++ b/sources/web/datalab/polymer/test/item-list-test.html
@@ -19,15 +19,19 @@ the License.
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../components/item-list/item-list.html">
   </head>
   <body>
-    <script>
-      // Load and run all tests (.html, .js). Keep element tests in HTML files so we
-      // can use fixtures, and keep all other tests in javascript files
-      WCT.loadSuites([
-        'toolbar-test.html',
-        'item-list-test.html',
-      ]);
-    </script>
+
+    <test-fixture id="item-list-fixture">
+      <template>
+        <item-list></item-list>
+      </template>
+    </test-fixture>
+
+    <script src="item-list-test.js"></script>
+
   </body>
 </html>
+

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -1,0 +1,135 @@
+declare function flush(fn?: () => any): null;
+declare function assert(condition: boolean, message?: string): null;
+declare function fixture(element: string): any;
+
+/// <reference path="../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../node_modules/@types/chai/index.d.ts" />
+/// <reference path="../components/item-list/item-list.ts" />
+
+describe('<item-list>', () => {
+  let testFixture: ItemListElement;
+
+  function isSelected(i: number) {
+    const row = getRow(i);
+    const box = getCheckbox(i);
+    // Check three things: the index is in the selectedIndices array, the row
+    // has the selected attribute, and its checkbox is checked
+    return testFixture.selectedIndices.indexOf(i) > -1
+        && row.hasAttribute('selected')
+        && box.checked;
+  }
+
+  function getRow(i: number) {
+    return testFixture.$.listContainer.querySelectorAll('paper-item')[i];
+  }
+
+  function getCheckbox(i: number) {
+    const row = getRow(i);
+    return row.querySelector('paper-checkbox');
+  }
+
+  beforeEach(() => {
+    testFixture = fixture('item-list-fixture');
+    const rows: ItemListRow[] = [
+      {
+        firstCol: 'first column 1',
+        icon: 'folder',
+        secondCol: 'second column 1',
+        selected: false,
+      },
+      {
+        firstCol: 'first column 2',
+        icon: 'folder',
+        secondCol: 'second column 2',
+        selected: false,
+      },
+      {
+        firstCol: 'first column 3',
+        icon: 'folder',
+        secondCol: 'second column 3',
+        selected: false,
+      }
+    ];
+    testFixture.rows = rows;
+    flush();
+  });
+
+  it('displays a row per item in list', () => {
+    const children = testFixture.$.listContainer.querySelectorAll('paper-item');
+    assert(children.length === 3, 'three rows should appear');
+  });
+
+  it('selected items are selected', () => {
+    testFixture._selectItem(1);
+    flush();
+
+    assert(!isSelected(0), 'first item should not be selected');
+    assert(isSelected(1), 'second item should be selected');
+    assert(!isSelected(2), 'third item should not be selected');
+  });
+
+  it('selected items are returned', () => {
+    testFixture._selectItem(0);
+    testFixture._selectItem(2);
+    flush();
+
+    assert(JSON.stringify(testFixture.selectedIndices) === '[0,2]',
+        'first and third items should be selected');
+  });
+
+  it('can select/unselect all', () => {
+    const c = testFixture.$.header.querySelector('#selectAllCheckbox') as HTMLElement;
+    c.click();
+    flush();
+
+    assert(JSON.stringify(testFixture.selectedIndices) === '[0,1,2]');
+    assert(isSelected(0), 'all items should be selected');
+    assert(isSelected(1), 'all items should be selected');
+    assert(isSelected(2), 'all items should be selected');
+
+    c.click();
+    flush();
+
+    assert(JSON.stringify(testFixture.selectedIndices) === '[]');
+    assert(!isSelected(0), 'all items should be unselected');
+    assert(!isSelected(1), 'all items should be unselected');
+    assert(!isSelected(2), 'all items should be unselected');
+  });
+
+  it('clicking an item always selects it', () => {
+    const firstRow = getRow(0);
+    firstRow.click();
+    flush();
+
+    assert(isSelected(0), 'first item should be selected');
+
+    firstRow.click();
+    flush();
+
+    assert(isSelected(0), 'first item should still be selected');
+  });
+
+  it('selects only the clicked item if the checkbox was not clicked', () => {
+    const firstRow = getRow(0);
+    const secondRow = getRow(1);
+
+    firstRow.click();
+    secondRow.click();
+    flush();
+
+    assert(isSelected(1), 'only the second item should still be selected');
+  });
+
+  it('can do multi-selection using the checkboxes', () => {
+    const firstCheckbox = getCheckbox(0);
+    const secondCheckbox = getCheckbox(1);
+
+    firstCheckbox.click();
+    flush();
+    assert(isSelected(0), 'first item should be selected');
+
+    secondCheckbox.click();
+    flush();
+    assert(isSelected(0) && isSelected(1), 'both first and second items should be selected');
+  });
+});

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -70,7 +70,7 @@ describe('<item-list>', () => {
   }
 
   /**
-   * Rows must be recreated on each test with the fixture, to avoid state leakage
+   * Rows must be recreated on each test with the fixture, to avoid state leakage.
    */
   beforeEach(() => {
     testFixture = fixture('item-list-fixture');
@@ -101,7 +101,7 @@ describe('<item-list>', () => {
   });
 
   it('starts out with all items unselected', () => {
-    assert(!isSelected(0) && !isSelected(1) && !isSelected(2), 'all items should be unselected');
+    assert(JSON.stringify(testFixture.selectedIndices) === '[]', 'all items should be unselected');
   });
 
   it('displays column names in the header row', () => {
@@ -133,6 +133,8 @@ describe('<item-list>', () => {
     assert(!isSelected(0), 'first item should not be selected');
     assert(isSelected(1), 'second item should be selected');
     assert(!isSelected(2), 'third item should not be selected');
+    assert(!isSelected(3), 'fourth item should not be selected');
+    assert(!isSelected(4), 'fifth item should not be selected');
   });
 
   it('returns selected items', () => {
@@ -149,13 +151,15 @@ describe('<item-list>', () => {
 
     assert(JSON.stringify(testFixture.selectedIndices) === '[0,1,2,3,4]',
         'all items should be in the selected indices array');
-    assert(isSelected(0) && isSelected(1) && isSelected(2), 'all items should be selected');
+    assert(isSelected(0) && isSelected(1) && isSelected(2) && isSelected(3) && isSelected(4),
+        'all items should be selected');
 
     c.click();
 
     assert(JSON.stringify(testFixture.selectedIndices) === '[]',
         'no items should be in the selected indices array');
-    assert(!isSelected(0) && !isSelected(1) && !isSelected(2), 'all items should be unselected');
+    assert(!isSelected(0) && !isSelected(1) && !isSelected(2) && !isSelected(3) && !isSelected(4),
+        'all items should be unselected');
   });
 
   it('selects all items if the Select All checkbox is clicked with one item selected', () => {
@@ -163,7 +167,8 @@ describe('<item-list>', () => {
     const c = testFixture.$.header.querySelector('#selectAllCheckbox') as HTMLElement;
     c.click();
 
-    assert(isSelected(0) && isSelected(1) && isSelected(2), 'all items should be selected');
+    assert(JSON.stringify(testFixture.selectedIndices) === '[0,1,2,3,4]',
+        'all items should be selected');
   });
 
   it('checks the Select All checkbox if all items are selected individually', () => {
@@ -220,10 +225,10 @@ describe('<item-list>', () => {
 
     thirdCheckbox.click();
     assert(isSelected(0) && isSelected(2), 'both first and third items should be selected');
-    assert(!isSelected(1), 'second item should not be selected');
+    assert(!isSelected(1) && !isSelected(3) && !isSelected(4), 'the rest should not be selected');
 
     firstCheckbox.click();
-    assert(!isSelected(0) && !isSelected(1) && isSelected(2),
+    assert(!isSelected(0) && !isSelected(1) && isSelected(2) && !isSelected(3) && !isSelected(4),
         'first item should ben unselected after the second click');
   });
 
@@ -237,7 +242,7 @@ describe('<item-list>', () => {
     }));
 
     assert(isSelected(0) && isSelected(2), 'both first and third items should be selected');
-    assert(!isSelected(1), 'second item should not be selected');
+    assert(!isSelected(1) && !isSelected(3) && !isSelected(4), 'the rest should not be selected');
 
     firstRow.dispatchEvent(new MouseEvent('click', {
       ctrlKey: true,
@@ -256,7 +261,8 @@ describe('<item-list>', () => {
       shiftKey: true,
     }));
 
-    assert(isSelected(0) && isSelected(1) && isSelected(2), 'all items should be selected');
+    assert(isSelected(0) && isSelected(1) && isSelected(2), 'items 1 to 3 should be selected');
+    assert(!isSelected(3) && !isSelected(4), 'the rest should be unselected');
   });
 
   it('can do multi-selection with ctrl and shift key combinations', () => {

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -229,7 +229,7 @@ describe('<item-list>', () => {
 
     firstCheckbox.click();
     assert(!isSelected(0) && !isSelected(1) && isSelected(2) && !isSelected(3) && !isSelected(4),
-        'first item should ben unselected after the second click');
+        'first item should be unselected after the second click');
   });
 
   it('can do multi-selection using the ctrl key', () => {

--- a/sources/web/datalab/polymer/test/toolbar-test.html
+++ b/sources/web/datalab/polymer/test/toolbar-test.html
@@ -19,6 +19,8 @@ the License.
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
+    <script src="../modules/ApiManager.js"></script>
+    <script src="../modules/SettingsManager.js"></script>
 
     <link rel="import" href="../components/datalab-toolbar/datalab-toolbar.html">
   </head>

--- a/sources/web/datalab/polymer/wct.conf.json
+++ b/sources/web/datalab/polymer/wct.conf.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "sauce": {
+      "disabled": true
+    }
+  }
+}

--- a/third_party/externs/ts/polymer/polymer.d.ts
+++ b/third_party/externs/ts/polymer/polymer.d.ts
@@ -116,6 +116,10 @@ declare module Polymer {
     static import(element: string, property: string): PolymerTemplate;
   }
 
+  class dom {
+    static flush(): null;
+  }
+
   function importHref(href: string,
                       onload?: Function,
                       onerror?: Function,


### PR DESCRIPTION
This PR adds tests for the item-list element. It also adds a `package.json` file at the root of the experimental UI directory for npm dependencies. Later on, we can download TS types automatically. For now, this manifest is used for the current build process, and to start tests. To build the front-end, you can navigate to sources/web/datalab/polymer and run `npm run build`. To start tests, you can do `npm test` from the same directory.

Testing the item-list is done in isolation, by feeding rows and columns arrays, and checking various interactions.

One gotcha here is for webcomponent tester to play nice with the Chrome devtools page, the sauce plugin needs to be disabled, otherwise it keeps refreshing the page, which is very annoying for debugging tests. See https://github.com/Polymer/web-component-tester/issues/242#issuecomment-163438535.