### PR TITLE
[Data First] Add Table Details Pane

### DIFF
--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -20,6 +20,7 @@
     "paper-item": "PolymerElements/paper-item#^2.0.0",
     "paper-progress": "PolymerElements/paper-progress#^2.0.0",
     "paper-radio-group": "PolymerElements/paper-radio-group#^2.0.0",
+    "paper-spinner": "PolymerElements/paper-spinner#^2.0.0",
     "paper-toast": "PolymerElements/paper-toast#^2.0.0",
     "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.0",
     "polymer": "Polymer/polymer#^2.0.1",

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -35,58 +35,30 @@ the License.
         font-size: var(--app-content-font-size);
         color: var(--app-primary-color);
       }
-      #toolbar {
-        height: calc(var(--toolbar-height) - 1px); /* for border-bottom */
-        width: 100%;
-        display: flex;
-        background-color: var(--app-secondary-color);
-        border-bottom: 1px solid var(--border-color);
-      }
-      .toolbar-button {
-        color: var(--app-primary-color);
-        margin: 4px;
-        font-weight: normal;
-        border-radius: 0px;
-      }
-      .toolbar-button > iron-icon {
-        width: 20px;
-        padding-right: 5px;
-      }
-      .toolbar-spacer {
-        flex-grow: 1;
-      }
       #data-container {
         display: flex;
-        margin: 15px;
+        height: 100%;
       }
       .resultsColumn {
+        margin: 15px;
         flex-grow: 1;
       }
+      #search-div {
+        height: var(--toolbar-height);
+      }
       .results-container {
-        height: 100%;
+        height: calc(100% - var(--toolbar-height));
         display: flex;
       }
       #results {
         width: 100%;
       }
       #detailsPane {
-        /* TODO - Add box-shadow and other styling once we put some real content here. */
-      }
-      .details-pane-enabled--true {
-        width: 400px;
-      }
-      .details-pane-enabled--false {
-        width: 0px;
+        background-color: var(--secondary-bg-color);
+        box-shadow: inset 4px 0px 10px -3px rgba(0, 0, 0, 0.1);
+        width: var(--details-pane-width);
       }
     </style>
-
-    <!--Toolbar with action buttons -->
-    <div id="toolbar">
-      <div class="toolbar-spacer"></div>
-      <paper-button id="toggleDetails" class="navbar-button" on-click="_toggleDetailsPane">
-        <iron-icon icon="visibility"></iron-icon>
-      </paper-button>
-    </div>
 
     <div id="data-container">
       <div class="resultsColumn">
@@ -109,7 +81,7 @@ the License.
       </div>
 
       <!-- Details pane -->
-      <div id="detailsPane" class$="details-pane-enabled--{{_isDetailsPaneToggledOn}}">
+      <div id="detailsPane">
         <table-details id="details"></table-details>
       </div>
 

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -14,6 +14,7 @@ the License.
 
 <link rel="import" href="../../components/item-list/item-list.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
+<link rel="import" href="../../components/table-details/table-details.html">
 
 <link rel="import" href="../../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../../bower_components/iron-a11y-keys/iron-a11y-keys.html">
@@ -109,7 +110,7 @@ the License.
 
       <!-- Details pane -->
       <div id="detailsPane" class$="details-pane-enabled--{{_isDetailsPaneToggledOn}}">
-        <div id="detailsContents"></div>
+        <table-details id="details"></table-details>
       </div>
 
     </div>

--- a/sources/web/datalab/polymer/components/table-details/table-details.html
+++ b/sources/web/datalab/polymer/components/table-details/table-details.html
@@ -39,7 +39,6 @@ the License.
       }
       table {
         border-spacing: 1px;
-        border-left: 0px solid transparent;
         padding: 0 0 4px 0;
         width: 100%;
       }
@@ -100,6 +99,7 @@ the License.
       <br>
 
       <table>
+        <!--TODO: Flatten out the fields list-->
         <template is="dom-repeat" items={{_table.schema.fields}} as="column">
           <tr>
             <td class="field">{{column.name}}</td>

--- a/sources/web/datalab/polymer/components/table-details/table-details.html
+++ b/sources/web/datalab/polymer/components/table-details/table-details.html
@@ -59,6 +59,7 @@ the License.
       <paper-spinner active hidden$={{!_busy}}></paper-spinner>
     </div>
     <div id="container" hidden$={{!_table}}>
+      <br>
       <h3>Table Details: {{_table.tableReference.tableId}}</h3>
       <span class="strong">Project: </span><span>{{_table.tableReference.projectId}}</span>
       <br>

--- a/sources/web/datalab/polymer/components/table-details/table-details.html
+++ b/sources/web/datalab/polymer/components/table-details/table-details.html
@@ -14,46 +14,101 @@ the License.
 
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 
+<link rel="import" href="../../bower_components/paper-spinner/paper-spinner.html">
+
 <dom-module id="table-details">
   <template>
     <style include="datalab-shared-styles">
+      #placeholder {
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+      paper-spinner {
+        --paper-spinner-stroke-width: 2px;
+      }
       #container {
         padding: 0px 20px;
         height: 100%;
         overflow-y: auto;
+        color: var(--primary-fg-color);
       }
       .strong {
         font-weight: bold;
       }
+      table {
+        border-spacing: 1px;
+        border-left: 0px solid transparent;
+        padding: 0 0 4px 0;
+        width: 100%;
+      }
+      td.field {
+        padding: 10px;
+        background-color: #eee;
+        font-weight: bold;
+      }
+      td.value {
+        padding: 10px;
+        background-color: #fff;
+      }
+      .separator {
+        margin: 20px 0px;
+      }
     </style>
-    <div id="container" hidden$="{{!table}}">
-      <h3>Table Details: {{table.tableReference.tableId}}</h3>
-      <span class="strong">Project: </span><span>{{table.tableReference.projectId}}</span>
+    <div id="placeholder" hidden$={{_table}}>
+      <paper-spinner active hidden$={{!_busy}}></paper-spinner>
+    </div>
+    <div id="container" hidden$={{!_table}}>
+      <h3>Table Details: {{_table.tableReference.tableId}}</h3>
+      <span class="strong">Project: </span><span>{{_table.tableReference.projectId}}</span>
       <br>
-      <span class="strong">Dataset: </span><span>{{table.tableReference.datasetId}}</span>
+      <br>
+      <span class="strong">Dataset: </span><span>{{_table.tableReference.datasetId}}</span>
+      <br>
       <br>
       <table>
         <tr>
-          <td>Table Size</td>
-          <td>{{table.numBytes}}</td>
+          <td class="field">Table Size</td>
+          <td class="value">{{tableSize}}</td>
         </tr>
         <tr>
-          <td>Long Term Storage Size</td>
-          <td>{{table.numLongTermBytes}}</td>
+          <td class="field">Long Term Storage Size</td>
+          <td class="value">{{longTermTableSize}}</td>
         </tr>
         <tr>
-          <td>Number of Rows</td>
-          <td>{{table.numRows}}</td>
+          <td class="field">Number of Rows</td>
+          <td class="value">{{numRows}}</td>
         </tr>
         <tr>
-          <td>Creation Time</td>
-          <td>{{table.creationTime}}</td>
+          <td class="field">Creation Time</td>
+          <td class="value">{{creationTime}}</td>
         </tr>
         <tr>
-          <td>Last Modified</td>
-          <td>{{table.lastModifiedTime}}</td>
+          <td class="field">Last Modified</td>
+          <td class="value">{{lastModifiedTime}}</td>
+        </tr>
+        <tr>
+          <td class="field">Data Location</td>
+          <td class="value">{{_table.location}}</td>
         </tr>
       </table>
+
+      <hr class="separator">
+
+      <div class="strong">Schema</div>
+      <br>
+
+      <table>
+        <template is="dom-repeat" items={{_table.schema.fields}} as="column">
+          <tr>
+            <td class="field">{{column.name}}</td>
+            <td class="value">{{column.type}}</td>
+            <td class="value">{{_formatMode(column.mode)}}</td>
+          </tr>
+        </template>
+      </table>
+
     </div>
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/table-details/table-details.html
+++ b/sources/web/datalab/polymer/components/table-details/table-details.html
@@ -1,0 +1,61 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
+
+<dom-module id="table-details">
+  <template>
+    <style include="datalab-shared-styles">
+      #container {
+        padding: 0px 20px;
+        height: 100%;
+        overflow-y: auto;
+      }
+      .strong {
+        font-weight: bold;
+      }
+    </style>
+    <div id="container" hidden$="{{!table}}">
+      <h3>Table Details: {{table.tableReference.tableId}}</h3>
+      <span class="strong">Project: </span><span>{{table.tableReference.projectId}}</span>
+      <br>
+      <span class="strong">Dataset: </span><span>{{table.tableReference.datasetId}}</span>
+      <br>
+      <table>
+        <tr>
+          <td>Table Size</td>
+          <td>{{table.numBytes}}</td>
+        </tr>
+        <tr>
+          <td>Long Term Storage Size</td>
+          <td>{{table.numLongTermBytes}}</td>
+        </tr>
+        <tr>
+          <td>Number of Rows</td>
+          <td>{{table.numRows}}</td>
+        </tr>
+        <tr>
+          <td>Creation Time</td>
+          <td>{{table.creationTime}}</td>
+        </tr>
+        <tr>
+          <td>Last Modified</td>
+          <td>{{table.lastModifiedTime}}</td>
+        </tr>
+      </table>
+    </div>
+  </template>
+</dom-module>
+
+<script src="table-details.js"></script>

--- a/sources/web/datalab/polymer/components/table-details/table-details.ts
+++ b/sources/web/datalab/polymer/components/table-details/table-details.ts
@@ -20,15 +20,115 @@
 class TableDetailsElement extends Polymer.Element {
 
   /**
-   * Table object whose details to show.
+   * Id for table whose details to show.
    */
-  public table: gapi.client.bigquery.BigqueryTable | null;
+  public tableId: string;
+
+  private _table: gapi.client.bigquery.BigqueryTable | null;
+  private _busy = false;
+  private readonly DEFAULT_MODE = 'NULLABLE';
 
   static get is() { return 'table-details'; }
 
   static get properties() {
     return {
+      _table: {
+        type: Object,
+        value: null,
+      },
+      creationTime: {
+        computed: '_computeCreationTime(_table)',
+        type: String,
+      },
+      lastModifiedTime: {
+        computed: '_computeLastModifiedTime(_table)',
+        type: String,
+      },
+      longTermTableSize: {
+        computed: '_computeLongTermTableSize(_table)',
+        type: String,
+      },
+      numRows: {
+        computed: '_computeNumRows(_table)',
+        type: String,
+      },
+      tableId: {
+        observer: '_tableIdChanged',
+        type: String,
+        value: '',
+      },
+      tableSize: {
+        computed: '_computeTableSize(_table)',
+        type: String,
+      },
     };
+  }
+
+  _tableIdChanged() {
+    const matches = this.tableId.match(/^(.*):(.*)\.(.*)$/);
+    if (matches && matches.length === 4) { // The whole string is matched as first result
+      this._busy = true;
+      const projectId = matches[1];
+      const datasetId = matches[2];
+      const tableId = matches[3];
+
+      GapiManager.getTableDetails(projectId, datasetId, tableId)
+        .then((result) => {
+          this._table = JSON.parse(result.body) as gapi.client.bigquery.BigqueryTable;
+        }, (error) => console.log('Failed to get table details: ' + error.body))
+        .then(() => this._busy = false);
+    } else {
+      this._table = null;
+    }
+  }
+
+  _computeCreationTime(table: gapi.client.bigquery.BigqueryTable | null) {
+    if (table) {
+      return new Date(parseInt(table.creationTime, 10)).toLocaleString();
+    } else {
+      return '';
+    }
+  }
+
+  _computeLastModifiedTime(table: gapi.client.bigquery.BigqueryTable | null) {
+    if (table) {
+      return new Date(parseInt(table.lastModifiedTime, 10)).toLocaleString();
+    } else {
+      return '';
+    }
+  }
+
+  _computeNumRows(table: gapi.client.bigquery.BigqueryTable | null) {
+    return table ? parseInt(table.numRows, 10).toLocaleString() : '';
+  }
+
+  _computeLongTermTableSize(table: gapi.client.bigquery.BigqueryTable | null) {
+    return table ? this._bytesToReadableSize(table.numLongTermBytes) : '';
+  }
+
+  _computeTableSize(table: gapi.client.bigquery.BigqueryTable | null) {
+    return table ? this._bytesToReadableSize(table.numBytes) : '';
+  }
+
+  /**
+   * Converts the given number of bytes into a human readable string with units
+   * and a two-decimal-point number
+   */
+  _bytesToReadableSize(bytesStr: string) {
+    const kilo = 1024;
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    let bytes = parseInt(bytesStr, 10);
+    let level = 0;
+
+    while (bytes >= kilo) {
+      bytes /= kilo;
+      ++level;
+    }
+    return bytes.toFixed(2) + ' ' + units[level];
+  }
+
+  _formatMode(mode: string) {
+    return mode || this.DEFAULT_MODE;
   }
 
 }

--- a/sources/web/datalab/polymer/components/table-details/table-details.ts
+++ b/sources/web/datalab/polymer/components/table-details/table-details.ts
@@ -74,7 +74,7 @@ class TableDetailsElement extends Polymer.Element {
 
       GapiManager.getBigqueryTableDetails(projectId, datasetId, tableId)
         .then((response: HttpResponse<gapi.client.bigquery.Table>) => {
-          this._table = JSON.parse(response.body);
+          this._table = response.result;
         }, (errorResponse) =>
             console.error('Failed to get table details: ' + errorResponse.body))
         .then(() => this._busy = false);

--- a/sources/web/datalab/polymer/components/table-details/table-details.ts
+++ b/sources/web/datalab/polymer/components/table-details/table-details.ts
@@ -24,7 +24,7 @@ class TableDetailsElement extends Polymer.Element {
    */
   public tableId: string;
 
-  private _table: gapi.client.bigquery.BigqueryTable | null;
+  private _table: gapi.client.bigquery.Table | null;
   private _busy = false;
   private readonly DEFAULT_MODE = 'NULLABLE';
 
@@ -72,17 +72,18 @@ class TableDetailsElement extends Polymer.Element {
       const datasetId = matches[2];
       const tableId = matches[3];
 
-      GapiManager.getTableDetails(projectId, datasetId, tableId)
-        .then((result) => {
-          this._table = JSON.parse(result.body) as gapi.client.bigquery.BigqueryTable;
-        }, (error) => console.log('Failed to get table details: ' + error.body))
+      GapiManager.getBigqueryTableDetails(projectId, datasetId, tableId)
+        .then((response: HttpResponse<gapi.client.bigquery.Table>) => {
+          this._table = JSON.parse(response.body);
+        }, (errorResponse) =>
+            console.error('Failed to get table details: ' + errorResponse.body))
         .then(() => this._busy = false);
     } else {
       this._table = null;
     }
   }
 
-  _computeCreationTime(table: gapi.client.bigquery.BigqueryTable | null) {
+  _computeCreationTime(table: gapi.client.bigquery.Table | null) {
     if (table) {
       return new Date(parseInt(table.creationTime, 10)).toLocaleString();
     } else {
@@ -90,7 +91,7 @@ class TableDetailsElement extends Polymer.Element {
     }
   }
 
-  _computeLastModifiedTime(table: gapi.client.bigquery.BigqueryTable | null) {
+  _computeLastModifiedTime(table: gapi.client.bigquery.Table | null) {
     if (table) {
       return new Date(parseInt(table.lastModifiedTime, 10)).toLocaleString();
     } else {
@@ -98,15 +99,15 @@ class TableDetailsElement extends Polymer.Element {
     }
   }
 
-  _computeNumRows(table: gapi.client.bigquery.BigqueryTable | null) {
+  _computeNumRows(table: gapi.client.bigquery.Table | null) {
     return table ? parseInt(table.numRows, 10).toLocaleString() : '';
   }
 
-  _computeLongTermTableSize(table: gapi.client.bigquery.BigqueryTable | null) {
+  _computeLongTermTableSize(table: gapi.client.bigquery.Table | null) {
     return table ? this._bytesToReadableSize(table.numLongTermBytes) : '';
   }
 
-  _computeTableSize(table: gapi.client.bigquery.BigqueryTable | null) {
+  _computeTableSize(table: gapi.client.bigquery.Table | null) {
     return table ? this._bytesToReadableSize(table.numBytes) : '';
   }
 
@@ -117,14 +118,14 @@ class TableDetailsElement extends Polymer.Element {
   _bytesToReadableSize(bytesStr: string) {
     const kilo = 1024;
     const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-    let bytes = parseInt(bytesStr, 10);
+    let bytesLeft = parseInt(bytesStr, 10);
     let level = 0;
 
-    while (bytes >= kilo) {
-      bytes /= kilo;
+    while (bytesLeft >= kilo) {
+      bytesLeft /= kilo;
       ++level;
     }
-    return bytes.toFixed(2) + ' ' + units[level];
+    return bytesLeft.toFixed(2) + ' ' + units[level];
   }
 
   _formatMode(mode: string) {

--- a/sources/web/datalab/polymer/components/table-details/table-details.ts
+++ b/sources/web/datalab/polymer/components/table-details/table-details.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Table details pane element for Datalab.
+ * This element is designed to be displayed in a side bar that displays more
+ * information about a selected BigQuery table.
+ */
+class TableDetailsElement extends Polymer.Element {
+
+  /**
+   * Table object whose details to show.
+   */
+  public table: gapi.client.bigquery.BigqueryTable | null;
+
+  static get is() { return 'table-details'; }
+
+  static get properties() {
+    return {
+    };
+  }
+
+}
+
+customElements.define(TableDetailsElement.is, TableDetailsElement);

--- a/sources/web/datalab/polymer/modules/GapiManager.ts
+++ b/sources/web/datalab/polymer/modules/GapiManager.ts
@@ -104,6 +104,20 @@ class GapiManager {
     return GapiManager._loadBigQuery().then(() => gapi.client.bigquery.tables.list(request));
   }
 
+  /**
+   * Fetches table details from BigQuery
+   */
+  // TODO: fix return type
+  public static getTableDetails(projectId: string, datasetId: string, tableId: string):
+      gapi.client.HttpRequest<gapi.client.bigquery.BigqueryTable> {
+    const request = {
+      datasetId,
+      projectId,
+      tableId,
+    };
+    return GapiManager._loadBigQuery().then(() => gapi.client.bigquery.tables.get(request));
+  }
+
   private static _initClient(signInChangedCallback: (signedIn: boolean) => void) {
     // Initialize the client with API key and People API, and initialize OAuth with an
     // OAuth 2.0 client ID and scopes (space delimited string) to request access.

--- a/sources/web/datalab/polymer/modules/GapiManager.ts
+++ b/sources/web/datalab/polymer/modules/GapiManager.ts
@@ -107,8 +107,8 @@ class GapiManager {
   /**
    * Fetches table details from BigQuery
    */
-  public static getTableDetails(projectId: string, datasetId: string, tableId: string):
-      gapi.client.HttpRequest<gapi.client.bigquery.BigqueryTable> {
+  public static getBigqueryTableDetails(projectId: string, datasetId: string, tableId: string):
+      gapi.client.HttpRequest<gapi.client.bigquery.Table> {
     const request = {
       datasetId,
       projectId,

--- a/sources/web/datalab/polymer/modules/GapiManager.ts
+++ b/sources/web/datalab/polymer/modules/GapiManager.ts
@@ -107,7 +107,6 @@ class GapiManager {
   /**
    * Fetches table details from BigQuery
    */
-  // TODO: fix return type
   public static getTableDetails(projectId: string, datasetId: string, tableId: string):
       gapi.client.HttpRequest<gapi.client.bigquery.BigqueryTable> {
     const request = {

--- a/third_party/externs/ts/gapi/bigquery.d.ts
+++ b/third_party/externs/ts/gapi/bigquery.d.ts
@@ -10,7 +10,7 @@ declare namespace gapi.client {
 
     const tables: {
       list: (request?: ListTablesRequest) => HttpRequest<ListTablesResponse>;
-      get: (request?: GetTableRequest) => HttpRequest<BigqueryTable>;
+      get: (request?: GetTableRequest) => HttpRequest<Table>;
     }
 
     interface DatasetReference {
@@ -74,7 +74,7 @@ declare namespace gapi.client {
       tables: Array<TableResource>;
     }
 
-    interface BigqueryTable {
+    interface Table {
       creationTime: string;
       etag: string;
       id: string;

--- a/third_party/externs/ts/gapi/bigquery.d.ts
+++ b/third_party/externs/ts/gapi/bigquery.d.ts
@@ -10,6 +10,7 @@ declare namespace gapi.client {
 
     const tables: {
       list: (request?: ListTablesRequest) => HttpRequest<ListTablesResponse>;
+      get: (request?: GetTableRequest) => HttpRequest<BigqueryTable>;
     }
 
     interface DatasetReference {
@@ -60,11 +61,46 @@ declare namespace gapi.client {
       projectId: string;
     }
 
+    interface GetTableRequest {
+      datasetId: string;
+      projectId: string;
+      tableId: string;
+    }
+
     interface ListTablesResponse {
       kind: string;   // Should always be "bigquery#tableList"
       etag: string;
       nextPageToken: string;
       tables: Array<TableResource>;
+    }
+
+    interface BigqueryTable {
+      creationTime: string;
+      etag: string;
+      id: string;
+      kind: string;   // Should always be "bigquery#tableList"
+      labels: [{
+        name: string;
+        value: string;
+      }]
+      lastModifiedTime: string;
+      location: string;
+      numBytes: string;
+      numLongTermBytes: string;
+      numRows: string;
+      schema: {
+        fields: [{
+          name: string;
+          type: string;
+        }]
+      }
+      selfLink: string;
+      tableReference: {
+        projectId: string;
+        datasetId: string;
+        tableId: string;
+      }
+      type: string;
     }
 
     interface ProjectReference {


### PR DESCRIPTION
This PR adds a details pane to the Data First page that shows the selected table's details. One caveat is the schema only shows the columns in the first level, as I haven't yet added flattening (or some other solution) to the schema. This will be coming next.

![image](https://user-images.githubusercontent.com/1424661/28800098-1f625dda-7600-11e7-9557-3f823952b833.png)
