### PR TITLE
Start the Datalab container using a systemd service

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -159,76 +159,72 @@ cleanup_tmp
 journalctl -u google-startup-scripts --no-pager > /var/log/startupscript.log
 """
 
-_DATALAB_CONTAINER_MANIFEST_URL = (
-    'http://metadata.google.internal/' +
-    'computeMetadata/v1/instance/attributes/google-container-manifest')
-
 _DATALAB_CLOUD_CONFIG = """
 #cloud-config
+
+users:
+- name: datalab
+  uid: 2000
+  groups: docker
+- name: logger
+  uid: 2001
+  groups: docker
+
+write_files:
+- path: /etc/systemd/system/datalab.service
+  permissions: 0644
+  owner: root
+  content: |
+    [Unit]
+    Description=datalab docker container
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Environment="HOME=/home/datalab"
+    ExecStart=/usr/bin/docker run --rm -u 0 \
+       --name=datalab \
+       -p 127.0.0.1:8080:8080 \
+       -v /mnt/disks/datalab-pd/content:/content \
+       -v /mnt/disks/datalab-pd/tmp:/tmp \
+       --env=HOME=/content \
+       --env=DATALAB_ENV=GCE \
+       --env=DATALAB_DEBUG=true \
+       --env='DATALAB_SETTINGS_OVERRIDES={{"enableAutoGCSBackups": {1}, "consoleLogLevel": "{2}" }}' \
+       --env='DATALAB_GIT_AUTHOR={3}' \
+       --env='DATALAB_INITIAL_USER_SETTINGS={4}' \
+       {0}
+    Restart=always
+    RestartSec=1
+
+- path: /etc/systemd/system/logger.service
+  permissions: 0644
+  owner: root
+  content: |
+    [Unit]
+    Description=logging docker container
+    Requires=network-online.target
+    After=network-online.target
+
+    [Service]
+    Environment="HOME=/home/logger"
+    ExecStartPre=/usr/share/google/dockercfg_update.sh
+    ExecStartPre=-/usr/bin/docker rm -fv logger
+    ExecStart=/usr/bin/docker run --rm -u 0 \
+       --name=logger \
+       -v /var/log:/var/log \
+       -v /var/lib/docker/containers:/var/lib/docker/containers \
+       --env='FLUENTD_ARGS=-q' \
+       gcr.io/google_containers/fluentd-gcp:1.18
+    Restart=always
+    RestartSec=1
 
 runcmd:
 - ['while', '[', '!', '-e', '/mnt/disks/datalab-pd/tmp', ']', ';',
    'do', 'sleep', '1', ';', 'done']
-- ['curl', '-X', 'GET', '-H', 'Metadata-Flavor: Google','{0}',
-   '-o', '/tmp/podspec.yaml']
-- ['kubelet', '--pod-manifest-path', '/tmp/podspec.yaml']
-""".format(_DATALAB_CONTAINER_MANIFEST_URL)
-
-_DATALAB_CONTAINER_SPEC = """
-apiVersion: v1
-kind: Pod
-metadata:
-  name: 'datalab-server'
-spec:
-  containers:
-    - name: datalab
-      image: {0}
-      command: ['/datalab/run.sh']
-      imagePullPolicy: IfNotPresent
-      ports:
-        - containerPort: 8080
-          hostPort: 8080
-          hostIP: 127.0.0.1
-      env:
-        - name: DATALAB_ENV
-          value: GCE
-        - name: DATALAB_DEBUG
-          value: 'true'
-        - name: DATALAB_SETTINGS_OVERRIDES
-          value: '{{"enableAutoGCSBackups": {1}, "consoleLogLevel": "{2}" }}'
-        - name: DATALAB_GIT_AUTHOR
-          value: '{3}'
-        - name: DATALAB_INITIAL_USER_SETTINGS
-          value: '{4}'
-      volumeMounts:
-        - name: content
-          mountPath: /content
-        - name: tmp
-          mountPath: /tmp
-    - name: logger
-      image: gcr.io/google_containers/fluentd-gcp:1.18
-      env:
-        - name: FLUENTD_ARGS
-          value: -q
-      volumeMounts:
-        - name: varlog
-          mountPath: /var/log
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-  volumes:
-    - name: content
-      hostPath:
-        path: /mnt/disks/datalab-pd/content
-    - name: tmp
-      hostPath:
-        path: /mnt/disks/datalab-pd/tmp
-    - name: varlog
-      hostPath:
-        path: /var/log
-    - name: varlibdockercontainers
-      hostPath:
-        path: /var/lib/docker/containers
+- systemctl daemon-reload
+- systemctl start datalab.service
+- systemctl start logger.service
 """
 
 
@@ -603,31 +599,25 @@ def run(args, gcloud_compute, gcloud_repos,
         if idle_timeout else ''
     with tempfile.NamedTemporaryFile(delete=False) as startup_script_file, \
             tempfile.NamedTemporaryFile(delete=False) as user_data_file, \
-            tempfile.NamedTemporaryFile(delete=False) as manifest_file, \
             tempfile.NamedTemporaryFile(delete=False) as for_user_file:
         try:
             startup_script_file.write(_DATALAB_STARTUP_SCRIPT.format(
                 args.image_name, _DATALAB_NOTEBOOKS_REPOSITORY))
             startup_script_file.close()
-            user_data_file.write(_DATALAB_CLOUD_CONFIG)
-            user_data_file.close()
-            manifest_file.write(
-                _DATALAB_CONTAINER_SPEC.format(
+            user_data_file.write(_DATALAB_CLOUD_CONFIG.format(
                     args.image_name, enable_backups,
                     console_log_level, escaped_email, initial_user_settings))
-            manifest_file.close()
+            user_data_file.close()
             for_user_file.write(user_email)
             for_user_file.close()
             metadata_template = (
                 'startup-script={0},' +
                 'user-data={1},' +
-                'google-container-manifest={2},' +
-                'for-user={3}')
+                'for-user={2}')
             metadata_from_file = (
                 metadata_template.format(
                     startup_script_file.name,
                     user_data_file.name,
-                    manifest_file.name,
                     for_user_file.name))
             cmd.extend([
                 '--format=none',
@@ -646,7 +636,6 @@ def run(args, gcloud_compute, gcloud_repos,
         finally:
             os.remove(startup_script_file.name)
             os.remove(user_data_file.name)
-            os.remove(manifest_file.name)
             os.remove(for_user_file.name)
 
     if (not args.no_connect) and (not args.for_user):

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -190,7 +190,10 @@ write_files:
        --env=HOME=/content \
        --env=DATALAB_ENV=GCE \
        --env=DATALAB_DEBUG=true \
-       --env='DATALAB_SETTINGS_OVERRIDES={{"enableAutoGCSBackups": {1}, "consoleLogLevel": "{2}" }}' \
+       --env='DATALAB_SETTINGS_OVERRIDES={{ \
+            "enableAutoGCSBackups": {1}, \
+            "consoleLogLevel": "{2}" \
+       }}' \
        --env='DATALAB_GIT_AUTHOR={3}' \
        --env='DATALAB_INITIAL_USER_SETTINGS={4}' \
        {0}


### PR DESCRIPTION
This commit changes the VMs created by the `datalab` tool
to use systemd services for running their containers rather
than using a kubelet.

This removes one rather large runtime dependency and in my
testing this cuts the VM startup time down by more than one
minute.

This fixes #1373