### PR TITLE
[Polymer UI] Add timeout panel to Account menu

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -165,6 +165,13 @@ declare module common {
     idleTimeoutShutdownCommand: string;
   }
 
+  interface TimeoutInfo {
+    enabled: boolean;
+    expirationTime: number;
+    secondsRemaining: number;
+    idleTimeoutSeconds: number;
+  }
+
   interface Map<T> {
     [index: string]: T;
   }

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -16,6 +16,7 @@ the License.
 <link rel="import" href="../../components/datalab-info/datalab-info.html">
 <link rel="import" href="../../components/datalab-settings/datalab-settings.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
+<link rel="import" href="../../components/timeout-panel/timeout-panel.html">
 
 <link rel="import" href="../../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
@@ -112,6 +113,7 @@ the License.
     below the toolbar-->
     <paper-dialog id="accountDropdown" class="account-dropdown">
       <auth-panel></auth-panel>
+      <timeout-panel id="accountTimeoutPanel"></timeout-panel>
     </paper-dialog>
 
     <!--Info dialog. This shows centered in the middle of the window-->

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
@@ -35,10 +35,12 @@ class ToolbarElement extends Polymer.Element {
    */
   _accountIconClicked() {
     this.$.accountDropdown.toggle();
+    this.$.accountTimeoutPanel.onOpenChange(this.$.accountDropdown.opened);
   }
 
   _closeAccountDropdown() {
     this.$.accountDropdown.close();
+    this.$.accountTimeoutPanel.onOpenChange(false);
   }
 
   /**

--- a/sources/web/datalab/polymer/components/timeout-panel/timeout-panel.html
+++ b/sources/web/datalab/polymer/components/timeout-panel/timeout-panel.html
@@ -1,0 +1,40 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
+
+<link rel="import" href="../../bower_components/iron-icon/iron-icon.html">
+<link rel="import" href="../../bower_components/iron-icons/image-icons.html">
+
+<dom-module id="timeout-panel">
+  <template>
+    <style include="datalab-shared-styles">
+      #timeoutLabel {
+        color: #fff;
+        background-color: #449d44;
+        border-color: #398439;
+      }
+    </style>
+
+    <div id="timeoutControls" hidden={{!_timeoutControlsEnabled}}>
+      <iron-icon id="timeoutEnabledIcon" icon="image:timer" hidden="{{!_timeoutEnabled}}" on-click="_disableTimeout"></iron-icon>
+      <iron-icon id="timeoutDisabledIcon" icon="image:timer-off" hidden="{{_timeoutEnabled}}" on-click="_enableTimeout"></iron-icon>
+      <span id="timeoutText">{{_timeoutText}}</span>
+    </div>
+
+  </template>
+</dom-module>
+
+<script src="../../modules/TimeoutManager.js"></script>
+<script src="timeout-panel.js"></script>

--- a/sources/web/datalab/polymer/components/timeout-panel/timeout-panel.html
+++ b/sources/web/datalab/polymer/components/timeout-panel/timeout-panel.html
@@ -20,16 +20,13 @@ the License.
 <dom-module id="timeout-panel">
   <template>
     <style include="datalab-shared-styles">
-      #timeoutLabel {
-        color: #fff;
-        background-color: #449d44;
-        border-color: #398439;
-      }
     </style>
 
     <div id="timeoutControls" hidden={{!_timeoutControlsEnabled}}>
-      <iron-icon id="timeoutEnabledIcon" icon="image:timer" hidden="{{!_timeoutEnabled}}" on-click="_disableTimeout"></iron-icon>
-      <iron-icon id="timeoutDisabledIcon" icon="image:timer-off" hidden="{{_timeoutEnabled}}" on-click="_enableTimeout"></iron-icon>
+      <iron-icon id="timeoutEnabledIcon" icon="image:timer"
+          hidden="{{!_timeoutEnabled}}" on-click="_disableTimeout"></iron-icon>
+      <iron-icon id="timeoutDisabledIcon" icon="image:timer-off"
+          hidden="{{_timeoutEnabled}}" on-click="_enableTimeout"></iron-icon>
       <span id="timeoutText">{{_timeoutText}}</span>
     </div>
 

--- a/sources/web/datalab/polymer/components/timeout-panel/timeout-panel.ts
+++ b/sources/web/datalab/polymer/components/timeout-panel/timeout-panel.ts
@@ -28,11 +28,6 @@
 class TimeoutPanel extends Polymer.Element {
 
   private static _displayInterval = 1000;  // Update display every second
-  private static _hoursPerDay = 24;
-  private static _minutesPerHour = 60;
-  private static _secondsPerMinute = 60;
-  private static _secondsPerHour = TimeoutPanel._secondsPerMinute * TimeoutPanel._minutesPerHour;
-  private static _secondsPerDay = TimeoutPanel._secondsPerHour * TimeoutPanel._hoursPerDay;
   private static _queryIntervalWhenEnabled = 15 * 1000;  // How often to query when timeout is enabled
   private static _queryIntervalWhenDisabled = 60 * 1000;  // How often to query when timeout is disabled
 
@@ -101,79 +96,16 @@ class TimeoutPanel extends Polymer.Element {
       if (secondsRemaining < 0) {
         secondsRemaining = 0;
       }
-      const roundedSecondsRemaining = this._roundToApproximateTime(secondsRemaining);
+      const roundedSecondsRemaining = TimeoutManager.roundToApproximateTime(secondsRemaining);
       const maybeAbout = (roundedSecondsRemaining !== secondsRemaining) ? 'about ' : '';
       this._timeoutText = (roundedSecondsRemaining === 0) ?
           'Idle timeout exceeded' :
-          'Idle timeout in ' + maybeAbout + this._secondsToString(roundedSecondsRemaining);
+          'Idle timeout in ' + maybeAbout + TimeoutManager.secondsToString(roundedSecondsRemaining);
     } else {
       this._timeoutText = 'Idle timeout is disabled';
     }
 
     this._runTimer();
-  }
-
-  // Rounds seconds to an approximate time, based on magnitude.
-  // We use rounding instead of truncating so that the user will generally see
-  // the number they specified, such as "3h", rather than something like "2h 50m".
-  private _roundToApproximateTime(seconds: number): number {
-    if (seconds <= 2 * TimeoutPanel._secondsPerMinute) {
-      return seconds;  // No rounding when less than 2 minutes.
-    }
-    const minutes = Math.round(seconds / TimeoutPanel._secondsPerMinute);
-    if (minutes <= 20) {
-      // Round to nearest minute when under 20.5 minutes.
-      return minutes * TimeoutPanel._secondsPerMinute;
-    }
-    if (minutes <= 60) {
-      // Round to nearest 5 minutes when under 1.5 hour.
-      return Math.round(minutes / 5) * 5 * TimeoutPanel._secondsPerMinute;
-    }
-    const hours = Math.round(minutes / TimeoutPanel._secondsPerMinute);
-    if (hours <= 2) {
-      // Round to nearest 10 minutes when under 2.5 hours.
-      return Math.round(minutes / 10) * 10 * TimeoutPanel._secondsPerMinute;
-    }
-    if (hours <= 5) {
-      // Round to nearest half hour when under 5.5 hours.
-      return Math.round(minutes / 30) * 30 * TimeoutPanel._secondsPerMinute;
-    }
-    const days = Math.round(hours / TimeoutPanel._hoursPerDay);
-    if (days <= 3) {
-      // Round to nearest hour when under 3.5 days.
-      return hours * TimeoutPanel._secondsPerHour;
-    }
-    // Round to nearest day when 3.5 days or more.
-    return days * TimeoutPanel._secondsPerDay;
-  }
-
-  // Converts a number of seconds into a string that include m, h, and d units.
-  private _secondsToString(seconds: number): string {
-    let s = '';         // build a string
-    let t = seconds;    // number of seconds left to convert
-    let sep = '';       // separator, gets set to space once s is not null
-    if (t > TimeoutPanel._secondsPerDay) {
-      const days = Math.floor(t / TimeoutPanel._secondsPerDay);
-      t = t % TimeoutPanel._secondsPerDay;
-      s = s + sep + days + 'd';
-      sep = ' ';
-    }
-    if (t > TimeoutPanel._secondsPerHour) {
-      const hours = Math.floor(t / TimeoutPanel._secondsPerHour);
-      t = t % TimeoutPanel._secondsPerHour;
-      s = s + sep + hours + 'h';
-      sep = ' ';
-    }
-    if (t > TimeoutPanel._secondsPerMinute) {
-      const minutes = Math.floor(t / TimeoutPanel._secondsPerMinute);
-      t = t % TimeoutPanel._secondsPerMinute;
-      s = s + sep + minutes + 'm';
-      sep = ' ';
-    }
-    if (t > 0) {
-      s = s + sep + t + 's';
-    }
-    return s;
   }
 
   /**

--- a/sources/web/datalab/polymer/components/timeout-panel/timeout-panel.ts
+++ b/sources/web/datalab/polymer/components/timeout-panel/timeout-panel.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/// <reference path="../../modules/GapiManager.ts" />
+/// <reference path="../../modules/TimeoutManager.ts" />
+
+// TODO: look through datalab/static/idle-timeout.js for additional features to port to here.
+
+// TODO: we need to make on-blur work on our tabs so that we stop sending API calls such as
+// /api/sessions when a tab is not visible, as that prevents idle timeout.
+
+/**
+ * Idle timeout panel.
+ * This element provides a timeout icon and a timeout status string.
+ * When the icon is clicked, it toggles whether the idle timeout is enabled.
+ */
+class TimeoutPanel extends Polymer.Element {
+
+  private static _displayInterval = 1000;  // Update display every second
+  private static _queryIntervalWhenEnabled = 15 * 1000;  // How often to query when timeout is enabled
+  private static _queryIntervalWhenDisabled = 60 * 1000;  // How often to query when timeout is disabled
+
+  private _isOpen: boolean;
+  private _lastQueryTime = 0;
+  private _timeoutControlsEnabled: boolean;
+  private _timeoutEnabled: boolean;
+  private _timeoutInfo: common.TimeoutInfo;
+  private _timeoutText: string;
+  private _updateTimer: number;
+
+  static get is() { return 'timeout-panel'; }
+
+  static get properties() {
+    return {
+      _timeoutControlsEnabled: {
+        type: Boolean,
+        value: false,
+      },
+      _timeoutEnabled: {
+        type: Boolean,
+        value: false,
+      },
+      _timeoutText: {
+        type: String,
+        value: 'waiting for timeout status',
+      },
+    };
+  }
+
+  /**
+   * Updates our timeout controls.
+   * This should be called when our element becomes visible or hidden.
+   * @param open True if our element is visible.
+   */
+  onOpenChange(isOpen: boolean): Promise<void> {
+    this._isOpen = isOpen;
+    return this._updateTimeoutInfo();
+  }
+
+  _disableTimeout(): Promise<void> {
+    console.log('== disabling timeout');
+    return TimeoutManager.setTimeoutEnabled(false)
+        .then(() => this._updateTimeoutInfo());
+  }
+
+  _enableTimeout(): Promise<void> {
+    console.log('== enabling timeout');
+    return TimeoutManager.setTimeoutEnabled(true)
+        .then(() => this._updateTimeoutInfo());
+  }
+
+  private _updateTimeoutInfo(): Promise<void> {
+    console.log('== updateTimeoutInfo');
+    this._lastQueryTime = Date.now();
+    return TimeoutManager.getTimeout()
+        .then((timeoutInfo) => {
+          this._timeoutInfo = timeoutInfo;
+          this._updateTimeoutDisplay();
+        });
+  }
+
+  private _updateTimeoutDisplay(): void {
+    const timeoutInfo = this._timeoutInfo;
+    // console.log('== updateTimeoutDisplay:', timeoutInfo);
+    this._timeoutControlsEnabled = this._isOpen && (timeoutInfo.secondsRemaining > 0);
+    this._timeoutEnabled = timeoutInfo.enabled;
+    if (this._timeoutEnabled) {
+      let secondsRemaining = Math.floor((timeoutInfo.expirationTime - Date.now()) / 1000);
+      if (secondsRemaining < 0) {
+        secondsRemaining = 0;
+      }
+      const roundedSecondsRemaining = this._roundToApproximateTime(secondsRemaining);
+      const maybeAbout = (roundedSecondsRemaining !== secondsRemaining) ? 'about ' : '';
+      this._timeoutText = (roundedSecondsRemaining === 0) ?
+          'Idle timeout exceeded' :
+          'Idle timeout in ' + maybeAbout + this._secondsToString(roundedSecondsRemaining);
+    } else {
+      this._timeoutText = 'Idle timeout is disabled';
+    }
+
+    this._runTimer();
+  }
+
+  // Rounds seconds to an approximate time, based on magnitude.
+  // We use rounding instead of truncating so that the user will generally see
+  // the number they specified, such as "3h", rather than something like "2h 50m".
+  private _roundToApproximateTime(seconds: number): number {
+    if (seconds <= 120) {
+      return seconds;  // No rounding when less than 2 minutes.
+    }
+    const minutes = Math.round(seconds / 60);
+    if (minutes <= 20) {
+      return minutes * 60; // Round to nearest minute when under 20.5 minutes.
+    }
+    if (minutes <= 60) {
+      return Math.round(minutes / 5) * 5 * 60; // Nearest 5 minutes when under 1.5 hour.
+    }
+    const hours = Math.round(minutes / 60);
+    if (hours <= 2) {
+      return Math.round(minutes / 10) * 10 * 60; // Nearest 10 minutes when under 2.5 hours.
+    }
+    if (hours <= 5) {
+      return Math.round(minutes / 30) * 30 * 60; // Nearest half hour when under 5.5 hours.
+    }
+    const days = Math.round(hours / 24);
+    if (days <= 3) {
+      return hours * 60 * 60; // Nearest hour when under 3.5 days.
+    }
+    return days * 24 * 60 * 60;     // Nearest day when 3.5 days or more.
+  }
+
+  // Converts a number of seconds into a string that include m, h, and d units.
+  private _secondsToString(seconds: number): string {
+    let s = '';         // build a string
+    let t = seconds;    // number of seconds left to convert
+    let sep = '';       // separator, gets set to space once s is not null
+    if (t > 86400) {
+      const days = Math.floor(t / 86400);
+      t = t % 86400;
+      s = s + sep + days + 'd';
+      sep = ' ';
+    }
+    if (t > 3600) {
+      const hours = Math.floor(t / 3600);
+      t = t % 3600;
+      s = s + sep + hours + 'h';
+      sep = ' ';
+    }
+    if (t > 60) {
+      const minutes = Math.floor(t / 60);
+      t = t % 60;
+      s = s + sep + minutes + 'm';
+      sep = ' ';
+    }
+    if (t > 0) {
+      s = s + sep + t + 's';
+    }
+    return s;
+  }
+
+  /**
+   * Runs the timer that updates our display and occasionally queries the timeout API.
+   */
+  private _runTimer() {
+    if (this._updateTimer) {
+      window.clearTimeout(this._updateTimer);
+      this._updateTimer = 0;
+    }
+    const callback = () => {
+      this._updateTimer = 0;
+      const queryInterval = this._timeoutEnabled ?
+          TimeoutPanel._queryIntervalWhenEnabled : TimeoutPanel._queryIntervalWhenDisabled;
+      const now = Date.now();
+      const timeSinceLastQuery = now - this._lastQueryTime;
+      if (timeSinceLastQuery > queryInterval) {
+        this._updateTimeoutInfo();
+      } else {
+        this._updateTimeoutDisplay();
+      }
+    };
+    this._updateTimer = window.setTimeout(callback, TimeoutPanel._displayInterval);
+  }
+}
+
+customElements.define(TimeoutPanel.is, TimeoutPanel);

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -430,7 +430,7 @@ class ApiManager {
    */
   public static sendRequestAsync(url: string, options?: XhrOptions) {
     return ApiManager.getBasePath()
-      .then((base: string) => ApiManager. _xhrJsonAsync(base + url, options));
+      .then((base: string) => ApiManager._xhrJsonAsync(base + url, options));
   }
 
   /**
@@ -440,7 +440,7 @@ class ApiManager {
    */
   public static sendTextRequestAsync(url: string, options?: XhrOptions): Promise<string> {
     return ApiManager.getBasePath()
-      .then((base: string) => ApiManager. _xhrTextAsync(base + url, options));
+      .then((base: string) => ApiManager._xhrTextAsync(base + url, options));
   }
 
   /**

--- a/sources/web/datalab/polymer/modules/ApiManager.ts
+++ b/sources/web/datalab/polymer/modules/ApiManager.ts
@@ -144,6 +144,11 @@ class ApiManager {
   public static readonly appSettingsUrl = '/api/settings';
 
   /**
+   * URL for timeout info
+   */
+  public static readonly timeoutUrl = '/_timeout';
+
+  /**
    * Current connection status. Set to the last connection status.
    */
   public static isConnected = true;
@@ -420,12 +425,22 @@ class ApiManager {
 
   /**
    * Sends an XMLHttpRequest to the specified URL, adding the required
-   * base path. This method returns immediately with a promise
-   * that resolves with the parsed object when the request completes.
+   * base path, and expecting a JSON response. This method returns immediately
+   * with a promise that resolves with the parsed object when the request completes.
    */
   public static sendRequestAsync(url: string, options?: XhrOptions) {
     return ApiManager.getBasePath()
       .then((base: string) => ApiManager. _xhrJsonAsync(base + url, options));
+  }
+
+  /**
+   * Sends an XMLHttpRequest to the specified URL, adding the required
+   * base path, and expecting a text response. This method returns immediately
+   * with a promise that resolves with the returned text when the request completes.
+   */
+  public static sendTextRequestAsync(url: string, options?: XhrOptions): Promise<string> {
+    return ApiManager.getBasePath()
+      .then((base: string) => ApiManager. _xhrTextAsync(base + url, options));
   }
 
   /**
@@ -441,9 +456,9 @@ class ApiManager {
   /**
    * Sends an XMLHttpRequest to the specified URL, and returns the
    * the response text. This method returns immediately with a promise
-   * that resolves with the parsed object when the request completes.
+   * that resolves with the response text when the request completes.
    */
-  private static _xhrTextAsync(url: string, options?: XhrOptions) {
+  private static _xhrTextAsync(url: string, options?: XhrOptions): Promise<string> {
 
     options = options || {};
     const method = options.method || 'GET';

--- a/sources/web/datalab/polymer/modules/TimeoutManager.ts
+++ b/sources/web/datalab/polymer/modules/TimeoutManager.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Handles API calls related to idle timeout.
+ */
+class TimeoutManager {
+
+  /**
+   * Queries the server for the timeout info.
+   */
+  public static getTimeout(): Promise<common.TimeoutInfo> {
+    return ApiManager.sendRequestAsync(ApiManager.timeoutUrl)
+        .then((timeoutInfo) => {
+          timeoutInfo.expirationTime = (timeoutInfo.idleTimeoutSeconds > 0) ?
+            Date.now() + timeoutInfo.secondsRemaining * 1000 : 0;
+          return timeoutInfo;
+        });
+  }
+
+  /**
+   * Enables or disables idle timeout.
+   */
+   public static setTimeoutEnabled(enabled: boolean): Promise<string> {
+    const timeoutUrl = ApiManager.timeoutUrl + '?enabled=' + enabled;
+    const xhrOptions: XhrOptions = {
+      method: 'POST',
+    };
+    return ApiManager.sendTextRequestAsync(timeoutUrl, xhrOptions);
+  }
+}

--- a/sources/web/datalab/polymer/modules/TimeoutManager.ts
+++ b/sources/web/datalab/polymer/modules/TimeoutManager.ts
@@ -17,6 +17,12 @@
  */
 class TimeoutManager {
 
+  private static _hoursPerDay = 24;
+  private static _minutesPerHour = 60;
+  private static _secondsPerMinute = 60;
+  private static _secondsPerHour = TimeoutManager._secondsPerMinute * TimeoutManager._minutesPerHour;
+  private static _secondsPerDay = TimeoutManager._secondsPerHour * TimeoutManager._hoursPerDay;
+
   /**
    * Queries the server for the timeout info.
    */
@@ -38,5 +44,72 @@ class TimeoutManager {
       method: 'POST',
     };
     return ApiManager.sendTextRequestAsync(timeoutUrl, xhrOptions);
+  }
+
+  /**
+   * Rounds seconds to an approximate time, based on magnitude.
+   * We use rounding instead of truncating so that the user will generally see
+   * the number they specified, such as "3h", rather than something like "2h 50m".
+   */
+  public static roundToApproximateTime(seconds: number): number {
+    if (seconds <= 2 * TimeoutManager._secondsPerMinute) {
+      return seconds;  // No rounding when less than 2 minutes.
+    }
+    const minutes = Math.round(seconds / TimeoutManager._secondsPerMinute);
+    if (minutes <= 20) {
+      // Round to nearest minute when under 20.5 minutes.
+      return minutes * TimeoutManager._secondsPerMinute;
+    }
+    if (minutes <= 60) {
+      // Round to nearest 5 minutes when under 1.5 hour.
+      return Math.round(minutes / 5) * 5 * TimeoutManager._secondsPerMinute;
+    }
+    const hours = Math.round(minutes / TimeoutManager._secondsPerMinute);
+    if (hours <= 2) {
+      // Round to nearest 10 minutes when under 2.5 hours.
+      return Math.round(minutes / 10) * 10 * TimeoutManager._secondsPerMinute;
+    }
+    if (hours <= 5) {
+      // Round to nearest half hour when under 5.5 hours.
+      return Math.round(minutes / 30) * 30 * TimeoutManager._secondsPerMinute;
+    }
+    const days = Math.round(hours / TimeoutManager._hoursPerDay);
+    if (days <= 3) {
+      // Round to nearest hour when under 3.5 days.
+      return hours * TimeoutManager._secondsPerHour;
+    }
+    // Round to nearest day when 3.5 days or more.
+    return days * TimeoutManager._secondsPerDay;
+  }
+
+  /**
+   * Converts a number of seconds into a string that include m, h, and d units.
+   */
+  public static secondsToString(seconds: number): string {
+    let s = '';         // build a string
+    let t = seconds;    // number of seconds left to convert
+    let sep = '';       // separator, gets set to space once s is not null
+    if (t > TimeoutManager._secondsPerDay) {
+      const days = Math.floor(t / TimeoutManager._secondsPerDay);
+      t = t % TimeoutManager._secondsPerDay;
+      s = s + sep + days + 'd';
+      sep = ' ';
+    }
+    if (t > TimeoutManager._secondsPerHour) {
+      const hours = Math.floor(t / TimeoutManager._secondsPerHour);
+      t = t % TimeoutManager._secondsPerHour;
+      s = s + sep + hours + 'h';
+      sep = ' ';
+    }
+    if (t > TimeoutManager._secondsPerMinute) {
+      const minutes = Math.floor(t / TimeoutManager._secondsPerMinute);
+      t = t % TimeoutManager._secondsPerMinute;
+      s = s + sep + minutes + 'm';
+      sep = ' ';
+    }
+    if (t > 0) {
+      s = s + sep + t + 's';
+    }
+    return s;
   }
 }

--- a/sources/web/datalab/polymer/test/TimeoutManager-test.html
+++ b/sources/web/datalab/polymer/test/TimeoutManager-test.html
@@ -19,19 +19,10 @@ the License.
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
+
+    <script src="../modules/TimeoutManager.js"></script>
   </head>
   <body>
-    <script>
-      // Load and run all tests (.html, .js). Keep element tests in HTML files so we
-      // can use fixtures, and keep all other tests in javascript files
-      WCT.loadSuites([
-        'item-list-test.html',
-        'resizable-divider-test.html',
-        'table-preview-test.html',
-        'TimeoutManager-test.html',
-        'timeout-panel-test.html',
-        'toolbar-test.html',
-      ]);
-    </script>
+    <script src="TimeoutManager-test.js"></script>
   </body>
 </html>

--- a/sources/web/datalab/polymer/test/TimeoutManager-test.ts
+++ b/sources/web/datalab/polymer/test/TimeoutManager-test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+declare function assert(condition: boolean): null;
+declare function assert(condition: boolean, message: string): null;
+
+/// <reference path="../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../node_modules/@types/chai/index.d.ts" />
+
+describe('TimeoutManager', () => {
+
+  describe('roundToApproximateTime', function() {
+    it('does not round small numbers', function() {
+      assert(TimeoutManager.roundToApproximateTime(0) == 0);
+      assert(TimeoutManager.roundToApproximateTime(11) == 11);
+      assert(TimeoutManager.roundToApproximateTime(99) == 99);
+    });
+    it('rounds these values to the nearest minute', function() {
+      assert(TimeoutManager.roundToApproximateTime(2*60) == 2*60);
+      assert(TimeoutManager.roundToApproximateTime(2*60 + 15) == 2*60);
+      assert(TimeoutManager.roundToApproximateTime(2*60 + 51) == 3*60);
+      assert(TimeoutManager.roundToApproximateTime(19*60 + 11) == 19*60);
+    });
+    it('rounds these values to the nearest 5 minutes', function() {
+      assert(TimeoutManager.roundToApproximateTime(21*60) == 20*60);
+      assert(TimeoutManager.roundToApproximateTime(23*60) == 25*60);
+      assert(TimeoutManager.roundToApproximateTime(62*60 + 15) == 60*60);
+      assert(TimeoutManager.roundToApproximateTime(88*60 + 15) == 90*60);
+    });
+    it('rounds these values to the nearest 10 minutes', function() {
+      assert(TimeoutManager.roundToApproximateTime(96*60) == 100*60);
+      assert(TimeoutManager.roundToApproximateTime(133*60) == 130*60);
+      assert(TimeoutManager.roundToApproximateTime(148*60) == 150*60);
+    });
+    it('rounds these values to the nearest half hour', function() {
+      assert(TimeoutManager.roundToApproximateTime(3*60*60 + 18*60) == 3*60*60 + 30*60);
+      assert(TimeoutManager.roundToApproximateTime(4*60*60 + 12*60) == 4*60*60);
+    });
+    it('rounds these values to the nearest hour', function() {
+      assert(TimeoutManager.roundToApproximateTime(8*60*60 + 38*60) == 9*60*60);
+      assert(TimeoutManager.roundToApproximateTime(42*60*60 + 12*60) == 42*60*60);
+    });
+    it('rounds these values to the nearest day', function() {
+      assert(TimeoutManager.roundToApproximateTime(5*24*60*60 + 8*60*60 + 2) == 5*24*60*60);
+    });
+  });
+
+  describe('secondsToString', function() {
+    it('converts zero and negative to empy string', function() {
+      assert(TimeoutManager.secondsToString(0) == '');
+      assert(TimeoutManager.secondsToString(-1) == '');
+    });
+    it('converts single-unit strings correctly', function() {
+      assert(TimeoutManager.secondsToString(1) == '1s');
+      assert(TimeoutManager.secondsToString(15) == '15s');
+      assert(TimeoutManager.secondsToString(2*60) == '2m');
+      assert(TimeoutManager.secondsToString(4*60*60) == '4h');
+      assert(TimeoutManager.secondsToString(3*24*60*60) == '3d');
+    });
+    it('converts multi-unit strings correctly', function() {
+      assert(TimeoutManager.secondsToString(60 + 5) == '1m 5s');
+      assert(TimeoutManager.secondsToString(1*60*60 + 30) == '1h 30s');
+      assert(TimeoutManager.secondsToString(3*60*60 + 10*60 + 25) == '3h 10m 25s');
+      assert(TimeoutManager.secondsToString(5*24*60*60 + 4*60*60 + 7*60) == '5d 4h 7m');
+    });
+  });
+
+});

--- a/sources/web/datalab/polymer/test/timeout-panel-test.html
+++ b/sources/web/datalab/polymer/test/timeout-panel-test.html
@@ -19,17 +19,20 @@ the License.
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
+
+    <script src="../modules/ApiManager.js"></script>
+
+    <link rel="import" href="../components/timeout-panel/timeout-panel.html">
   </head>
   <body>
-    <script>
-      // Load and run all tests (.html, .js). Keep element tests in HTML files so we
-      // can use fixtures, and keep all other tests in javascript files
-      WCT.loadSuites([
-        'item-list-test.html',
-        'table-preview-test.html',
-        'timeout-panel-test.html',
-        'toolbar-test.html',
-      ]);
-    </script>
+
+    <test-fixture id="timeout-panel-fixture">
+      <template>
+        <timeout-panel></timeout-panel>
+      </template>
+    </test-fixture>
+
+    <script src="timeout-panel-test.js"></script>
+
   </body>
 </html>

--- a/sources/web/datalab/polymer/test/timeout-panel-test.ts
+++ b/sources/web/datalab/polymer/test/timeout-panel-test.ts
@@ -27,11 +27,20 @@ declare function fixture(element: string): any;
 describe('<timeout-panel>', () => {
   let testFixture: TimeoutPanel;
 
+  const mockDateNow = 1501799255586;
+  const mockIdleTimeoutSeconds = 900; // 15 minutes
+  const mockSecondsRemaining = 590;   // Just under ten minutes
   const mockTimeoutInfo: common.TimeoutInfo = {
     enabled: true,
-    expirationTime: Date.now() + 55 * 1000,
-    idleTimeoutSeconds: 90,
-    secondsRemaining: 55,
+    expirationTime: mockDateNow + mockSecondsRemaining * 1000,
+    idleTimeoutSeconds: mockIdleTimeoutSeconds,
+    secondsRemaining: mockSecondsRemaining,
+  };
+  const mockTimeoutDisabledInfo: common.TimeoutInfo = {
+    enabled: false,
+    expirationTime: mockDateNow + mockIdleTimeoutSeconds * 1000,
+    idleTimeoutSeconds: mockIdleTimeoutSeconds,
+    secondsRemaining: mockIdleTimeoutSeconds,
   };
 
   beforeEach(() => {
@@ -43,7 +52,7 @@ describe('<timeout-panel>', () => {
     assert(testFixture.$.timeoutControls.hidden, 'timeoutControls should be hidden');
   });
 
-  it('shows one icon when opened', (done: () => void) => {
+  it('shows the enabled icon when opened', (done: () => void) => {
     TimeoutManager.getTimeout = () => {
       return Promise.resolve(mockTimeoutInfo);
     };
@@ -55,4 +64,65 @@ describe('<timeout-panel>', () => {
     });
   });
 
+  it('shows the disabled icon after being disabled', (done: () => void) => {
+    let timeoutEnabled = true;
+    TimeoutManager.getTimeout = () => {
+      const timeoutInfo = timeoutEnabled? mockTimeoutInfo : mockTimeoutDisabledInfo;
+      return Promise.resolve(timeoutInfo);
+    };
+    TimeoutManager.setTimeoutEnabled = (enabled: boolean) => {
+      timeoutEnabled = enabled;
+      return Promise.resolve('OK');
+    };
+    testFixture.onOpenChange(true).then(() => {
+      const enabledIcon = testFixture.$.timeoutControls.querySelector('#timeoutEnabledIcon') as HTMLElement;
+      enabledIcon.click(); // disable the timer
+    });
+    // Clicking the button execute two sequential async calls. The following timeout
+    // ensures that our mock executions complete before the rest of the code executes.
+    window.setTimeout(() => {
+      assert(testFixture.$.timeoutEnabledIcon.hidden, 'timeoutEnabledIcon should be hidden');
+      assert(!testFixture.$.timeoutDisabledIcon.hidden, 'timeoutDisabledIcon should be showing');
+      done();
+    }, 1);
+  });
+
+  it('shows "disabled" text when disabled', (done: () => void) => {
+    let timeoutEnabled = true;
+    TimeoutManager.getTimeout = () => {
+      const timeoutInfo = timeoutEnabled? mockTimeoutInfo : mockTimeoutDisabledInfo;
+      return Promise.resolve(timeoutInfo);
+    };
+    TimeoutManager.setTimeoutEnabled = (enabled: boolean) => {
+      timeoutEnabled = enabled;
+      return Promise.resolve('OK');
+    };
+    Date.now = () => {
+      return mockDateNow;
+    }
+    testFixture.onOpenChange(true).then(() => {
+      const enabledIcon = testFixture.$.timeoutControls.querySelector('#timeoutEnabledIcon') as HTMLElement;
+      enabledIcon.click(); // disable the timer
+    });
+    // Clicking the button execute two sequential async calls. The following timeout
+    // ensures that our mock executions complete before the rest of the code executes.
+    window.setTimeout(() => {
+      assert(testFixture.$.timeoutText.innerHTML === 'Idle timeout is disabled', 'Timeout line should show disabled');
+      done();
+    });
+  });
+
+  it('shows time remaining text when enabled', (done: () => void) => {
+    TimeoutManager.getTimeout = () => {
+      return Promise.resolve(mockTimeoutInfo);
+    };
+    Date.now = () => {
+      return mockDateNow;
+    }
+    testFixture.onOpenChange(true).then(() => {
+      Polymer.dom.flush();
+      assert(testFixture.$.timeoutText.innerHTML === 'Idle timeout in about 10m', 'Timeout line should show info');
+      done();
+    });
+  });
 });

--- a/sources/web/datalab/polymer/test/timeout-panel-test.ts
+++ b/sources/web/datalab/polymer/test/timeout-panel-test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+declare function assert(condition: boolean, message: string): null;
+declare function fixture(element: string): any;
+
+/// <reference path="../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../node_modules/@types/chai/index.d.ts" />
+/// <reference path="../components/timeout-panel/timeout-panel.ts" />
+
+/*
+ * For all Polymer component testing, be sure to call Polymer's flush() after
+ * any code that will cause shadow dom redistribution.
+ */
+
+describe('<timeout-panel>', () => {
+  let testFixture: TimeoutPanel;
+
+  const mockTimeoutInfo: common.TimeoutInfo = {
+    enabled: true,
+    expirationTime: Date.now() + 55 * 1000,
+    idleTimeoutSeconds: 90,
+    secondsRemaining: 55,
+  };
+
+  beforeEach(() => {
+    testFixture = fixture('timeout-panel-fixture');
+    Polymer.dom.flush();
+  });
+
+  it('starts with controls not displayed', () => {
+    assert(testFixture.$.timeoutControls.hidden, 'timeoutControls should be hidden');
+  });
+
+  it('shows one icon when opened', (done: () => void) => {
+    TimeoutManager.getTimeout = () => {
+      return Promise.resolve(mockTimeoutInfo);
+    };
+    testFixture.onOpenChange(true).then(() => {
+      Polymer.dom.flush();
+      assert(!testFixture.$.timeoutEnabledIcon.hidden, 'timeoutEnabledIcon should be showing');
+      assert(testFixture.$.timeoutDisabledIcon.hidden, 'timeoutDisabledIcon should be hidden');
+      done();
+    });
+  });
+
+});

--- a/third_party/externs/ts/polymer/polymer.d.ts
+++ b/third_party/externs/ts/polymer/polymer.d.ts
@@ -108,6 +108,7 @@ declare module Polymer {
     attached(): void;
     detached(): void;
     connectedCallback(): void;
+    disconnectedCallback(): void;
     attributeChanged?(attrName: string, oldVal: any, newVal: any): void;
     prototype?: Object;
   }


### PR DESCRIPTION
This PR adds the timeout info display to the account menu in the Polymer UI. As in the old UI, clicking on the timer icon toggles whether the idle timeout is enabled. The timeout line is not displayed if the timeout has been disabled by setting the value to 0.

The value displayed in the timeout line counts down as the time until shutdown runs out, but the Polymer code currently is pretty aggressive about requesting info, such as asking for the list of sessions every minute, so in practice the timer will not count down until we fix that issue and make our code not ask for that kind of information when the corresponding tab is not visible.

Display when enabled:
![idle-timeout-enabled](https://user-images.githubusercontent.com/116825/28899639-12fc155c-77a1-11e7-89d4-82359ecf7444.png)

Display when disabled by clicking on the timer icon:
![idle-timeout-disabled](https://user-images.githubusercontent.com/116825/28899647-227eafbc-77a1-11e7-8935-01a24d4c16e3.png)

