### PR TITLE
[Polymer UI] Display Data tab in sidebar once user has visited the Data page.

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
@@ -83,16 +83,14 @@ the License.
       <div class="button-placeholder"></div>
       <iron-selector class="container" attr-for-selected="id" selected={{page}}
                      class="drawer-list" role="navigation">
-        <div hidden$="{{!_showDataTab}}">
-          <a href="{{_uiroot}}/data" id="data">
-            <paper-button class="sidebar-button">
-              <div class="sidebar-button-container">
-                <iron-icon class="sidebar-button-icon" icon="av:library-books"></iron-icon>
-                <div class="sidebar-button-title">Data</div>
-              </div>
-            </paper-button>
-          </a>
-        </div>
+        <a href="{{_uiroot}}/data" id="data" hidden$="{{!_showDataTab}}">
+          <paper-button class="sidebar-button">
+            <div class="sidebar-button-container">
+              <iron-icon class="sidebar-button-icon" icon="av:library-books"></iron-icon>
+              <div class="sidebar-button-title">Data</div>
+            </div>
+          </paper-button>
+        </a>
         <a href="{{_uiroot}}/files" id="files">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
@@ -80,17 +80,17 @@ the License.
       <div class="sidebar-button"></div>
       <iron-selector class="container" attr-for-selected="id" selected={{page}}
                      class="drawer-list" role="navigation">
-        <!-- uncomment this once we have the data tab working satisfactorily
-        <a href="/data" id="data">
-          <paper-button class="sidebar-button">
-            <div class="sidebar-button-container">
-              <iron-icon class="sidebar-button-icon" icon="av:library-books"></iron-icon>
-              <div class="sidebar-button-title">Data</div>
-            </div>
-          </paper-button>
-        </a>
-        -->
-        <a href="/files" id="files">
+        <div hidden$="{{!_showDataTab}}">
+          <a href="{{_uiroot}}/data" id="data">
+            <paper-button class="sidebar-button">
+              <div class="sidebar-button-container">
+                <iron-icon class="sidebar-button-icon" icon="av:library-books"></iron-icon>
+                <div class="sidebar-button-title">Data</div>
+              </div>
+            </paper-button>
+          </a>
+        </div>
+        <a href="{{_uiroot}}/files" id="files">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="editor:insert-drive-file"></iron-icon>
@@ -98,7 +98,7 @@ the License.
             </div>
           </paper-button>
         </a>
-        <a href="/sessions" id="sessions">
+        <a href="{{_uiroot}}/sessions" id="sessions">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="list"></iron-icon>
@@ -106,7 +106,7 @@ the License.
             </div>
           </paper-button>
         </a>
-        <a href="/terminal" id="terminal">
+        <a href="{{_uiroot}}/terminal" id="terminal">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="av:featured-play-list"></iron-icon>

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
@@ -24,6 +24,7 @@ class SidebarElement extends Polymer.Element {
    */
   public page: string;
 
+  // TODO - remove _showDataTab once the Data tab is ready to be visible
   private _showDataTab = false;
   private _uiroot: string;
 

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
@@ -24,15 +24,37 @@ class SidebarElement extends Polymer.Element {
    */
   public page: string;
 
+  private _showDataTab = false;
+  private _uiroot: string;
+
   static get is() { return 'datalab-sidebar'; }
 
   static get properties() {
     return {
+      _showDataTab: {
+        type: Boolean,
+        value: false,
+      },
+      _uiroot: {
+        type: String,
+        value: '',
+      },
       page: {
         type: String,
         value: 'files',
       },
     };
+  }
+
+  public ready() {
+    super.ready();
+    if (location.pathname.startsWith('/exp/')) {
+      this._uiroot = '/exp';
+    }
+    if (location.pathname.startsWith('/exp/data') ||
+        location.pathname.startsWith('/data')) {
+      this._showDataTab = true;
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds a change such that once the user has visited the Data page by entering the URL for it, the Data tab shows up in the sidebar. It also fixes navigation for sidebar buttons when using the "/exp" mechanism to access the experimental UI pages.