### PR TITLE
[Polymer UI] Divider element, use in Data First page

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -19,6 +19,7 @@ the License.
 <link rel="import" href="../../components/datalab-notification/datalab-notification.html">
 <link rel="import" href="../../components/datalab-sidebar/datalab-sidebar.html">
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
+<link rel="import" href="../../components/resizable-divider/resizable-divider.html">
 
 <dom-module id="datalab-app">
   <template>
@@ -68,13 +69,14 @@ the License.
           <datalab-sidebar page={{page}}></datalab-sidebar>
         </div>
         <div class="datalab-main-content">
-          <iron-pages id="pages" selected="{{page}}" attr-for-selected="name"
+          <!--<iron-pages id="pages" selected="{{page}}" attr-for-selected="name"
                       fallback-selection="files">
             <datalab-data name="data"></datalab-data>
             <datalab-files name="files"></datalab-files>
             <datalab-sessions name="sessions"></datalab-sessions>
             <datalab-terminal name="terminal"></datalab-terminal>
-          </iron-pages>
+          </iron-pages>-->
+          <resizable-divider></resizable-divider>
         </div>
       </div>
     </div>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -69,14 +69,13 @@ the License.
           <datalab-sidebar page={{page}}></datalab-sidebar>
         </div>
         <div class="datalab-main-content">
-          <!--<iron-pages id="pages" selected="{{page}}" attr-for-selected="name"
+          <iron-pages id="pages" selected="{{page}}" attr-for-selected="name"
                       fallback-selection="files">
             <datalab-data name="data"></datalab-data>
             <datalab-files name="files"></datalab-files>
             <datalab-sessions name="sessions"></datalab-sessions>
             <datalab-terminal name="terminal"></datalab-terminal>
-          </iron-pages>-->
-          <resizable-divider></resizable-divider>
+          </iron-pages>
         </div>
       </div>
     </div>

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -87,7 +87,7 @@ the License.
 
     <div id="data-container">
 
-      <resizable-divider init-divider-position="70" minimum-width-px="200">
+      <resizable-divider initial-divider-position="70" minimum-width-px="200">
 
         <div class="resultsColumn" slot="left">
           <!-- Input box to enter search terms -->

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -35,6 +35,10 @@ the License.
         font-size: var(--app-content-font-size);
         color: var(--primary-fg-color);
       }
+      resizable-divider {
+        width: 100%;
+        height: 100%;
+      }
       #data-container {
         display: flex;
         height: 100%;
@@ -82,25 +86,34 @@ the License.
     </style>
 
     <div id="data-container">
-      <div class="resultsColumn">
-        <!-- Input box to enter search terms -->
-        <div id="search-div">
-          <iron-a11y-keys id="searchKeys" keys="enter" on-keys-pressed="_search"></iron-a11y-keys>
-          <iron-icon icon="search" id="search-icon"></iron-icon>
-          <input id="searchBox" placeholder="Search for data, then press Enter"
-                 value="{{_searchValue::input}}"></input>
+
+      <resizable-divider init-divider-position="70" minimum-width-px="200">
+
+        <div class="resultsColumn" slot="left">
+          <!-- Input box to enter search terms -->
+          <div id="search-div">
+            <!-- TODO - could use value-changed event on paper-input to call _search
+                on every keystroke, with a delay so it fires only after the user has stopped
+                typing for a moment. -->
+            <iron-a11y-keys id="searchKeys" keys="enter" on-keys-pressed="_search"></iron-a11y-keys>
+            <paper-input id="searchBox" label="Search for data" spellcheck=false autofocus
+                                        value="{{_searchValue}}" no-label-float>
+            <iron-icon icon="search" slot="prefix" on-click="_search"></iron-icon>
+            </paper-input>
+          </div>
+
+          <!-- List of results -->
+          <div class='results-container'>
+            <item-list id="results"></item-list>
+          </div>
         </div>
 
-        <!-- List of results -->
-        <div class='results-container'>
-          <item-list id="results"></item-list>
+        <!-- Preview pane -->
+        <div id="previewPane" slot="right">
+          <table-preview id="preview"></table-preview>
         </div>
-      </div>
 
-      <!-- Details pane -->
-      <div id="previewPane">
-        <table-preview id="preview"></table-preview>
-      </div>
+      </resizable-divider>
 
     </div>
 

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -58,7 +58,8 @@ the License.
         color: var(--primary-fg-color);
       }
       #searchBox {
-        border: 1px solid #ccc;
+        border: 1px solid var(--border-color);
+        background-color: var(--primary-bg-color);
         border-radius: 2px;
         height: 25px;
         width: 70%;

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -92,14 +92,10 @@ the License.
         <div class="resultsColumn" slot="left">
           <!-- Input box to enter search terms -->
           <div id="search-div">
-            <!-- TODO - could use value-changed event on paper-input to call _search
-                on every keystroke, with a delay so it fires only after the user has stopped
-                typing for a moment. -->
             <iron-a11y-keys id="searchKeys" keys="enter" on-keys-pressed="_search"></iron-a11y-keys>
-            <paper-input id="searchBox" label="Search for data" spellcheck=false autofocus
-                                        value="{{_searchValue}}" no-label-float>
-            <iron-icon icon="search" slot="prefix" on-click="_search"></iron-icon>
-            </paper-input>
+            <iron-icon icon="search" id="search-icon"></iron-icon>
+            <input id="searchBox" placeholder="Search for data, then press Enter"
+                 value="{{_searchValue::input}}"></input>
           </div>
 
           <!-- List of results -->

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -44,7 +44,7 @@ the License.
         height: 100%;
       }
       .resultsColumn {
-        margin: 15px;
+        padding: 15px;
         flex-grow: 1;
       }
       #search-div {
@@ -81,7 +81,6 @@ the License.
       #previewPane {
         background-color: var(--secondary-bg-color);
         box-shadow: inset 4px 0px 10px -3px rgba(0, 0, 0, 0.1);
-        width: var(--preview-pane-width);
       }
     </style>
 
@@ -95,9 +94,8 @@ the License.
             <iron-a11y-keys id="searchKeys" keys="enter" on-keys-pressed="_search"></iron-a11y-keys>
             <iron-icon icon="search" id="search-icon"></iron-icon>
             <input id="searchBox" placeholder="Search for data, then press Enter"
-                 value="{{_searchValue::input}}"></input>
+                value="{{_searchValue::input}}">
           </div>
-
           <!-- List of results -->
           <div class='results-container'>
             <item-list id="results"></item-list>

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -47,6 +47,7 @@ the License.
       app-header {
         background-color: var(--primary-accent-color);
         color: var(--toolbar-fg-color);
+        z-index: 1;
       }
       app-toolbar {
         display: flex;

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -12,6 +12,8 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+
 <dom-module id="resizable-divider">
   <template>
 
@@ -30,15 +32,18 @@ the License.
         width: 50%;
         user-select: none;
       }
-      /*
+      /**
        * Slotted elements should fill the content slots, and be border-boxed so
-       * they can add padding
+       * they can add padding.
        */
       ::slotted(*) {
         width: 100%;
         height: 100%;
         box-sizing: border-box;
       }
+      /**
+      * Consider applying a style rule that can be passed to this element.
+      */
       #divider {
         cursor: col-resize;
         user-select: none;

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -17,27 +17,30 @@ the License.
 
     <style include="datalab-shared-styles">
       :host {
-        --divider-width: 4px;
+        --divider-width: 5px;
       }
       #container {
         height: 100%;
         width: 100%;
         display: flex;
+        position: relative;
       }
-      .pane, #divider {
+      .pane {
         overflow: auto;
-        width: calc(50% - var(--divider-width));
+        width: 50%;
         user-select: none;
       }
       #divider {
         cursor: col-resize;
-        width: calc(2 * var(--divider-width));
         user-select: none;
-        box-shadow: inset 0px 0px 5px 1px #ccc;
-        z-index: 1;
+        position: absolute;
+        top: 0px;
+        bottom: 0px;
+        left: calc(50% - var(--divider-width));
+        right: calc(50% + var(--divider-width));
+        width: calc(2 * var(--divider-width));
       }
       #divider.active {
-        box-shadow: inset 0px 0px 5px 2px #ccc;
         user-select: none;
       }
     </style>

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -25,7 +25,7 @@ the License.
         display: flex;
       }
       .pane, #divider {
-        overflow: hidden;
+        overflow: auto;
         width: calc(50% - var(--divider-width));
         user-select: none;
       }
@@ -45,13 +45,13 @@ the License.
     <div id="container">
 
       <div id="p1" class="pane">
-        Pane1
+        <slot name="left"></slot>
       </div>
 
       <div id="divider" on-mousedown="{{_mouseDownHandler}}"></div>
 
       <div id="p2" class="pane">
-        Pane2
+        <slot name="right"></slot>
       </div>
 
     </div>

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -30,6 +30,10 @@ the License.
         width: 50%;
         user-select: none;
       }
+      /*
+       * Slotted elements should fill the content slots, and be border-boxed so
+       * they can add padding
+       */
       ::slotted(*) {
         width: 100%;
         height: 100%;
@@ -47,6 +51,7 @@ the License.
       }
       #divider.active {
         user-select: none;
+        background-color: var(--selection-bg-color);
       }
     </style>
 

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -1,0 +1,62 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<dom-module id="resizable-divider">
+  <template>
+
+    <style include="datalab-shared-styles">
+      :host {
+        --divider-width: 4px;
+      }
+      #container {
+        height: 100%;
+        width: 100%;
+        display: flex;
+      }
+      .pane, #divider {
+        overflow: hidden;
+        width: calc(50% - var(--divider-width));
+        user-select: none;
+      }
+      #divider {
+        cursor: col-resize;
+        width: calc(2 * var(--divider-width));
+        user-select: none;
+        box-shadow: inset 0px 0px 5px 1px #ccc;
+        z-index: 1;
+      }
+      #divider.active {
+        box-shadow: inset 0px 0px 5px 2px #ccc;
+        user-select: none;
+      }
+    </style>
+
+    <div id="container">
+
+      <div id="p1" class="pane">
+        Pane1
+      </div>
+
+      <div id="divider" on-mousedown="{{_mouseDownHandler}}"></div>
+
+      <div id="p2" class="pane">
+        Pane2
+      </div>
+
+    </div>
+
+  </template>
+</dom-module>
+
+<script src="resizable-divider.js"></script>

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -19,7 +19,7 @@ the License.
 
     <style include="datalab-shared-styles">
       :host {
-        --divider-width: 5px;
+        --divider-half-width: 5px;
       }
       #container {
         height: 100%;
@@ -50,9 +50,9 @@ the License.
         position: absolute;
         top: 0px;
         bottom: 0px;
-        left: calc(50% - var(--divider-width));
-        right: calc(50% + var(--divider-width));
-        width: calc(2 * var(--divider-width));
+        left: calc(50% - var(--divider-half-width));
+        right: calc(50% + var(--divider-half-width));
+        width: calc(2 * var(--divider-half-width));
       }
       #divider.active {
         user-select: none;

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -62,13 +62,13 @@ the License.
 
     <div id="container">
 
-      <div id="p1" class="pane">
+      <div id="leftPane" class="pane">
         <slot name="left"></slot>
       </div>
 
       <div id="divider" on-mousedown="{{_mouseDownHandler}}"></div>
 
-      <div id="p2" class="pane">
+      <div id="rightPane" class="pane">
         <slot name="right"></slot>
       </div>
 

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -30,6 +30,11 @@ the License.
         width: 50%;
         user-select: none;
       }
+      ::slotted(*) {
+        width: 100%;
+        height: 100%;
+        box-sizing: border-box;
+      }
       #divider {
         cursor: col-resize;
         user-select: none;

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
@@ -91,22 +91,22 @@ class ResizableDividerElement extends Polymer.Element {
   _resizePanes(newPos: number) {
     const container = this.$.container as HTMLDivElement;
     const divider = this.$.divider as HTMLDivElement;
-    const p1 = this.$.p1 as HTMLDivElement;
-    const p2 = this.$.p2 as HTMLDivElement;
+    const leftPane = this.$.leftPane as HTMLDivElement;
+    const rightPane = this.$.rightPane as HTMLDivElement;
 
     const containerRect = container.getBoundingClientRect();
 
-    const newP1Width = newPos - containerRect.left;
-    const newP2Width = containerRect.right - newPos;
+    const newLeftPaneWidth = newPos - containerRect.left;
+    const newRightPaneWidth = containerRect.right - newPos;
 
     // Stop if either pane is getting too small
-    if (newP1Width < this.minimumWidthPx || newP2Width < this.minimumWidthPx) {
+    if (newLeftPaneWidth < this.minimumWidthPx || newRightPaneWidth < this.minimumWidthPx) {
       return;
     }
 
-    p1.style.width = newP1Width / containerRect.width * 100 + '%';
-    p2.style.width = newP2Width / containerRect.width * 100 + '%';
-    divider.style.left = p1.style.width;
+    leftPane.style.width = newLeftPaneWidth / containerRect.width * 100 + '%';
+    rightPane.style.width = newRightPaneWidth / containerRect.width * 100 + '%';
+    divider.style.left = leftPane.style.width;
   }
 
 }

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Resizable divider element for Datalab.
+ * This element is a container for two elements with a vertical resize divider.
+ */
+class ResizableDividerElement extends Polymer.Element {
+
+  /**
+   * Minimum pane width in pixels.
+   */
+  public minimumWidthPx: number;
+
+  private _boundMouseDownHandler: EventListenerOrEventListenerObject;
+  private _boundMouseupHandler: EventListenerOrEventListenerObject;
+  private _boundMouseMoveHandler: EventListenerOrEventListenerObject;
+  private _dividerWidth = 4; // This matches the css variable --divider-width
+
+  static get is() { return 'resizable-divider'; }
+
+  static get properties() {
+    return {
+      minimumWidthPx: {
+        type: Number,
+        value: 50,
+      },
+    };
+  }
+
+  ready() {
+    super.ready();
+
+    this._boundMouseDownHandler = this._mouseDownHandler.bind(this);
+    this._boundMouseupHandler = this._mouseUpHandler.bind(this);
+    this._boundMouseMoveHandler = this._resizePanes.bind(this);
+
+    this.$.divider.addEventListener('mousedown', this._boundMouseDownHandler);
+  }
+
+  _mouseDownHandler(event: MouseEvent) {
+    document.addEventListener('mousemove', this._boundMouseMoveHandler, true);
+    document.addEventListener('mouseup', this._boundMouseupHandler, true);
+
+    // style the handle while dragging
+    this.$.divider.classList.add('active');
+
+    // (stop panes from receiving mouse events and inteferring with the drag
+    // works great for the iframe, not for CodeMirror
+    this.$.p1.style.pointerEvents = 'none';
+    this.$.p2.style.pointerEvents = 'none';
+
+    // resize the pane and a neighour
+    this._resizePanes(event);
+  }
+
+  _mouseUpHandler() {
+    document.removeEventListener('mouseup', this._boundMouseupHandler, true);
+    document.removeEventListener('mousemove', this._boundMouseMoveHandler, true);
+
+    // stop styling the handle as active because dragging is done
+    this.$.divider.classList.remove('active');
+
+    // let the panes have mouse events again
+    this.$.p1.style.pointerEvents = 'initial';
+    this.$.p2.style.pointerEvents = 'initial';
+  }
+
+  /**
+   * Resize 2 panes on either side of the handle
+   */
+  _resizePanes(event: MouseEvent) {
+    const container = this.$.container as HTMLDivElement;
+    const p1 = this.$.p1 as HTMLDivElement;
+    const p2 = this.$.p2 as HTMLDivElement;
+    const containerRect = container.getBoundingClientRect();
+
+    const newP1Width = event.clientX - containerRect.left - this._dividerWidth;
+    const newP2Width = containerRect.right - event.clientX - this._dividerWidth;
+
+    // Stop if either pane is getting too small
+    if (newP1Width < this.minimumWidthPx || newP2Width < this.minimumWidthPx) {
+      return;
+    }
+
+    p1.style.width = newP1Width / containerRect.width * 100 + '%';
+    p2.style.width = newP2Width / containerRect.width * 100 + '%';
+  }
+
+}
+
+customElements.define(ResizableDividerElement.is, ResizableDividerElement);

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
@@ -26,7 +26,7 @@ class ResizableDividerElement extends Polymer.Element {
   /**
    * Initial position of the divider in percentage. Defaults to 50(%);
    */
-  public initDividerPosition: number;
+  public initialDividerPosition: number;
 
   private _boundMouseDownHandler: EventListenerOrEventListenerObject;
   private _boundMouseupHandler: EventListenerOrEventListenerObject;
@@ -35,7 +35,7 @@ class ResizableDividerElement extends Polymer.Element {
 
   static get properties() {
     return {
-      initDividerPosition: {
+      initialDividerPosition: {
         type: Number,
         value: 50,
       },
@@ -61,7 +61,7 @@ class ResizableDividerElement extends Polymer.Element {
     // Initialize the divider position. We need to calculate this initial
     // position relative to the container element.
     const containerRect = container.getBoundingClientRect();
-    const pos = containerRect.left + (containerRect.width * this.initDividerPosition / 100);
+    const pos = containerRect.left + (containerRect.width * this.initialDividerPosition / 100);
     this._resizePanes(pos);
   }
 

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
@@ -31,8 +31,6 @@ class ResizableDividerElement extends Polymer.Element {
   private _boundMouseDownHandler: EventListenerOrEventListenerObject;
   private _boundMouseupHandler: EventListenerOrEventListenerObject;
   private _boundMouseMoveHandler: EventListenerOrEventListenerObject;
-  private _dividerWidth = 4; // This matches the css variable --divider-width
-
   static get is() { return 'resizable-divider'; }
 
   static get properties() {
@@ -92,12 +90,14 @@ class ResizableDividerElement extends Polymer.Element {
    */
   _resizePanes(newPos: number) {
     const container = this.$.container as HTMLDivElement;
+    const divider = this.$.divider as HTMLDivElement;
     const p1 = this.$.p1 as HTMLDivElement;
     const p2 = this.$.p2 as HTMLDivElement;
+
     const containerRect = container.getBoundingClientRect();
 
-    const newP1Width = newPos - containerRect.left - this._dividerWidth;
-    const newP2Width = containerRect.right - newPos - this._dividerWidth;
+    const newP1Width = newPos - containerRect.left;
+    const newP2Width = containerRect.right - newPos;
 
     // Stop if either pane is getting too small
     if (newP1Width < this.minimumWidthPx || newP2Width < this.minimumWidthPx) {
@@ -106,6 +106,7 @@ class ResizableDividerElement extends Polymer.Element {
 
     p1.style.width = newP1Width / containerRect.width * 100 + '%';
     p2.style.width = newP2Width / containerRect.width * 100 + '%';
+    divider.style.left = p1.style.width;
   }
 
 }

--- a/sources/web/datalab/polymer/test/index.html
+++ b/sources/web/datalab/polymer/test/index.html
@@ -26,6 +26,7 @@ the License.
       // can use fixtures, and keep all other tests in javascript files
       WCT.loadSuites([
         'item-list-test.html',
+        'resizable-divider-test.html',
         'table-preview-test.html',
         'toolbar-test.html',
       ]);

--- a/sources/web/datalab/polymer/test/resizable-divider-test.html
+++ b/sources/web/datalab/polymer/test/resizable-divider-test.html
@@ -20,20 +20,41 @@ the License.
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
 
-    <script src="../modules/ApiManager.js"></script>
-    <script src="../modules/GapiManager.js"></script>
-
-    <link rel="import" href="../components/table-preview/table-preview.html">
+    <link rel="import" href="../components/resizable-divider/resizable-divider.html">
   </head>
   <body>
 
-    <test-fixture id="table-preview-fixture">
-      <template>
-        <table-preview></table-preview>
-      </template>
-    </test-fixture>
+    <style>
+      #container {
+        height: 800px;
+        width: 400px;
+      }
+      #left-pane, #right-pane {
+        height: 100%;
+        width: 100%;
+      }
+    </style>
 
-    <script src="table-preview-test.js"></script>
+    <div id="container">
+      <test-fixture id="resizable-divider-fixture">
+        <template>
+            <resizable-divider>
+              <div slot="left">
+                <div id="left-pane">
+                  left pane
+                </div>
+              </div>
+              <div slot="right">
+                <div id="right-pane">
+                  right pane
+                </div>
+              </div>
+            </resizable-divider>
+        </template>
+      </test-fixture>
+    </div>
+
+    <script src="resizable-divider-test.js"></script>
 
   </body>
 </html>

--- a/sources/web/datalab/polymer/test/resizable-divider-test.ts
+++ b/sources/web/datalab/polymer/test/resizable-divider-test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+declare function assert(condition: boolean, message: string): null;
+declare function fixture(element: string): any;
+
+/// <reference path="../node_modules/@types/mocha/index.d.ts" />
+/// <reference path="../node_modules/@types/chai/index.d.ts" />
+/// <reference path="../components/resizable-divider/resizable-divider.ts" />
+
+/*
+ * For all Polymer component testing, be sure to call Polymer's flush() after
+ * any code that will cause shadow dom redistribution, such as observed array
+ * mutation, wich is used by the dom-repeater in this case.
+ */
+
+function dragAndDrop(element: HTMLElement, x1: number, y1: number, x2: number, y2: number) {
+  const clickInfo: MouseEventInit = {
+    clientX: x1,
+    clientY: y1,
+  };
+  element.dispatchEvent(new MouseEvent('mousedown', clickInfo));
+
+  const moveInfo: MouseEventInit = {
+    clientX: x2,
+    clientY: y2,
+  };
+  document.dispatchEvent(new MouseEvent('mousemove', moveInfo));
+
+  document.dispatchEvent(new MouseEvent('mouseup'));
+}
+
+describe('<resizable-divider>', () => {
+  let testFixture: ResizableDividerElement;
+  let divider: HTMLDivElement;
+  let left: HTMLDivElement;
+  let right: HTMLDivElement;
+
+  beforeEach(() => {
+    testFixture = fixture('resizable-divider-fixture');
+    divider = testFixture.$.divider;
+    // Have to use querySelector to get the pane's slotted elements because
+    // they're in the inserted element's light DOM
+    left = testFixture.querySelector('#left-pane') as HTMLDivElement;
+    right = testFixture.querySelector('#right-pane') as HTMLDivElement;
+  });
+
+  it('inserts the given elements into panes', () => {
+
+    assert(!!left, 'left pane should exist under the divider element');
+    assert(!!right, 'right pane should exist under the divider element');
+
+    assert(left.innerText === 'left pane', 'left pane\'s contents should appear in first slot');
+    assert(right.innerText === 'right pane', 'right pane\'s contents should appear in second slot');
+  });
+
+  it('shows left pane to the left of the right pane, and divider in between', () => {
+    const offset = testFixture.getBoundingClientRect().left;
+    assert(left.getBoundingClientRect().left === offset, 'left pane should stick to the left');
+    assert(left.getBoundingClientRect().right === offset + 200,
+        'left pane should extend all the way to the middle of the container');
+
+    assert(divider.getBoundingClientRect().left === offset + 200,
+        'divider should start at the middle of the container');
+
+    assert(right.getBoundingClientRect().left === offset + 200,
+        'right pane should start at the middle of the container');
+    assert(right.getBoundingClientRect().left === offset + 200,
+        'right pane stick to the right of the container');
+  });
+
+  it('makes child panes fill height', () => {
+    assert(left.getBoundingClientRect().height === 800, 'left pane should be fill the height');
+    assert(right.getBoundingClientRect().height === 800, 'right pane should be fill the height');
+  });
+
+  it('shows panes with half the element width by default', () => {
+    assert(left.getBoundingClientRect().width === 200, 'left pane should be half the width');
+    assert(right.getBoundingClientRect().width === 200, 'right pane should be half the width');
+  });
+
+  it('resizes panes when divider is dragged', () => {
+    const x = divider.getBoundingClientRect().left;
+    const y = divider.getBoundingClientRect().top;
+    const offset = testFixture.getBoundingClientRect().left;
+
+    dragAndDrop(divider, x, y, x - 100, y + 300);
+
+    assert(left.getBoundingClientRect().width === 100,
+        'left pane should be 100px after resizing');
+    assert(right.getBoundingClientRect().width === 300,
+        'right pane should be 100px after resizing');
+    assert(divider.getBoundingClientRect().left === offset + 100,
+        'divider should move with mouse when resizing');
+  });
+
+});

--- a/sources/web/datalab/polymer/test/resizable-divider-test.ts
+++ b/sources/web/datalab/polymer/test/resizable-divider-test.ts
@@ -61,8 +61,8 @@ describe('<resizable-divider>', () => {
     assert(!!left, 'left pane should exist under the divider element');
     assert(!!right, 'right pane should exist under the divider element');
 
-    assert(left.innerText === 'left pane', 'left pane\'s contents should appear in first slot');
-    assert(right.innerText === 'right pane', 'right pane\'s contents should appear in second slot');
+    assert(left.innerText === 'left pane', 'left pane\'s contents should appear in left slot');
+    assert(right.innerText === 'right pane', 'right pane\'s contents should appear in right slot');
   });
 
   it('shows left pane to the left of the right pane, and divider in between', () => {


### PR DESCRIPTION
This adds a vertical divider element with two panes. This element can be dropped in the document with two child divs with slots "left" and "right", and is customizable to provide the initial split percentage, and the minimum pane size.

The element is not visible by default, but the mouse pointer will change to a resize cursor when the user hovers on it, so it's up to the elements using the divider to distinguish the two panes somehow to make the divider visible if needed, for example by adding a right border to the left pane, or a box-shadow to either pane. While it's being dragged, its background color changes slightly.

Future work for this element could be making the divider customizable.