### PR TITLE
Only refresh files/sessions if document has focus

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -92,8 +92,6 @@ class DatalabAppElement extends Polymer.Element {
     super.ready();
 
     window.addEventListener('focus', () => this._focusHandler());
-    // TODO: Need to also add a blur event listener that calls the current page's blur
-    // handler, but I cannot get this to work as of now.
   }
 
   /**

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -802,9 +802,10 @@ class FilesElement extends Polymer.Element {
    * Starts auto refreshing the file list, and also triggers an immediate refresh.
    */
   _focusHandler() {
-    // Refresh the file list periodically. Note that we don't rely solely on the
-    // interval to keep the list in sync, the refresh also happens after file
-    // operations, and when the files page gains focus.
+    // Refresh the file list periodically as long as the document is focused.
+    // Note that we don't rely solely on the interval to keep the list in sync,
+    // the refresh also happens after file operations, and when the files page
+    // gains focus.
     if (!this._fileListRefreshIntervalHandle) {
       this._fileListRefreshIntervalHandle = setInterval(() => {
         if (document.hasFocus()) {

--- a/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
+++ b/sources/web/datalab/polymer/components/datalab-files/datalab-files.ts
@@ -806,8 +806,11 @@ class FilesElement extends Polymer.Element {
     // interval to keep the list in sync, the refresh also happens after file
     // operations, and when the files page gains focus.
     if (!this._fileListRefreshIntervalHandle) {
-      this._fileListRefreshIntervalHandle =
-          setInterval(this._fetchFileList.bind(this), this._fileListRefreshInterval);
+      this._fileListRefreshIntervalHandle = setInterval(() => {
+        if (document.hasFocus()) {
+          this._fetchFileList();
+        }
+      }, this._fileListRefreshInterval);
     }
     // Now refresh the list once.
     this._fetchFileList();

--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
@@ -170,8 +170,11 @@ class SessionsElement extends Polymer.Element {
     // change typically when the user opens a notebook, then switches back to
     // the sessions page. Killing a session also triggers a refresh.
     if (!this._sessionListRefreshIntervalHandle) {
-      this._sessionListRefreshIntervalHandle =
-          setInterval(this._fetchSessionList.bind(this), this._sessionListRefreshInterval);
+      this._sessionListRefreshIntervalHandle = setInterval(() => {
+        if (document.hasFocus()) {
+          this._fetchSessionList();
+        }
+      }, this._sessionListRefreshInterval);
     }
     // Now refresh the list once.
     this._fetchSessionList();

--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
@@ -164,11 +164,12 @@ class SessionsElement extends Polymer.Element {
    * Starts auto refreshing the session list, and also triggers an immediate refresh.
    */
   _focusHandler() {
-    // Refresh the session list periodically. Note that we don't rely solely on
-    // the interval to keep the list in sync, the refresh also happens when the
-    // sessions page gains focus, which is more useful since the list will
-    // change typically when the user opens a notebook, then switches back to
-    // the sessions page. Killing a session also triggers a refresh.
+    // Refresh the session list periodically as long as the document has focus.
+    // Note that we don't rely solely on the interval to keep the list in sync,
+    // the refresh also happens when the sessions page gains focus, which is
+    // more useful since the list will change typically when the user opens a
+    // notebook, then switches back to the sessions page. Killing a session also
+    // triggers a refresh.
     if (!this._sessionListRefreshIntervalHandle) {
       this._sessionListRefreshIntervalHandle = setInterval(() => {
         if (document.hasFocus()) {

--- a/sources/web/datalab/polymer/components/timeout-panel/timeout-panel.ts
+++ b/sources/web/datalab/polymer/components/timeout-panel/timeout-panel.ts
@@ -17,9 +17,6 @@
 
 // TODO: look through datalab/static/idle-timeout.js for additional features to port to here.
 
-// TODO: we need to make on-blur work on our tabs so that we stop sending API calls such as
-// /api/sessions when a tab is not visible, as that prevents idle timeout.
-
 /**
  * Idle timeout panel.
  * This element provides a timeout icon and a timeout status string.


### PR DESCRIPTION
This is a workaround to prevent unnecessary file/session refresh calls, since I couldn't get a `blur` event listener to work.