### PR TITLE
[Polymer UI] Fix <datalab-toolbar> tests, run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,7 @@ script:
 - npm install -s -q --depth 0
 - npm test
 - for i in `ls ui/broken/`; do echo ui/broken/$i; base64 ui/broken/$i; echo \"-----\"; done
+- cd ../sources/web/datalab/polymer/test
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
+- npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,4 @@ script:
 - for i in `ls ui/broken/`; do echo ui/broken/$i; base64 ui/broken/$i; echo \"-----\"; done
 - cd ../sources/web/datalab/polymer/test
 - export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 - npm test

--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.html
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.html
@@ -15,7 +15,6 @@ the License.
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 <link rel="import" href="../../components/item-list/item-list.html">
 
-<link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../bower_components/paper-progress/paper-progress.html">

--- a/sources/web/datalab/polymer/test/toolbar-test.html
+++ b/sources/web/datalab/polymer/test/toolbar-test.html
@@ -32,46 +32,7 @@ the License.
       </template>
     </test-fixture>
 
-    <script>
-      suite('<datalab-toolbar>', function() {
-        var testToolbar;
-        setup(function() {
-          testToolbar = fixture('toolbar-fixture');
-        });
-        test('opens and closes account menu', function() {
-          testToolbar.$.accountButton.click();
-          assert.isTrue(testToolbar.$.accountDropdown.opened);
-
-          // Click the account button again to make sure it also closes the dropdown.
-          testToolbar.$.accountButton.click();
-          assert.isFalse(testToolbar.$.accountDropdown.opened);
-        });
-        test('opens and closes info dialog', function(done) {
-          testToolbar.$.infoButton.click();
-          assert.isTrue(testToolbar.$.infoDialog.opened);
-
-          // Click the info button again to make sure it also closes the dialog.
-          // Dialogs use animations, so give it a small wait
-          setTimeout(() => {
-            testToolbar.$.infoButton.click();
-            assert.isFalse(testToolbar.$.infoDialog.opened);
-            done();
-          }, 10);
-        });
-        test('opens and closes settings dialog', function(done) {
-          testToolbar.$.settingsButton.click();
-          assert.isTrue(testToolbar.$.settingsDialog.opened);
-
-          // Click the settings button again to make sure it also closes the dialog.
-          // Dialogs use animations, so give it a small wait
-          setTimeout(() => {
-            testToolbar.$.settingsButton.click();
-            assert.isFalse(testToolbar.$.settingsDialog.opened);
-            done();
-          }, 10);
-        });
-      });
-    </script>
+    <script src="toolbar-test.js"></script>
 
   </body>
 </html>

--- a/sources/web/datalab/polymer/test/toolbar-test.ts
+++ b/sources/web/datalab/polymer/test/toolbar-test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+declare function assert(condition: boolean, message: string): null;
+declare function fixture(element: string): any;
+
+/// <reference path="../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../node_modules/@types/chai/index.d.ts" />
+/// <reference path="../components/table-preview/table-preview.ts" />
+/// <reference path="../../../../../third_party/externs/ts/gapi/gapi.d.ts" />
+
+/*
+ * For all Polymer component testing, be sure to call Polymer's flush() after
+ * any code that will cause shadow dom redistribution, such as observed array
+ * mutation, wich is used by the dom-repeater in this case.
+ */
+
+describe('<table-preview>', () => {
+  let testFixture: ToolbarElement;
+
+  beforeEach(() => {
+    GapiManager.listenForSignInChanges = () => Promise.resolve();
+    ApiManager.getBasePath = () => {
+      return Promise.resolve('testbase');
+    };
+
+    testFixture = fixture('toolbar-fixture');
+  });
+
+  it('opens and closes account menu', () => {
+    testFixture.$.accountButton.click();
+    assert(testFixture.$.accountDropdown.opened, 'account dropdown should open on click');
+
+    // Click the account button again to make sure it also closes the dropdown.
+    testFixture.$.accountButton.click();
+    assert(!testFixture.$.accountDropdown.opened, 'account dropdown should close on click');
+  });
+
+  it('opens and closes info dialog', (done) => {
+    let hasOpened = false;
+
+    testFixture.$.infoDialog.addEventListener('iron-overlay-closed', () => {
+      assert(hasOpened, 'dialog should have opened on first click');
+      done();
+    });
+
+    testFixture.$.infoDialog.addEventListener('iron-overlay-opened', () => {
+      hasOpened = true;
+      testFixture.$.infoButton.click();
+    });
+
+    testFixture.$.infoButton.click();
+  });
+
+  it('opens and closes settings dialog', (done) => {
+    let hasOpened = false;
+
+    testFixture.$.settingsDialog.addEventListener('iron-overlay-closed', () => {
+      assert(hasOpened, 'dialog should have opened on first click');
+      done();
+    });
+
+    testFixture.$.settingsDialog.addEventListener('iron-overlay-opened', () => {
+      hasOpened = true;
+      testFixture.$.settingsButton.click();
+    });
+
+    testFixture.$.settingsButton.click();
+  });
+});


### PR DESCRIPTION
This PR does the following:
- Fix <datalab-toolbar> tests, which were spitting out long messages because of the `ApiManager.getBasePath()` call, which was returning an HTML file because there is no server to handle it.
- Separate out these tests into their own file, and rewrite them to use events instead of timeouts so they're more reliable.
- Run the Polymer UI element tests on Travis.