### PR TITLE
Make sure gapi is loaded before making GapiManager operations

### DIFF
--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
@@ -71,10 +71,11 @@ class AuthPanel extends Polymer.Element {
         .then((email: string) => {
           this._userInfo = 'Signed in as ' + email;
           this._projectInfo = 'No project is set';  // TODO
+
+          const ev = new Event('signInOutDone');
+          this.dispatchEvent(ev);
         });
     }
-    const ev = new Event('signInOutDone');
-    this.dispatchEvent(ev);
   }
 }
 

--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
@@ -47,7 +47,10 @@ class AuthPanel extends Polymer.Element {
 
   ready() {
     super.ready();
-    GapiManager.loadGapi(this._signInChanged.bind(this));
+    GapiManager.listenForSignInChanges(this._signInChanged.bind(this))
+      .catch(() => {
+        // TODO: handle errors authenticating
+      });
   }
 
   _signInClicked() {
@@ -64,8 +67,11 @@ class AuthPanel extends Polymer.Element {
   _signInChanged(signedIn: boolean) {
     this._signedIn = signedIn;
     if (signedIn) {
-      this._userInfo = 'Signed in as ' + GapiManager.getSignedInEmail();
-      this._projectInfo = 'No project is set';  // TODO
+      GapiManager.getSignedInEmail()
+        .then((email: string) => {
+          this._userInfo = 'Signed in as ' + email;
+          this._projectInfo = 'No project is set';  // TODO
+        });
     }
     const ev = new Event('signInOutDone');
     this.dispatchEvent(ev);

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -91,6 +91,9 @@ class DataElement extends Polymer.Element {
           console.log('== projects: ', response);
           const projectResults: Result[] = response.result.projects.map(this._bqProjectToResult.bind(this)) as Result[];
           resultHandler(projectResults);
+        })
+        .catch(() => {
+          // TODO: handle errors getting projects
         });
     // The filter arg when querying for datasets must be of the form labels.<name>[:<value>],
     // see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list
@@ -99,12 +102,18 @@ class DataElement extends Polymer.Element {
           console.log('== datasets: ', response);
           const datasetResults: Result[] = response.result.datasets.map(this._bqDatasetToResult.bind(this)) as Result[];
           resultHandler(datasetResults);
+        })
+        .catch(() => {
+          // TODO: handle errors getting projects
         });
     GapiManager.listBigQueryTables(sampleProject, searchValue /* datasetId */)
         .then((response: HttpResponse<gapi.client.bigquery.ListTablesResponse>) => {
           console.log('== tables: ', response);
           const tableResults: Result[] = response.result.tables.map(this._bqTableToResult.bind(this)) as Result[];
           resultHandler(tableResults);
+        })
+        .catch(() => {
+          // TODO: handle errors getting projects
         });
   }
 
@@ -158,7 +167,6 @@ class DataElement extends Polymer.Element {
   }
 
   _resultsSelectionChanged() {
-    console.log('== result selection changed');
     const selectedIndices = (this.$.results as ItemListElement).selectedIndices;
     if (selectedIndices.length === 1) {
       const selectedItem = this._resultsList[selectedIndices[0]];

--- a/sources/web/datalab/polymer/modules/GapiManager.ts
+++ b/sources/web/datalab/polymer/modules/GapiManager.ts
@@ -54,7 +54,7 @@ class GapiManager {
           .then(() => gapi.load('client:auth2', resolve))
           .catch((e: Error) => {
             if (e instanceof MissingClientIdError) {
-              console.log(e.message);
+              console.error(e.message);
             }
             reject(e);
           });
@@ -91,20 +91,25 @@ class GapiManager {
       .then(() => gapi.auth2.getAuthInstance().signOut());
   }
 
-  /** Returns the signed-in user's email address. */
+  /**
+   * Returns a promise that resolves to the signed-in user's email address.
+   */
   public static getSignedInEmail(): Promise<string> {
     return this.loadGapi()
       .then(() => gapi.auth2.getAuthInstance().currentUser.get().getBasicProfile().getEmail());
   }
 
-  /** Gets the list of BigQuery projects, returns a Promise. */
+  /**
+   * Gets the list of BigQuery projects, returns a Promise.
+   */
   public static listBigQueryProjects():
       gapi.client.HttpRequest<gapi.client.bigquery.ListProjectsResponse> {
     return this._loadBigQuery()
       .then(() => gapi.client.bigquery.projects.list());
   }
 
-  /** Gets the list of BigQuery datasets in the specified project, returns a Promise.
+  /**
+   * Gets the list of BigQuery datasets in the specified project, returns a Promise.
    * @param projectId
    * @param filter A label filter of the form label.<name>[:<value>], as described in
    *     https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list
@@ -147,20 +152,20 @@ class GapiManager {
       .then(() => gapi.client.bigquery.tables.get(request));
   }
 
+  /**
+   * Observes changes to the sign in status, and calls the provided callback
+   * with the changes.
+   */
   public static listenForSignInChanges(signInChangedCallback: (signedIn: boolean) => void):
       Promise<void> {
     return this.loadGapi()
       .then(() => {
-        // If auth status is already know, initialize the callback now
-        if (gapi && gapi.auth2) {
-          const signedIn = gapi.auth2.getAuthInstance().isSignedIn.get();
-          signInChangedCallback(signedIn);
-        }
+        // Initialize the callback now
+        signInChangedCallback(gapi.auth2.getAuthInstance().isSignedIn.get());
 
         // Listen for auth changes
         gapi.auth2.getAuthInstance().isSignedIn.listen(() => {
-          const signedIn = gapi.auth2.getAuthInstance().isSignedIn.get();
-          signInChangedCallback(signedIn);
+          signInChangedCallback(gapi.auth2.getAuthInstance().isSignedIn.get());
         });
       });
   }

--- a/third_party/externs/ts/gapi/bigquery.d.ts
+++ b/third_party/externs/ts/gapi/bigquery.d.ts
@@ -77,7 +77,7 @@ declare namespace gapi.client {
     interface Field {
       description?: string;
       fields?: Field[];
-      mode: string;
+      mode?: string;
       name: string;
       type: string;
     }

--- a/third_party/externs/ts/gapi/bigquery.d.ts
+++ b/third_party/externs/ts/gapi/bigquery.d.ts
@@ -74,26 +74,32 @@ declare namespace gapi.client {
       tables: Array<TableResource>;
     }
 
+    interface Field {
+      description?: string;
+      fields?: Field[];
+      mode: string;
+      name: string;
+      type: string;
+    }
+
     interface Table {
       creationTime: string;
+      description?: string;
       etag: string;
       id: string;
       kind: string;   // Should always be "bigquery#tableList"
       labels: [{
         name: string;
         value: string;
-      }]
+      }];
       lastModifiedTime: string;
       location: string;
       numBytes: string;
       numLongTermBytes: string;
       numRows: string;
       schema: {
-        fields: [{
-          name: string;
-          type: string;
-        }]
-      }
+        fields: Field[];
+      };
       selfLink: string;
       tableReference: {
         projectId: string;


### PR DESCRIPTION
This PR changes `GapiManager` to add a dependency on `gapi.load` for all its operations. This way any of its public methods can be called at any point, and it would first make sure the module has loaded. The actual loading happens only once, then its resulting promise is returned every time it's called.