### PR TITLE
[Polymer UI] New file save dialog for editor

### DIFF
--- a/sources/web/datalab/polymer/components/base-dialog/base-dialog.ts
+++ b/sources/web/datalab/polymer/components/base-dialog/base-dialog.ts
@@ -20,6 +20,18 @@ interface BaseDialogCloseResult {
 }
 
 /**
+ * Options for opening a base dialog.
+ */
+interface BaseDialogOptions extends Object {
+  big?: boolean;
+  cancelLabel?: string;
+  isError?: boolean;
+  messageHtml?: string;
+  okLabel?: string;
+  title: string;
+}
+
+/**
  * Base Dialog element for Datalab. This element can be extended to insert custom markup
  * (including other custom elements) inside it. This can be best done by stamping the
  * subclass's element template into the #body element of this class.

--- a/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.html
+++ b/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.html
@@ -17,6 +17,7 @@ the License.
 
 <link rel="import" href="../../components/datalab-notification/datalab-notification.html">
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
+<link rel="import" href="../../components/directory-picker-dialog/directory-picker-dialog.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 
 <dom-module id="datalab-editor">

--- a/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.ts
+++ b/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.ts
@@ -161,38 +161,39 @@ class DatalabEditorElement extends Polymer.Element {
                   this._file = model;
                   return this.dispatchEvent(new NotificationEvent('Saved.'));
                 });
+                // TODO: Handle save failure here.
             }
           }
 
           return Promise.resolve(null);
         });
-    }
-
-    // If _file is defined, we're saving to an existing file
-    if (this._file) {
-      const filePath = this._file.path;
-      const dirPath = filePath.substr(0, filePath.lastIndexOf(this._file.name));
-
-      const model: JupyterFile = {
-        content: this._editor.doc.getValue(),
-        created: this._file.created,
-        format: this._file.format,
-        last_modified: new Date().toISOString(),
-        mimetype: this._file.mimetype,
-        name: this._file.name,
-        path: dirPath,
-        type: this._file.type,
-        writable: this._file.writable,
-      };
-
-      return ApiManager.saveJupyterFile(model)
-        .then(() => {
-          this._file = model;
-          return this.dispatchEvent(new NotificationEvent('Saved.'));
-        });
-      // TODO: Handle save failure here.
     } else {
-      return Promise.resolve(null);
+    // If _file is defined, we're saving to an existing file
+      if (this._file) {
+        const filePath = this._file.path;
+        const dirPath = filePath.substr(0, filePath.lastIndexOf(this._file.name));
+
+        const model: JupyterFile = {
+          content: this._editor.doc.getValue(),
+          created: this._file.created,
+          format: this._file.format,
+          last_modified: new Date().toISOString(),
+          mimetype: this._file.mimetype,
+          name: this._file.name,
+          path: dirPath,
+          type: this._file.type,
+          writable: this._file.writable,
+        };
+
+        return ApiManager.saveJupyterFile(model)
+          .then(() => {
+            this._file = model;
+            return this.dispatchEvent(new NotificationEvent('Saved.'));
+          });
+        // TODO: Handle save failure here.
+      } else {
+        return Promise.resolve(null);
+      }
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.ts
+++ b/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.ts
@@ -168,32 +168,28 @@ class DatalabEditorElement extends Polymer.Element {
           return Promise.resolve(null);
         });
     } else {
-    // If _file is defined, we're saving to an existing file
-      if (this._file) {
-        const filePath = this._file.path;
-        const dirPath = filePath.substr(0, filePath.lastIndexOf(this._file.name));
+      // If _file is defined, we're saving to an existing file
+      const filePath = this._file.path;
+      const dirPath = filePath.substr(0, filePath.lastIndexOf(this._file.name));
 
-        const model: JupyterFile = {
-          content: this._editor.doc.getValue(),
-          created: this._file.created,
-          format: this._file.format,
-          last_modified: new Date().toISOString(),
-          mimetype: this._file.mimetype,
-          name: this._file.name,
-          path: dirPath,
-          type: this._file.type,
-          writable: this._file.writable,
-        };
+      const model: JupyterFile = {
+        content: this._editor.doc.getValue(),
+        created: this._file.created,
+        format: this._file.format,
+        last_modified: new Date().toISOString(),
+        mimetype: this._file.mimetype,
+        name: this._file.name,
+        path: dirPath,
+        type: this._file.type,
+        writable: this._file.writable,
+      };
 
-        return ApiManager.saveJupyterFile(model)
-          .then(() => {
-            this._file = model;
-            return this.dispatchEvent(new NotificationEvent('Saved.'));
-          });
-        // TODO: Handle save failure here.
-      } else {
-        return Promise.resolve(null);
-      }
+      return ApiManager.saveJupyterFile(model)
+        .then(() => {
+          this._file = model;
+          return this.dispatchEvent(new NotificationEvent('Saved.'));
+        });
+      // TODO: Handle save failure here.
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -406,7 +406,7 @@ class FilesElement extends Polymer.Element {
       let warningMsg = files.length > 1 ? 'Some of the files you selected are '
                                           : 'The file you selected is ';
       warningMsg += 'larger than 25MB. You might experience browser freeze or crash.';
-      const dialogOptions: DialogOptions = {
+      const dialogOptions: BaseDialogOptions = {
         messageHtml: warningMsg,
         okLabel: 'Upload Anyway',
         title: 'Warning: Large File',
@@ -494,7 +494,7 @@ class FilesElement extends Polymer.Element {
   _createNewItem(type: string) {
 
     // First, open a dialog to let the user specify a name for the notebook.
-    const inputOptions: DialogOptions = {
+    const inputOptions: InputDialogOptions = {
       inputLabel: 'Name',
       okLabel: 'Create',
       title: 'New ' + type,
@@ -552,7 +552,7 @@ class FilesElement extends Polymer.Element {
       const selectedObject = this._fileList[i];
 
       // Open a dialog to let the user specify the new name for the selected item.
-      const inputOptions: DialogOptions = {
+      const inputOptions: InputDialogOptions = {
         inputLabel: 'New name',
         inputValue: selectedObject.name,
         okLabel: 'Rename',
@@ -620,7 +620,7 @@ class FilesElement extends Polymer.Element {
       const messageHtml = '<div>Are you sure you want to delete:</div>' + itemList;
 
       // Open a dialog to let the user confirm deleting the list of selected items.
-      const inputOptions: DialogOptions = {
+      const inputOptions: BaseDialogOptions = {
         messageHtml,
         okLabel: 'Delete',
         title,
@@ -684,10 +684,11 @@ class FilesElement extends Polymer.Element {
       const i = selectedIndices[0];
       const selectedObject = this._fileList[i];
 
-      const options: DialogOptions = {
+      const options: DirectoryPickerDialogOptions = {
         big: true,
         okLabel: 'Copy Here',
         title: 'Copy Item',
+        withFileName: false,
       };
       return Utils.showDialog(DirectoryPickerDialogElement, options)
         .then((closeResult: DirectoryPickerDialogCloseResult) => {
@@ -723,10 +724,11 @@ class FilesElement extends Polymer.Element {
       const i = selectedIndices[0];
       const selectedObject = this._fileList[i];
 
-      const options: DialogOptions = {
+      const options: DirectoryPickerDialogOptions = {
         big: true,
         okLabel: 'Move Here',
         title: 'Move Item',
+        withFileName: false,
       };
       return Utils.showDialog(DirectoryPickerDialogElement, options)
         .then((closeResult: DirectoryPickerDialogCloseResult) => {

--- a/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.ts
+++ b/sources/web/datalab/polymer/components/directory-picker-dialog/directory-picker-dialog.ts
@@ -24,6 +24,14 @@ interface DirectoryPickerDialogCloseResult extends BaseDialogCloseResult {
 }
 
 /**
+ * Options for opening a directory picker dialog.
+ */
+interface DirectoryPickerDialogOptions extends BaseDialogOptions {
+  fileName?: string;
+  withFileName: boolean;
+}
+
+/**
  * Directory Picker Dialog element for Datalab, extends the Base dialog element.
  * This element is a modal dialog that presents the user with a file picker that can navigate
  * into directories to select destination path of copying or moving an item. It uses a minimal

--- a/sources/web/datalab/polymer/components/input-dialog/input-dialog.ts
+++ b/sources/web/datalab/polymer/components/input-dialog/input-dialog.ts
@@ -21,6 +21,15 @@ interface InputDialogCloseResult extends BaseDialogCloseResult {
 }
 
 /**
+ * Options for opening an input dialog.
+ */
+interface InputDialogOptions extends BaseDialogOptions {
+  bodyHtml?: string;
+  inputLabel?: string;
+  inputValue?: string;
+}
+
+/**
  * Input Dialog element for Datalab, extends the Base dialog element.
  * This element is a modal dialog that presents the user with an input box. The input
  * can optionally start up with a value that is selected. Currently, the modal

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -13,21 +13,6 @@
  */
 
 /**
- * Options for opening a dialog.
- */
-interface DialogOptions {
-  title: string;
-  messageHtml?: string;
-  bodyHtml?: string;
-  inputLabel?: string;
-  inputValue?: string;
-  okLabel?: string;
-  cancelLabel?: string;
-  big?: boolean;
-  isError?: boolean;
-}
-
-/**
  * Class provides helper methods for various operations.
  */
 class Utils {
@@ -39,35 +24,15 @@ class Utils {
    * @param type specifies which type of dialog to use
    * @param dialogOptions specifies different options for opening the dialog
    */
-  public static showDialog(dialogType: typeof BaseDialogElement, dialogOptions: DialogOptions):
-                                                                  Promise<BaseDialogCloseResult> {
+  public static showDialog(dialogType: typeof BaseDialogElement,
+                           dialogOptions: BaseDialogOptions): Promise<BaseDialogCloseResult> {
     const dialog = document.createElement(dialogType.is) as any;
     document.body.appendChild(dialog);
 
-    if (dialogOptions.title) {
-      dialog.title = dialogOptions.title;
-    }
-    if (dialogOptions.messageHtml) {
-      dialog.messageHtml = dialogOptions.messageHtml;
-    }
-    if (dialogOptions.inputLabel) {
-      dialog.inputLabel = dialogOptions.inputLabel;
-    }
-    if (dialogOptions.inputValue) {
-      dialog.inputValue = dialogOptions.inputValue;
-    }
-    if (dialogOptions.okLabel) {
-      dialog.okLabel = dialogOptions.okLabel;
-    }
-    if (dialogOptions.cancelLabel) {
-      dialog.cancelLabel = dialogOptions.cancelLabel;
-    }
-    if (dialogOptions.big !== undefined) {
-      dialog.big = dialogOptions.big;
-    }
-    if (dialogOptions.isError !== undefined) {
-      dialog.isError = dialogOptions.isError;
-    }
+    // Copy the dialog options fields into the dialog element
+    Object.keys(dialogOptions).forEach((key) => {
+      dialog[key] = (dialogOptions as any)[key];
+    });
 
     // Open the dialog
     return new Promise((resolve) => {
@@ -84,7 +49,7 @@ class Utils {
    * @param messageHtml error message
    */
   static showErrorDialog(title: string, messageHtml: string) {
-    const dialogOptions: DialogOptions = {
+    const dialogOptions: BaseDialogOptions = {
       isError: true,
       messageHtml,
       okLabel: 'Close',


### PR DESCRIPTION
This PR adds a directory picker to the editor when the user saves a new file.
The rest of this PR splits the dialog options per dialog type to enforce better type checking.

![image](https://user-images.githubusercontent.com/1424661/28510858-548cd4d8-6fff-11e7-94ee-c1dd3511824a.png)
