### PR TITLE
Drop trivially inferred type annotation.

### DIFF
--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -74,7 +74,7 @@ class ItemListElement extends Polymer.Element {
    */
   public selectedIndices: number[];
 
-  private _lastSelectedIndex: number = -1;
+  private _lastSelectedIndex = -1;
 
   static get is() { return 'item-list'; }
 


### PR DESCRIPTION
This generates a TSLint warning when compiling with recent version of tslint, because they are enforcing the 'no-inferrable-types' check specfied in
https://github.com/googledatalab/datalab/blob/master/sources/web/datalab/polymer/tslint.json#L36.

If this is intentional then the lint check should probably be changed to be a warning.

It would also be good if a local version of tslint was used to avoid these version differences.