### PR TITLE
[Polymer] Data tab: single-column mixed-data format, BQ data

### DIFF
--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -5,6 +5,8 @@
     "app-layout": "PolymerElements/app-layout#^2.0.0",
     "app-route": "PolymerElements/app-route#^2.0.0",
     "codemirror": "^5.27.2",
+    "iron-a11y-keys": "PolymerElements/iron-a11y-keys#^2.0.0",
+    "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^2.0.0",
     "iron-icons": "PolymerElements/iron-icons#^2.0.0",
     "iron-pages": "PolymerElements/iron-pages#^2.0.0",
     "iron-selector": "PolymerElements/iron-selector#^2.0.0",

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -15,6 +15,11 @@ the License.
 <link rel="import" href="../../components/item-list/item-list.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 
+<link rel="import" href="../../bower_components/iron-icon/iron-icon.html">
+<link rel="import" href="../../bower_components/iron-a11y-keys/iron-a11y-keys.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../bower_components/paper-input/paper-input.html">
+
 <dom-module id="datalab-data">
   <template>
     <style include="datalab-shared-styles">
@@ -29,25 +34,10 @@ the License.
         font-size: var(--app-content-font-size);
         color: var(--app-primary-color);
       }
-      div.tableDrillDown {
-        display: flex;
-        margin: 15px;
-      }
-      .collectionsColumn {
-        width: 33%;
-      }
-      .tablesColumn {
-        width: 33%;
-      }
-      .filteredColumn {
-        margin: 10px;
-      }
-      detailsColumn {
-        width: 33%;
-      }
       #toolbar {
         height: calc(var(--toolbar-height) - 1px); /* for border-bottom */
         width: 100%;
+        display: flex;
         background-color: var(--app-secondary-color);
         border-bottom: 1px solid var(--border-color);
       }
@@ -61,64 +51,61 @@ the License.
         width: 20px;
         padding-right: 5px;
       }
-      .collections-container {
+      .toolbar-spacer {
+        flex-grow: 1;
+      }
+      #data-container {
+        display: flex;
+        margin: 15px;
+      }
+      .resultsColumn {
+        flex-grow: 1;
+      }
+      .results-container {
         height: 100%;
         display: flex;
       }
-      .tables-container {
-        height: 100%;
-        display: flex;
+      #results {
+        width: 100%;
       }
-      #collections {
-        flex-grow: 1;
+      #detailsPane {
       }
-      #tables {
-        flex-grow: 1;
+      .details-pane-enabled--true {
+        width: 400px;
+      }
+      .details-pane-enabled--false {
+        width: 0px;
       }
     </style>
 
     <!--Toolbar with action buttons -->
     <div id="toolbar">
-      <paper-button class="toolbar-button" on-click="_search">
-        <iron-icon icon="search"></iron-icon>
-        <span>Search</span>
+      <div class="toolbar-spacer"></div>
+      <paper-button id="toggleDetails" class="navbar-button" on-click="_toggleDetailsPane">
+        <iron-icon icon="visibility"></iron-icon>
       </paper-button>
     </div>
 
-    <!-- Multi-column layout: collections (BQ datasets), tables -->
-    <div class="tableDrillDown">
+    <div id="data-container">
+      <div class="resultsColumn">
+        <!-- Input box to enter search terms -->
+        <div id="search-div">
+          <iron-a11y-keys id="searchKeys" keys="enter" on-keys-pressed="_search"></iron-a11y-keys>
+          <paper-input id="searchBox" label="Search for data" spellcheck=false autofocus
+                                      value="{{_searchValue}}" no-label-float>
+          <iron-icon icon="search" slot="prefix" on-click="_search"></iron-icon>
+          </paper-input>
+        </div>
 
-      <!-- Collections (BQ datasets) -->
-      <div class="collectionsColumn filteredColumn">
-        <div>
-          Collections Filter:
-            <paper-input id="collectionsFilterBox" label="Optional filter value" spellcheck=false autofocus
-                         value="{{_collectionsFilterValue}}" no-label-float>
-            </paper-input>
-        </div>
-        <!-- list of collections -->
-        <div class='collections-container'>
-          <item-list id="collections" hide-header="true"></item-list>
-        </div>
-      </div>
-
-      <!-- Tables -->
-      <div class="tablesColumn filteredColumn">
-        <div>
-          Tables Filter:
-            <paper-input id="tablesFilterBox" label="Optional filter value" spellcheck=false autofocus
-                         value="{{_tablesFilterValue}}" no-label-float>
-            </paper-input>
-        </div>
-        <!-- list of tables -->
-        <div class='tables-container'>
-          <item-list id="tables" hide-header="true"></item-list>
+        <!-- List of results -->
+        <div class='results-container'>
+          <item-list id="results"></item-list>
         </div>
       </div>
 
       <!-- Details pane -->
-      <div class="detailsColumn">
-        <div id="detailsPane"></div>
+      <div id="detailsPane" class$="details-pane-enabled--{{_isDetailsPaneToggledOn}}">
+        <div id="detailsContents"></div>
       </div>
 
     </div>

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -69,6 +69,7 @@ the License.
         width: 100%;
       }
       #detailsPane {
+        /* TODO - Add box-shadow and other styling once we put some real content here. */
       }
       .details-pane-enabled--true {
         width: 400px;
@@ -90,6 +91,9 @@ the License.
       <div class="resultsColumn">
         <!-- Input box to enter search terms -->
         <div id="search-div">
+          <!-- TODO - could use value-changed event on paper-input to call _search
+               on every keystroke, with a delay so it fires only after the user has stopped
+               typing for a moment. -->
           <iron-a11y-keys id="searchKeys" keys="enter" on-keys-pressed="_search"></iron-a11y-keys>
           <paper-input id="searchBox" label="Search for data" spellcheck=false autofocus
                                       value="{{_searchValue}}" no-label-float>

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -71,6 +71,8 @@ class DataElement extends Polymer.Element {
 
   /** Sends the user's query to the search API, renders results as they get returned. */
   _search() {
+    // TODO - clearing the resultsList may cause unnecessary refreshes, clean this up
+    //   when we figure out how we actually want to handle the search call.
     this._resultsList = [];
     this._sendQuery(this._searchValue, this._handleQueryResults.bind(this));
   }
@@ -80,6 +82,8 @@ class DataElement extends Polymer.Element {
   }
 
   _handleQueryResults(partialResults: Result[]) {
+    // TODO - add something to make sure the partialResults are for the right query,
+    //   so that late results don't accidentally get added to the next query results.
     this._resultsList = this._resultsList.concat(partialResults);
   }
 

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -18,53 +18,37 @@
 
 type HttpResponse<T> = gapi.client.HttpResponse<T>;
 
-interface Collection {
+interface Result {
   name: string;
-  status: string;
-  tables?: Table[];
-}
-
-interface Table {
-  name: string;
-  status: string;
+  type: string;
 }
 
 /**
  * Data element for Datalab.
- * Contains a form for initial user input, and a list of tables.
+ * Contains a form for initial user input, and a list of results.
  */
 class DataElement extends Polymer.Element {
 
-  /** The value the user can enter to filter the collections. */
-  // private _collectionsFilterValue : string;   //TODO(jimmc): uncomment when ready to use
-
-  /** The value the user can enter to filter the tables. */
-  // private _tablesFilterValue : string;    //TODO(jimmc): uncomment when ready to use
-
-  private _collectionsList: Collection[];
-  private _tablesList: Table[];
+  private _isDetailsPaneToggledOn: boolean;
+  private _resultsList: Result[];
+  private _searchValue: string;
 
   static get is() { return 'datalab-data'; }
 
   static get properties() {
     return {
-      _collectionsFilterValue: {
-        type: String,
-        value: 'no-filter',
+      _isDetailsPaneToggledOn: {
+        type: Boolean,
+        value: true,
       },
-      _collectionsList: {
-        observer: '_renderCollectionsList',
+      _resultsList: {
+        observer: '_renderResultsList',
         type: Array,
         value: () => [],
       },
-      _tablesFilterValue: {
+      _searchValue: {
         type: String,
-        value: 'no-filter',
-      },
-      _tablesList: {
-        observer: '_renderTablesList',
-        type: Array,
-        value: () => [],
+        value: '',
       },
     };
   }
@@ -72,154 +56,132 @@ class DataElement extends Polymer.Element {
   ready() {
     super.ready();
 
-    this._collectionsList = [];
-    const collectionsElement = this.$.collections as ItemListElement;
-    if (collectionsElement) {
-      collectionsElement.addEventListener('itemDoubleClick',
-                                    this._collectionsDoubleClicked.bind(this));
-      collectionsElement.addEventListener('selected-indices-changed',
-                                    this._collectionsSelectionChanged.bind(this));
+    this._resultsList = [];
+    const resultsElement = this.$.results as ItemListElement;
+    if (resultsElement) {
+      resultsElement.addEventListener('itemDoubleClick',
+                                    this._resultsDoubleClicked.bind(this));
+      resultsElement.addEventListener('selected-indices-changed',
+                                    this._resultsSelectionChanged.bind(this));
     }
 
-    this._tablesList = [];
-    const tablesElement = this.$.tables as ItemListElement;
-    if (tablesElement) {
-      tablesElement.addEventListener('itemDoubleClick',
-                                    this._tablesDoubleClicked.bind(this));
-      tablesElement.addEventListener('selected-indices-changed',
-                                    this._tablesSelectionChanged.bind(this));
-    }
+    (this.$.results as ItemListElement).columns = ['Name', 'Type'];
+    this.$.searchKeys.target = this.$.searchBox;
   }
 
-  _generateFakeCollectionsListForTesting() {
-    const collectionsList = [];
-    const count = Math.floor(Math.random() * 20);
-    for (let i = 0; i < count; i++) {
-      collectionsList.push(this._generateFakeCollectionForTesting());
-    }
-    return collectionsList;
-  }
-
-  _generateFakeCollectionForTesting() {
-    const fakeCollection = {
-      name: 'fakeCollection' + Math.floor(Math.random() * 1000000),
-      status: 'fake',
-    };
-    return fakeCollection;
-  }
-
-  _generateFakeTablesListForTesting() {
-    const tablesList = [];
-    const count = Math.floor(Math.random() * 20);
-    for (let i = 0; i < count; i++) {
-      tablesList.push(this._generateFakeTableForTesting());
-    }
-    return tablesList;
-  }
-
-  _generateFakeTableForTesting() {
-    const fakeTable = {
-      name: 'fakeTable' + Math.floor(Math.random() * 1000000),
-      status: 'fake',
-    };
-    return fakeTable;
-  }
-
-  /** Reads the user's query values, queries for tables, and updates the results. */
+  /** Sends the user's query to the search API, renders results as they get returned. */
   _search() {
-    this._collectionsList = this._generateFakeCollectionsListForTesting();
-    this._debugCallBigQuery();   // For debugging, make some BigQuery calls
+    this._resultsList = [];
+    this._sendQuery(this._searchValue, this._handleQueryResults.bind(this));
   }
 
-  // Make some calls to the BigQuery API and log the results to the console.
-  _debugCallBigQuery() {
+  _sendQuery(searchValue: string, resultHandler: (partialResults: Result[]) => void) {
+    this._callBigQuery(searchValue, resultHandler);
+  }
+
+  _handleQueryResults(partialResults: Result[]) {
+    this._resultsList = this._resultsList.concat(partialResults);
+  }
+
+  // Make some calls to the BigQuery API and pass the results to the resultHandler
+  _callBigQuery(searchValue: string, resultHandler: (partialResults: Result[]) => void) {
     const sampleProject = 'bigquery-public-data';
-    const sampleDataset = 'samples';
-    const emptyFilter = '';
     GapiManager.listBigQueryProjects()
-        .then((response: HttpResponse<gapi.client.bigquery.ListProjectsResponse>) => console.log('== projects: ', response));
-    GapiManager.listBigQueryDatasets(sampleProject, emptyFilter)
-        .then((response: HttpResponse<gapi.client.bigquery.ListDatasetsResponse>) => console.log('== datasets: ', response));
-    GapiManager.listBigQueryTables(sampleProject, sampleDataset, emptyFilter)
-        .then((response: HttpResponse<gapi.client.bigquery.ListTablesResponse>) => console.log('== tables: ', response));
+        .then((response: HttpResponse<gapi.client.bigquery.ListProjectsResponse>) => {
+          console.log('== projects: ', response);
+          const projectResults: Result[] = response.result.projects.map(this._bqProjectToResult.bind(this)) as Result[];
+          resultHandler(projectResults);
+        });
+    // The filter arg when querying for datasets must be of the form labels.<name>[:<value>],
+    // see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list
+    GapiManager.listBigQueryDatasets(sampleProject, searchValue /* label filter */)
+        .then((response: HttpResponse<gapi.client.bigquery.ListDatasetsResponse>) => {
+          console.log('== datasets: ', response);
+          const datasetResults: Result[] = response.result.datasets.map(this._bqDatasetToResult.bind(this)) as Result[];
+          resultHandler(datasetResults);
+        });
+    GapiManager.listBigQueryTables(sampleProject, searchValue /* datasetId */)
+        .then((response: HttpResponse<gapi.client.bigquery.ListTablesResponse>) => {
+          console.log('== tables: ', response);
+          const tableResults: Result[] = response.result.tables.map(this._bqTableToResult.bind(this)) as Result[];
+          resultHandler(tableResults);
+        });
+  }
+
+  _bqProjectToResult(bqProject: gapi.client.bigquery.ProjectResource): Result {
+    return {
+      name: bqProject.id,
+      type: 'project',
+    } as Result;
+  }
+
+  _bqDatasetToResult(bqDataset: gapi.client.bigquery.DatasetResource): Result {
+    return {
+      name: bqDataset.id,
+      type: 'dataset',
+    } as Result;
+  }
+
+  _bqTableToResult(bqTable: gapi.client.bigquery.TableResource): Result {
+    return {
+      name: bqTable.id,
+      type: 'table',
+    } as Result;
   }
 
   /**
-   * Creates a new ItemListRow object for each entry in the collections list, and sends
+   * Creates a new ItemListRow object for each entry in the results list, and sends
    * the created list to the item-list to render.
    */
-  _renderCollectionsList() {
-    this.$.collections.rows = this._collectionsList.map((collection) => {
+  _renderResultsList() {
+    this.$.results.rows = this._resultsList.map((result) => {
       return {
-        firstCol: collection.name,
-        icon: 'folder',
-        secondCol: collection.status,
+        firstCol: result.name,
+        icon: this._typeToIcon(result.type),
+        secondCol: result.type,
         selected: false,
       };
     });
   }
 
-  _showTablesForCollection(collection: Collection) {
-    console.log('== collection selected:', collection);
-    if (!collection.tables) {
-      collection.tables = this._generateFakeTablesListForTesting();
-    }
-    this._tablesList = collection.tables;
+  _typeToIcon(type: string): string {
+    const typeMap: {[key: string]: string; } = {
+      dataset: 'folder',
+      project: 'view-quilt',
+      table: 'list',
+    };
+    return typeMap[type] || 'folder';
   }
 
-  _clearTablesList() {
-    this._tablesList = [];
+  _showDetailsForResult(result: Result) {
+    this.$.detailsPane.innerHTML =
+        'Selection: <b>' + result.name + '</b><br>' +
+        'Type: <b>' + result.type + '</b>';
   }
 
-  _showDetailsForTable(table: Table) {
-    this.$.detailsPane.innerHTML = 'Selected table: ' + table.name;
-  }
-
-  _clearTableDetails() {
+  _clearDetails() {
     this.$.detailsPane.innerHTML = '';
   }
 
+  _resultsDoubleClicked() {
+    console.log('== result double-clicked');
+  }
+
+  _resultsSelectionChanged() {
+    console.log('== result selection changed');
+    const selectedIndices = (this.$.results as ItemListElement).selectedIndices;
+    if (selectedIndices.length === 1) {
+      this._showDetailsForResult(this._resultsList[selectedIndices[0]]);
+    } else {
+      this._clearDetails();
+    }
+  }
+
   /**
-   * Creates a new ItemListRow object for each entry in the collections list, and sends
-   * the created list to the item-list to render.
+   * Switches details pane on or off.
    */
-  _renderTablesList() {
-    this.$.tables.rows = this._tablesList.map((table) => {
-      return {
-        firstCol: table.name,
-        icon: 'file',
-        secondCol: table.status,
-        selected: false,
-      };
-    });
-  }
-
-  _collectionsDoubleClicked() {
-    console.log('== collection double-clicked');
-  }
-
-  _collectionsSelectionChanged() {
-    console.log('== collection selection changed');
-    const selectedIndices = (this.$.collections as ItemListElement).selectedIndices;
-    if (selectedIndices.length === 1) {
-      this._showTablesForCollection(this._collectionsList[selectedIndices[0]]);
-    } else {
-      this._clearTablesList();
-    }
-  }
-
-  _tablesDoubleClicked() {
-    console.log('== table double-clicked');
-  }
-
-  _tablesSelectionChanged() {
-    console.log('== table selection changed');
-    const selectedIndices = (this.$.tables as ItemListElement).selectedIndices;
-    if (selectedIndices.length === 1) {
-      this._showDetailsForTable(this._tablesList[selectedIndices[0]]);
-    } else {
-      this._clearTableDetails();
-    }
+  _toggleDetailsPane() {
+    this._isDetailsPaneToggledOn = !this._isDetailsPaneToggledOn;
   }
 }
 

--- a/sources/web/datalab/polymer/modules/GapiManager.ts
+++ b/sources/web/datalab/polymer/modules/GapiManager.ts
@@ -82,7 +82,11 @@ class GapiManager {
     return GapiManager._loadBigQuery().then(() => gapi.client.bigquery.projects.list());
   }
 
-  /** Gets the list of BigQuery datasets in the specified project, returns a Promise. */
+  /** Gets the list of BigQuery datasets in the specified project, returns a Promise.
+   * @param projectId
+   * @param filter A label filter of the form label.<name>[:<value>], as described in
+   *     https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list
+   */
   public static listBigQueryDatasets(projectId: string, filter: string): gapi.client.HttpRequest<gapi.client.bigquery.ListDatasetsResponse> {
     const request = {
       filter,
@@ -92,10 +96,9 @@ class GapiManager {
   }
 
   /** Gets the list of BigQuery tables in the specified project and dataset, returns a Promise. */
-  public static listBigQueryTables(projectId: string, datasetId: string, filter: string): gapi.client.HttpRequest<gapi.client.bigquery.ListTablesResponse> {
+  public static listBigQueryTables(projectId: string, datasetId: string): gapi.client.HttpRequest<gapi.client.bigquery.ListTablesResponse> {
     const request = {
       datasetId,
-      filter,
       projectId,
     };
     return GapiManager._loadBigQuery().then(() => gapi.client.bigquery.tables.list(request));

--- a/third_party/externs/ts/gapi/bigquery.d.ts
+++ b/third_party/externs/ts/gapi/bigquery.d.ts
@@ -61,6 +61,10 @@ declare namespace gapi.client {
     }
 
     interface ListTablesResponse {
+      kind: string;   // Should always be "bigquery#tableList"
+      etag: string;
+      nextPageToken: string;
+      tables: Array<TableResource>;
     }
 
     interface ProjectReference {
@@ -75,7 +79,17 @@ declare namespace gapi.client {
       friendlyName: string;
     }
 
+    interface TableReference {
+      datasetId: string;
+      projectId: string;
+      tableId: string;
+    }
+
     interface TableResource {
+      kind: string;   // Should always be "bigquery#table"
+      id: string;
+      tableReference: TableReference;
+      type: string;   // "TABLE"
     }
   }
 }


### PR DESCRIPTION
This PR replaces the previous two-column layout with a single-column layout that has one text box for search terms and one list for heterogenous search results. It also wires in the BigQuery API so that the text in the search box is actually used to search for projects, datasets, and tables, which appear in the single results list with different icons. The details area on the right now has a Visibility icon that shows or hides that panel, same as the preview pane in the Files tab.
Turns out the BQ API is not really well suited for this approach, so it might take a while to make it work smoothly. Alternatively, I may try to figure out how to call Datauhb instead and see how far I can get with that.

![data-tab-bq-samples](https://user-images.githubusercontent.com/116825/28693635-9a1f7068-72da-11e7-8ca2-76d3b1b58fc6.png)
