### PR TITLE
[Polymer UI] Display idle-timeout-update status and errors in settings dialog

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
@@ -55,6 +55,9 @@ the License.
       #idleTimeoutUpdateLabel {
         padding-top: 9px;
       }
+      .update-error--true {
+        color: var(--error-color);
+      }
     </style>
 
     <!--Thin progress bar that shows when busy-->
@@ -83,7 +86,7 @@ the License.
           <br>
           Example values: 90m, 1h 30m, 2d 12h. Set to 0 to disable.
         </paper-tooltip>
-        <label id="idleTimeoutUpdateLabel">{{_idleTimeoutUpdateStatus}}</label>
+        <label id="idleTimeoutUpdateLabel" class$="update-error--{{_updateError}}">{{_idleTimeoutUpdateStatus}}</label>
       </div>
     </div>
 

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.html
@@ -52,6 +52,9 @@ the License.
           font-size: 13px;
         }
       }
+      #idleTimeoutUpdateLabel {
+        padding-top: 9px;
+      }
     </style>
 
     <!--Thin progress bar that shows when busy-->
@@ -80,6 +83,7 @@ the License.
           <br>
           Example values: 90m, 1h 30m, 2d 12h. Set to 0 to disable.
         </paper-tooltip>
+        <label id="idleTimeoutUpdateLabel">{{_idleTimeoutUpdateStatus}}</label>
       </div>
     </div>
 

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -32,6 +32,7 @@ class SettingsElement extends Polymer.Element {
   public idleTimeoutInterval: string;
 
   private _busy: boolean;
+  private _idleTimeoutUpdateStatus: string;
 
   static get is() { return 'datalab-settings'; }
 
@@ -40,6 +41,10 @@ class SettingsElement extends Polymer.Element {
       _busy: {
         type: Boolean,
         value: false,
+      },
+      _idleTimeoutUpdateStatus: {
+        type: String,
+        value: '',
       },
       idleTimeoutInterval: {
         type: String,
@@ -90,7 +95,8 @@ class SettingsElement extends Polymer.Element {
     // TODO: Show success/error status to user
     this._busy = true;
     return SettingsManager.setUserSettingAsync('idleTimeoutInterval', this.idleTimeoutInterval)
-      .catch((e: Error) => console.log('Error updating idle timeout interval: ', e))
+      .then(() => this._idleTimeoutUpdateStatus = 'Idle timeout updated')
+      .catch((e: Error) => this._idleTimeoutUpdateStatus = 'Update failed: ' + e.message)
       .then(() => this._busy = false);
   }
 

--- a/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
+++ b/sources/web/datalab/polymer/components/datalab-settings/datalab-settings.ts
@@ -33,6 +33,7 @@ class SettingsElement extends Polymer.Element {
 
   private _busy: boolean;
   private _idleTimeoutUpdateStatus: string;
+  private _updateError: boolean;
 
   static get is() { return 'datalab-settings'; }
 
@@ -45,6 +46,10 @@ class SettingsElement extends Polymer.Element {
       _idleTimeoutUpdateStatus: {
         type: String,
         value: '',
+      },
+      _updateError: {
+        type: Boolean,
+        value: false,
       },
       idleTimeoutInterval: {
         type: String,
@@ -69,6 +74,8 @@ class SettingsElement extends Polymer.Element {
    */
   loadSettings() {
     this._busy = true;
+    this._idleTimeoutUpdateStatus = '';
+    this._updateError = false;
     return SettingsManager.getUserSettingsAsync(true /*forceRefresh*/)
       .then((settings: common.UserSettings) => {
         this.theme = settings.theme;
@@ -94,9 +101,14 @@ class SettingsElement extends Polymer.Element {
   _idleTimoutIntervalChanged() {
     // TODO: Show success/error status to user
     this._busy = true;
+    this._idleTimeoutUpdateStatus = '';
+    this._updateError = false;
     return SettingsManager.setUserSettingAsync('idleTimeoutInterval', this.idleTimeoutInterval)
       .then(() => this._idleTimeoutUpdateStatus = 'Idle timeout updated')
-      .catch((e: Error) => this._idleTimeoutUpdateStatus = 'Update failed: ' + e.message)
+      .catch((e: Error) => {
+        this._idleTimeoutUpdateStatus = 'Update failed: ' + e.message;
+        this._updateError = true;
+      })
       .then(() => this._busy = false);
   }
 

--- a/sources/web/datalab/polymer/index.dark.css
+++ b/sources/web/datalab/polymer/index.dark.css
@@ -16,6 +16,7 @@
   --border-color: #333;
   --disabled-bg-color: var(--primary-bg-color);
   --disabled-fg-color: #555;
+  --error-color: #f00;
   --primary-accent-color: #222;
   --primary-bg-color: #222;
   --primary-fg-color: #aaa;

--- a/sources/web/datalab/polymer/index.light.css
+++ b/sources/web/datalab/polymer/index.light.css
@@ -16,6 +16,7 @@
   --border-color: #eee;
   --disabled-bg-color: var(--primary-bg-color);
   --disabled-fg-color: #aaa;
+  --error-color: #f00;
   --primary-accent-color: #424242;
   --primary-bg-color: #fff;
   --primary-fg-color: #444;


### PR DESCRIPTION
This PR implements a TODO to display a success message or an error message when the user presses the Update button in the Settings dialog to update the idle timeout.

Success:
![timeout-update-succeeded](https://user-images.githubusercontent.com/116825/28949768-ce9ea90a-7873-11e7-9993-3b94419eb3cc.png)

Error, light theme:
![timeout-update-failed-light](https://user-images.githubusercontent.com/116825/28981518-f283a756-7906-11e7-8270-f27442b16bca.png)

Error, dark theme:
![timeout-update-failed-dark](https://user-images.githubusercontent.com/116825/28981533-fbb4d1a6-7906-11e7-8a71-93447d6929f2.png)

