### PR TITLE
[Data First] Use UTC to convert date

### DIFF
--- a/sources/web/datalab/polymer/components/table-preview/table-preview.ts
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.ts
@@ -93,7 +93,7 @@ class TablePreviewElement extends Polymer.Element {
 
   _computeCreationTime(table: gapi.client.bigquery.Table | null) {
     if (table) {
-      return new Date(parseInt(table.creationTime, 10)).toLocaleString();
+      return new Date(parseInt(table.creationTime, 10)).toUTCString();
     } else {
       return '';
     }
@@ -101,7 +101,7 @@ class TablePreviewElement extends Polymer.Element {
 
   _computeLastModifiedTime(table: gapi.client.bigquery.Table | null) {
     if (table) {
-      return new Date(parseInt(table.lastModifiedTime, 10)).toLocaleString();
+      return new Date(parseInt(table.lastModifiedTime, 10)).toUTCString();
     } else {
       return '';
     }

--- a/sources/web/datalab/polymer/test/table-preview-test.ts
+++ b/sources/web/datalab/polymer/test/table-preview-test.ts
@@ -106,9 +106,9 @@ describe('<table-preview>', () => {
           'should see readable long term table size');
       assert(testFixture.$.numRows.innerText === '1,234,567,890',
           'should see comma-separated number of rows');
-      assert(testFixture.$.creationTime.innerText === '7/31/2017, 3:47:51 PM',
+      assert(testFixture.$.creationTime.innerText === 'Mon, 31 Jul 2017 22:47:51 GMT',
           'should parse timestamp into readable text');
-      assert(testFixture.$.lastModifiedTime.innerText === '8/1/2017, 10:19:54 AM',
+      assert(testFixture.$.lastModifiedTime.innerText === 'Tue, 01 Aug 2017 17:19:54 GMT',
           'should parse timestamp into readable text');
       assert(testFixture.$.location.innerText === mockTable.location, 'should see location');
 


### PR DESCRIPTION
To reduce the confusion if the data was created in a different time zone than the client.