### PR TITLE
[Data First] Notebook Templates + Open in Notebook

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -85,28 +85,28 @@ class DataElement extends Polymer.Element {
 
   // Make some calls to the BigQuery API and pass the results to the resultHandler
   _callBigQuery(searchValue: string, resultHandler: (partialResults: Result[]) => void) {
-    // const sampleProject = 'bigquery-public-data';
-    // GapiManager.listBigQueryProjects()
-    //     .then((response: HttpResponse<gapi.client.bigquery.ListProjectsResponse>) => {
-    //       console.log('== projects: ', response);
-    //       const projectResults: Result[] = response.result.projects.map(this._bqProjectToResult.bind(this)) as Result[];
-    //       resultHandler(projectResults);
-    //     })
-    //     .catch(() => {
-    //       // TODO: handle errors getting projects
-    //     });
-    // // The filter arg when querying for datasets must be of the form labels.<name>[:<value>],
-    // // see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list
-    // GapiManager.listBigQueryDatasets(sampleProject, searchValue /* label filter */)
-    //     .then((response: HttpResponse<gapi.client.bigquery.ListDatasetsResponse>) => {
-    //       console.log('== datasets: ', response);
-    //       const datasetResults: Result[] = response.result.datasets.map(this._bqDatasetToResult.bind(this)) as Result[];
-    //       resultHandler(datasetResults);
-    //     })
-    //     .catch(() => {
-    //       // TODO: handle errors getting projects
-    //     });
-    GapiManager.listBigQueryTables('yelsayed-project1', searchValue /* datasetId */)
+    const sampleProject = 'bigquery-public-data';
+    GapiManager.listBigQueryProjects()
+        .then((response: HttpResponse<gapi.client.bigquery.ListProjectsResponse>) => {
+          console.log('== projects: ', response);
+          const projectResults: Result[] = response.result.projects.map(this._bqProjectToResult.bind(this)) as Result[];
+          resultHandler(projectResults);
+        })
+        .catch(() => {
+          // TODO: handle errors getting projects
+        });
+    // The filter arg when querying for datasets must be of the form labels.<name>[:<value>],
+    // see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list
+    GapiManager.listBigQueryDatasets(sampleProject, searchValue /* label filter */)
+        .then((response: HttpResponse<gapi.client.bigquery.ListDatasetsResponse>) => {
+          console.log('== datasets: ', response);
+          const datasetResults: Result[] = response.result.datasets.map(this._bqDatasetToResult.bind(this)) as Result[];
+          resultHandler(datasetResults);
+        })
+        .catch(() => {
+          // TODO: handle errors getting projects
+        });
+    GapiManager.listBigQueryTables(sampleProject, searchValue /* datasetId */)
         .then((response: HttpResponse<gapi.client.bigquery.ListTablesResponse>) => {
           console.log('== tables: ', response);
           const tableResults: Result[] = response.result.tables.map(this._bqTableToResult.bind(this)) as Result[];

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -85,28 +85,28 @@ class DataElement extends Polymer.Element {
 
   // Make some calls to the BigQuery API and pass the results to the resultHandler
   _callBigQuery(searchValue: string, resultHandler: (partialResults: Result[]) => void) {
-    const sampleProject = 'bigquery-public-data';
-    GapiManager.listBigQueryProjects()
-        .then((response: HttpResponse<gapi.client.bigquery.ListProjectsResponse>) => {
-          console.log('== projects: ', response);
-          const projectResults: Result[] = response.result.projects.map(this._bqProjectToResult.bind(this)) as Result[];
-          resultHandler(projectResults);
-        })
-        .catch(() => {
-          // TODO: handle errors getting projects
-        });
-    // The filter arg when querying for datasets must be of the form labels.<name>[:<value>],
-    // see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list
-    GapiManager.listBigQueryDatasets(sampleProject, searchValue /* label filter */)
-        .then((response: HttpResponse<gapi.client.bigquery.ListDatasetsResponse>) => {
-          console.log('== datasets: ', response);
-          const datasetResults: Result[] = response.result.datasets.map(this._bqDatasetToResult.bind(this)) as Result[];
-          resultHandler(datasetResults);
-        })
-        .catch(() => {
-          // TODO: handle errors getting projects
-        });
-    GapiManager.listBigQueryTables(sampleProject, searchValue /* datasetId */)
+    // const sampleProject = 'bigquery-public-data';
+    // GapiManager.listBigQueryProjects()
+    //     .then((response: HttpResponse<gapi.client.bigquery.ListProjectsResponse>) => {
+    //       console.log('== projects: ', response);
+    //       const projectResults: Result[] = response.result.projects.map(this._bqProjectToResult.bind(this)) as Result[];
+    //       resultHandler(projectResults);
+    //     })
+    //     .catch(() => {
+    //       // TODO: handle errors getting projects
+    //     });
+    // // The filter arg when querying for datasets must be of the form labels.<name>[:<value>],
+    // // see https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets/list
+    // GapiManager.listBigQueryDatasets(sampleProject, searchValue /* label filter */)
+    //     .then((response: HttpResponse<gapi.client.bigquery.ListDatasetsResponse>) => {
+    //       console.log('== datasets: ', response);
+    //       const datasetResults: Result[] = response.result.datasets.map(this._bqDatasetToResult.bind(this)) as Result[];
+    //       resultHandler(datasetResults);
+    //     })
+    //     .catch(() => {
+    //       // TODO: handle errors getting projects
+    //     });
+    GapiManager.listBigQueryTables('yelsayed-project1', searchValue /* datasetId */)
         .then((response: HttpResponse<gapi.client.bigquery.ListTablesResponse>) => {
           console.log('== tables: ', response);
           const tableResults: Result[] = response.result.tables.map(this._bqTableToResult.bind(this)) as Result[];

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.html
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.html
@@ -28,6 +28,14 @@ the License.
       paper-spinner {
         --paper-spinner-stroke-width: 2px;
       }
+      #openInNotebookButton {
+        background-color: var(--paper-blue-600);
+        color: white;
+        width: 150px;
+      }
+      #openInNotebookButton:hover{
+        @apply --shadow-elevation-4dp;
+      }
       #container {
         padding: 0px 20px;
         height: 100%;
@@ -59,6 +67,10 @@ the License.
       <paper-spinner active hidden$={{!_busy}}></paper-spinner>
     </div>
     <div id="container" hidden$={{!_table}}>
+      <br>
+      <paper-button id="openInNotebookButton" raised on-click="_openInNotebook">
+        Open in Notebook
+      </paper-button>
       <br>
       <h3>Table Details: <span id="tableId">{{_table.tableReference.tableId}}</span></h3>
       <span class="strong">Project: </span>
@@ -116,4 +128,5 @@ the License.
   </template>
 </dom-module>
 
+<script src="../../modules/TemplateManager.js"></script>
 <script src="table-preview.js"></script>

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.ts
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.ts
@@ -140,10 +140,10 @@ class TablePreviewElement extends Polymer.Element {
 
     if (this._table) {
       const tableName = this._table.id.replace(':', '.'); // Standard BigQuery table name
-      const t = new TableSchemaTemplate(tableName);
+      const template = new TableSchemaTemplate(tableName);
 
       try {
-        const model = await TemplateManager.newNotebookFromTemplate(t);
+        const model = await TemplateManager.newNotebookFromTemplate(template);
 
         if (model) {
           const newFile = await ApiManager.saveJupyterFile(model) as JupyterFile;

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.ts
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.ts
@@ -133,6 +133,30 @@ class TablePreviewElement extends Polymer.Element {
     return mode || this.DEFAULT_MODE;
   }
 
+  /**
+   * Opens the current table in the table schema template notebook.
+   */
+  async _openInNotebook() {
+
+    if (this._table) {
+      const tableName = this._table.id.replace(':', '.'); // Standard BigQuery table name
+      const t = new TableSchemaTemplate(tableName);
+
+      try {
+        const model = await TemplateManager.newNotebookFromTemplate(t);
+
+        if (model) {
+          const newFile = await ApiManager.saveJupyterFile(model) as JupyterFile;
+          const basePath = await ApiManager.getBasePath();
+          const prefix = location.protocol + '//' + location.host + basePath + '/';
+          window.open(prefix + 'notebooks' + '/' + newFile.path, '_blank');
+        }
+      } catch (e) {
+        Utils.showErrorDialog('Error', e.message);
+      }
+    }
+  }
+
 }
 
 customElements.define(TablePreviewElement.is, TablePreviewElement);

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -193,7 +193,7 @@ class ApiManager {
    *               useful for downloading notebooks, which are by default read
    *               as JSON, which doesn't preserve formatting.
    */
-  public static getJupyterFile(path: string, asText?: boolean): Promise<JupyterFile> {
+  public static async getJupyterFile(path: string, asText?: boolean): Promise<JupyterFile> {
     if (path.startsWith('/')) {
       path = path.substr(1);
     }
@@ -212,7 +212,7 @@ class ApiManager {
    * and content are required fields.
    * @param model object containing file information to send to backend
    */
-  public static saveJupyterFile(model: JupyterFile) {
+  public static async saveJupyterFile(model: JupyterFile) {
     const xhrOptions: XhrOptions = {
       failureCodes: [409],
       method: 'PUT',

--- a/sources/web/datalab/polymer/modules/TemplateManager.ts
+++ b/sources/web/datalab/polymer/modules/TemplateManager.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/// <reference path="ApiManager.ts" />
+
+const PLACEHOLDER_PREFIX = '#$';
+
+interface TemplateParameter {
+  placeholder: string;
+  value: string | number;
+}
+
+/**
+ * This models a notebook template, including its path on disk as well as a
+ * list of its required parameters.
+ */
+class NotebookTemplate {
+  // Path to the template file on disk
+  path: string;
+
+  // List of parameters required by the template
+  parameters: TemplateParameter[];
+
+  constructor(path: string, parameters: TemplateParameter[]) {
+    this.path = path;
+    this.parameters = parameters;
+  }
+
+  /**
+   * Escapes all regex modifier characters in the given string.
+   */
+  private static _regexEscapeAll(s: string) {
+    return s.replace(/([.*+?^${}()|\[\]\/\\])/g, '\\$1');
+  }
+
+  /**
+   * Substitutes all placeholders in the given notebook's cells with their
+   * values.
+   */
+  public populatePlaceholders(notebook: JupyterNotebookModel) {
+
+    notebook.cells.forEach((cell: JupyterNotebookCellModel) => {
+      this.parameters.forEach((parameter: TemplateParameter) => {
+        const placeholder = PLACEHOLDER_PREFIX + parameter.placeholder;
+        const escapedPlaceholder = NotebookTemplate._regexEscapeAll(placeholder);
+        const regex = new RegExp(escapedPlaceholder);
+        const value = '\'' + parameter.value.toString() + '\'';
+        cell.source = cell.source.replace(regex, value);
+      });
+    });
+
+  }
+}
+
+/**
+ * This template contains one cell that shows the given table's schema.
+ */
+class TableSchemaTemplate extends NotebookTemplate {
+  constructor(tableName: string) {
+    const parameters = [{
+      placeholder: 'TABLE_NAME_PLACEHOLDER',
+      value: tableName,
+    }];
+
+    super('tableSchema.ipynb', parameters);
+  }
+}
+
+/**
+ * Manages notebook templates, which are notebooks that contain parameter
+ * placeholders. This class can also generate a notebook out of any such
+ * template. New templates can be created by extending the NotebookTemplate
+ * class, and adding a file on disk with placeholders. All placeholders have to
+ * use the same prefix declared in this file.
+ * TODO: Consider adding an isTemplateAvailable method that checks the
+ * existence of a given template on disk and ensures it has the right
+ * placeholders.
+ */
+class TemplateManager {
+
+  private static _templatePrefix = 'datalab/templates/';
+
+  public static async newNotebookFromTemplate(template: NotebookTemplate) {
+
+    const options: DirectoryPickerDialogOptions = {
+      big: true,
+      okLabel: 'Save Here',
+      title: 'New Notebook',
+      withFileName: true,
+    };
+
+    const closeResult = await Utils.showDialog(DirectoryPickerDialogElement, options) as
+        DirectoryPickerDialogCloseResult;
+
+    if (closeResult.confirmed && closeResult.fileName) {
+      const path = TemplateManager._templatePrefix + template.path;
+      const file = await ApiManager.getJupyterFile(path);
+
+      file.name = closeResult.fileName;
+      if (!file.name.endsWith('.ipynb')) {
+        file.name += '.ipynb';
+      }
+      file.path = closeResult.directoryPath;
+      template.populatePlaceholders(file.content as JupyterNotebookModel);
+
+      return file;
+    } else {
+      return null;
+    }
+
+  }
+
+}

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -24,8 +24,9 @@ class Utils {
    * @param type specifies which type of dialog to use
    * @param dialogOptions specifies different options for opening the dialog
    */
-  public static showDialog(dialogType: typeof BaseDialogElement,
-                           dialogOptions: BaseDialogOptions): Promise<BaseDialogCloseResult> {
+  public static async showDialog(dialogType: typeof BaseDialogElement,
+                                 dialogOptions: BaseDialogOptions):
+                                   Promise<BaseDialogCloseResult> {
     const dialog = document.createElement(dialogType.is) as any;
     document.body.appendChild(dialog);
 
@@ -40,7 +41,7 @@ class Utils {
         document.body.removeChild(dialog);
         resolve(closeResult);
       });
-    });
+    }) as Promise<BaseDialogCloseResult>;
   }
 
   /**
@@ -48,7 +49,7 @@ class Utils {
    * @param title error title
    * @param messageHtml error message
    */
-  static showErrorDialog(title: string, messageHtml: string) {
+  public static async showErrorDialog(title: string, messageHtml: string) {
     const dialogOptions: BaseDialogOptions = {
       isError: true,
       messageHtml,

--- a/sources/web/datalab/polymer/modules/Utils.ts
+++ b/sources/web/datalab/polymer/modules/Utils.ts
@@ -25,8 +25,7 @@ class Utils {
    * @param dialogOptions specifies different options for opening the dialog
    */
   public static async showDialog(dialogType: typeof BaseDialogElement,
-                                 dialogOptions: BaseDialogOptions):
-                                   Promise<BaseDialogCloseResult> {
+                                 dialogOptions: BaseDialogOptions) {
     const dialog = document.createElement(dialogType.is) as any;
     document.body.appendChild(dialog);
 


### PR DESCRIPTION
This is a POC for opening the selected BigQuery table in a template notebook. This adds a `TemplateManager` module that can be used to define new templates and can populate their properties and create a new notebook with the substituted content.

Note that for this to work, it needs the actual template notebook to exist on disk, currently fixed at the path `datalab/templates/<templateName>`. We can look into how to make this smoother in the future if we think this is a useful feature.

![image](https://user-images.githubusercontent.com/1424661/28898205-742f41ee-7799-11e7-8e82-285126bac16d.png)
