### PR TITLE
Begin implementation of new Data browser, also BigQueryFileManager.

### DIFF
--- a/sources/web/datalab/polymer/components/data-browser/data-browser.html
+++ b/sources/web/datalab/polymer/components/data-browser/data-browser.html
@@ -12,7 +12,20 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
-<link rel="import" href="../bigquery-file-manager/bigquery-file-manager.html">
-<link rel="import" href="../jupyter-file-manager/jupyter-file-manager.html">
+<link rel="import" href="../../components/file-browser/file-browser.html">
 
-<script src="file-manager-factory.js"></script>
+<dom-module id="data-browser">
+  <template>
+    <style include="datalab-shared-styles">
+    </style>
+
+    <div id="data-container">
+
+      <file-browser file-manager-type='bigquery' hide-toolbar></file-browser>
+
+    </div>
+
+  </template>
+</dom-module>
+
+<script src="data-browser.js"></script>

--- a/sources/web/datalab/polymer/components/data-browser/data-browser.ts
+++ b/sources/web/datalab/polymer/components/data-browser/data-browser.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/// <reference path="../input-dialog/input-dialog.ts" />
+/// <reference path="../item-list/item-list.ts" />
+
+/**
+ * Data Browser element for Datalab.
+ */
+class DataBrowserElement extends Polymer.Element {
+
+  static get is() { return 'data-browser'; }
+
+  static get properties() {
+    return {
+    };
+  }
+
+  ready() {
+    super.ready();
+  }
+}
+
+customElements.define(DataBrowserElement.is, DataBrowserElement);

--- a/sources/web/datalab/polymer/components/data-browser/data-browser.ts
+++ b/sources/web/datalab/polymer/components/data-browser/data-browser.ts
@@ -22,14 +22,6 @@ class DataBrowserElement extends Polymer.Element {
 
   static get is() { return 'data-browser'; }
 
-  static get properties() {
-    return {
-    };
-  }
-
-  ready() {
-    super.ready();
-  }
 }
 
 customElements.define(DataBrowserElement.is, DataBrowserElement);

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -75,6 +75,7 @@ the License.
         <div class="datalab-main-content">
           <iron-pages id="pages" selected="{{page}}" attr-for-selected="name"
                       fallback-selection="files">
+            <data-browser class="page" name="data2"></data-browser>
             <datalab-data class="page" name="data"></datalab-data>
             <file-browser class="page" name="files"></file-browser>
             <datalab-sessions class="page" name="sessions"></datalab-sessions>

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
@@ -83,7 +83,7 @@ the License.
       <div class="button-placeholder"></div>
       <iron-selector class="container" attr-for-selected="id" selected={{page}}
                      class="drawer-list" role="navigation">
-        <a href="{{_uiroot}}/data" id="data" hidden$="{{!_showDataTab}}">
+        <a href="{{_uiroot}}/{{_dataTabId}}" id="{{_dataTabId}}" hidden$="{{!_showDataTab}}">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="av:library-books"></iron-icon>

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
@@ -24,6 +24,7 @@ class SidebarElement extends Polymer.Element {
    */
   public page: string;
 
+  private _dataTabId: string;
   // TODO - remove _showDataTab once the Data tab is ready to be visible
   private _showDataTab = false;
   private _uiroot: string;
@@ -32,6 +33,10 @@ class SidebarElement extends Polymer.Element {
 
   static get properties() {
     return {
+      _dataTabId: {
+        type: String,
+        value: 'data',
+      },
       _showDataTab: {
         type: Boolean,
         value: false,
@@ -55,6 +60,10 @@ class SidebarElement extends Polymer.Element {
     if (location.pathname.startsWith('/exp/data') ||
         location.pathname.startsWith('/data')) {
       this._showDataTab = true;
+    }
+    if (location.pathname.startsWith('/exp/data2') ||
+        location.pathname.startsWith('/data2')) {
+      this._dataTabId = 'data2';
     }
   }
 }

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -194,7 +194,7 @@ the License.
       }
     </style>
 
-    <div id="toolbar" hidden$="{{small}}">
+    <div id="toolbar" hidden$="{{small}} || {{hideToolbar}}">
 
       <!--Default Add toolbar, contains Add buttons for notebook, file, and folder-->
       <span id="addToolbar">

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -139,15 +139,8 @@ class FileBrowserElement extends Polymer.Element {
     };
   }
 
-  constructor() {
-    super();
-
-    this._apiManager = ApiManagerFactory.getInstance();
-  }
-
   /**
-   * Called when the element's local DOM is ready and initialized We use it to
-   * initialize element state.
+   * Called when the element's local DOM is ready and initialized.
    */
   async ready() {
     // Must set this to true before calling super.ready(), because the latter will cause
@@ -157,18 +150,16 @@ class FileBrowserElement extends Polymer.Element {
 
     super.ready();
 
+    this._apiManager = ApiManagerFactory.getInstance();
+
     if (!this.fileManagerType) {
+      // TODO - This element should nto have to set a default file manager type, but
+      // it is currently required to know that we should load the startuppath.
       this.fileManagerType = 'jupyter';
-    }
-    switch (this.fileManagerType) {
-      case 'bigquery':
-        this._fileManager =
-            FileManagerFactory.getInstanceForType(FileManagerType.BIG_QUERY);
-        break;
-      default:
-      case 'jupyter':
-        this._fileManager = FileManagerFactory.getInstance();
-        break;
+      this._fileManager = FileManagerFactory.getInstance();
+    } else {
+      this._fileManager = FileManagerFactory.getInstanceForType(
+          FileManagerFactory.fileManagerNameToType(this.fileManagerType));
     }
 
     // TODO: Using a ready promise might be common enough a need that we should
@@ -842,6 +833,8 @@ class FileBrowserElement extends Polymer.Element {
   }
 
   private _loadStartupPath() {
+    // TODO - move this to SettingsManager and make it able to store startuppaths
+    // for multiple file managers.
     if (this.fileManagerType === 'jupyter') {
       return SettingsManager.getUserSettingsAsync(true /*forceRefresh*/)
         .then((settings: common.UserSettings) => {

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -47,6 +47,16 @@ class FileBrowserElement extends Polymer.Element {
   public currentPath: string;
 
   /**
+   * The type of FileManager we want to use for this file-browser.
+   */
+  public fileManagerType: string;   // default is in code below
+
+  /**
+   * True makes the toolbar never visible.
+   */
+  public hideToolbar: boolean;
+
+  /**
    * The currently selected file if exactly one is selected, or null if none is.
    */
   public selectedFile: DatalabFile | null;
@@ -110,6 +120,14 @@ class FileBrowserElement extends Polymer.Element {
         type: String,
         value: '',
       },
+      fileManagerType: {
+        type: String,
+        value: '',
+      },
+      hideToolbar: {
+        type: Boolean,
+        value: false,
+      },
       selectedFile: {
         type: Object,
         value: null,
@@ -124,9 +142,6 @@ class FileBrowserElement extends Polymer.Element {
   constructor() {
     super();
 
-    // TODO: Should choose the FileManager instance dynamically here based on
-    // the data source specified for this file-browser instance
-    this._fileManager = FileManagerFactory.getInstance();
     this._apiManager = ApiManagerFactory.getInstance();
   }
 
@@ -142,42 +157,26 @@ class FileBrowserElement extends Polymer.Element {
 
     super.ready();
 
+    if (!this.fileManagerType) {
+      this.fileManagerType = 'jupyter';
+    }
+    switch (this.fileManagerType) {
+      case 'bigquery':
+        this._fileManager =
+            FileManagerFactory.getInstanceForType(FileManagerType.BIG_QUERY);
+        break;
+      default:
+      case 'jupyter':
+        this._fileManager = FileManagerFactory.getInstance();
+        break;
+    }
+
     // TODO: Using a ready promise might be common enough a need that we should
     // consider adding it to a super class, maybe DatalabElement. For now, this
     // is the only element that needs it.
     if (!this.readyPromise) {
-      // Get the last startup path.
-      this.readyPromise = SettingsManager.getUserSettingsAsync(true /*forceRefresh*/)
-        .then((settings: common.UserSettings) => {
-          if (settings.startuppath) {
-            let path = settings.startuppath;
-            // For backward compatibility with the current path format.
-            if (path.startsWith('/tree/')) {
-              path = path.substr('/tree/'.length);
-            }
-            this.currentPath = path;
-          }
-        })
-        .catch(() => console.error('Failed to get the user settings.'))
-        .then(() => {
-
-          this._resizeHandler();
-          this._focusHandler();
-
-          const filesElement = this.shadowRoot.querySelector('#files');
-          if (filesElement) {
-            filesElement.addEventListener('itemDoubleClick',
-                                          this._handleDoubleClicked.bind(this));
-            filesElement.addEventListener('selected-indices-changed',
-                                          this._handleSelectionChanged.bind(this));
-          }
-
-          // For a small file/directory picker, we don't need to show the status.
-          (this.$.files as ItemListElement).columns = this.small ? ['Name'] : ['Name', 'Status'];
-
-          this._fetching = false;
-          return this._fetchFileList();
-        });
+      this.readyPromise = this._loadStartupPath()
+          .then(() => this._finishLoadingFiles());
     }
 
     return this.readyPromise;
@@ -241,6 +240,8 @@ class FileBrowserElement extends Polymer.Element {
       .catch((e: Error) => {
         if (throwOnError === true) {
           throw new Error('Error getting list of files: ' + e.message);
+        } else {
+          console.log('Error getting list of files:', e);
         }
       })
       .then(() => this._fetching = false);
@@ -838,6 +839,45 @@ class FileBrowserElement extends Polymer.Element {
       clearInterval(this._fileListRefreshIntervalHandle);
       this._fileListRefreshIntervalHandle = 0;
     }
+  }
+
+  private _loadStartupPath() {
+    if (this.fileManagerType === 'jupyter') {
+      return SettingsManager.getUserSettingsAsync(true /*forceRefresh*/)
+        .then((settings: common.UserSettings) => {
+          if (settings.startuppath) {
+            let path = settings.startuppath;
+            // For backward compatibility with the current path format.
+            if (path.startsWith('/tree/')) {
+              path = path.substr('/tree/'.length);
+            }
+            this.currentPath = path;
+          }
+        })
+        .catch(() => console.error('Failed to get the user settings.'));
+    } else {
+      this.currentPath = '/';
+      return Promise.resolve();
+    }
+  }
+
+  private _finishLoadingFiles() {
+    this._resizeHandler();
+    this._focusHandler();
+
+    const filesElement = this.shadowRoot.querySelector('#files');
+    if (filesElement) {
+      filesElement.addEventListener('itemDoubleClick',
+                                    this._handleDoubleClicked.bind(this));
+      filesElement.addEventListener('selected-indices-changed',
+                                    this._handleSelectionChanged.bind(this));
+    }
+
+    // For a small file/directory picker, we don't need to show the status.
+    (this.$.files as ItemListElement).columns = this.small ? ['Name'] : ['Name', 'Status'];
+
+    this._fetching = false;
+    return this._fetchFileList();
   }
 
 }

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.html
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.html
@@ -12,7 +12,6 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
-<link rel="import" href="../bigquery-file-manager/bigquery-file-manager.html">
-<link rel="import" href="../jupyter-file-manager/jupyter-file-manager.html">
+<link rel="import" href="../file-manager/file-manager.html">
 
-<script src="file-manager-factory.js"></script>
+<script src="bigquery-file-manager.js"></script>

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -24,35 +24,21 @@ class BigQueryMethodNotYetImplemented extends Error {
  */
 class BigQueryFileManager implements FileManager {
 
-  /**
-   * Returns a DatalabFile object representing the file or directory requested
-   * @param path string path to requested file
-   * @param asText whether the file should be downloaded as plain text. This is
-   *               useful for downloading notebooks, which are by default read
-   *               as JSON, which doesn't preserve formatting.
-   */
-  public async get(path: string, asText?: boolean): Promise<DatalabFile> {
-    path; asText; // Make compiler happy until we implement this function.
+  public async get(_path: string, _asText?: boolean): Promise<DatalabFile> {
     throw new BigQueryMethodNotYetImplemented('get');
   }
 
-  /**
-   * Uploads the given file object to the backend. The file's name, path, format,
-   * and content are required fields.
-   * @param model object containing file information to send to backend
-   */
-  public async save(file: DatalabFile): Promise<DatalabFile> {
-    file; // Make compiler happy until we implement this function.
+  public async save(_file: DatalabFile): Promise<DatalabFile> {
     throw new BigQueryMethodNotYetImplemented('save');
   }
 
-  /**
-   * Returns a list of files at the target path, each implementing the
-   * DatalabFile interface. Two requests are made to /api/contents and
-   * /api/sessions to get this data.
-   * @param path current path to list files under
-   */
   public list(path: string): Promise<DatalabFile[]> {
+    // BigQuery does not allow slashes in the names of projects,
+    // datasets, or tables, so we use them as separator characters
+    // to keep consistent with POSIX file hierarchies.
+    // We also filter out blank entries, which "collapses" consecutive
+    // slashes. It also means both '' and '/' turn into an empty
+    // array of pathParts and are thus interpreted as the root.
     const pathParts = path.split('/').filter((part) => !!part);
     if (pathParts.length === 0) {
       return this._listProjects();
@@ -66,42 +52,19 @@ class BigQueryFileManager implements FileManager {
     throw new BigQueryMethodNotYetImplemented('listing datasets');
   }
 
-  /**
-   * Creates a new notebook or directory.
-   * @param itemType type of the created item, can be 'notebook' or 'directory'
-   */
-  public create(itemType: DatalabFileType, path?: string): Promise<DatalabFile> {
-    itemType; path; // Make compiler happy until we implement this function.
+  public create(_itemType: DatalabFileType, _path?: string): Promise<DatalabFile> {
     throw new BigQueryMethodNotYetImplemented('create');
   }
 
-  /**
-   * Renames an item
-   * @param oldPath source path of the existing item
-   * @param newPath destination path of the renamed item
-   */
-  public rename(oldPath: string, newPath: string): Promise<DatalabFile> {
-    oldPath; newPath; // Make compiler happy until we implement this function.
+  public rename(_oldPath: string, _newPath: string): Promise<DatalabFile> {
     throw new BigQueryMethodNotYetImplemented('rename');
   }
 
-  /**
-   * Deletes an item
-   * @param path item path to delete
-   */
-  public delete(path: string): Promise<boolean> {
-    path; // Make compiler happy until we implement this function.
+  public delete(_path: string): Promise<boolean> {
     throw new BigQueryMethodNotYetImplemented('delete');
   }
 
-  /*
-   * Copies an item from source to destination. Item name collisions at the destination
-   * are handled by BigQuery.
-   * @param path path to copied item
-   * @param destinationDirectory directory to copy the item into
-   */
-  public copy(path: string, destinationDirectory: string): Promise<DatalabFile> {
-    path; destinationDirectory; // Make compiler happy until we implement this function.
+  public copy(_path: string, _destinationDirectory: string): Promise<DatalabFile> {
     throw new BigQueryMethodNotYetImplemented('copy');
   }
 

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+class BigQueryMethodNotYetImplemented extends Error {
+  constructor(apiFunctionName: string) {
+    super('BigQuery method ' + apiFunctionName + ' is not implemented');
+  }
+}
+
+/**
+ * A file manager that wraps the BigQuery API so that we can browse BQ projects,
+ * datasets, and tables like a filesystem.
+ */
+class BigQueryFileManager implements FileManager {
+
+  /**
+   * Returns a DatalabFile object representing the file or directory requested
+   * @param path string path to requested file
+   * @param asText whether the file should be downloaded as plain text. This is
+   *               useful for downloading notebooks, which are by default read
+   *               as JSON, which doesn't preserve formatting.
+   */
+  public async get(path: string, asText?: boolean): Promise<DatalabFile> {
+    path; asText; // Make compiler happy until we implement this function.
+    throw new BigQueryMethodNotYetImplemented('get');
+  }
+
+  /**
+   * Uploads the given file object to the backend. The file's name, path, format,
+   * and content are required fields.
+   * @param model object containing file information to send to backend
+   */
+  public async save(file: DatalabFile): Promise<DatalabFile> {
+    file; // Make compiler happy until we implement this function.
+    throw new BigQueryMethodNotYetImplemented('save');
+  }
+
+  /**
+   * Returns a list of files at the target path, each implementing the
+   * DatalabFile interface. Two requests are made to /api/contents and
+   * /api/sessions to get this data.
+   * @param path current path to list files under
+   */
+  public list(path: string): Promise<DatalabFile[]> {
+    const pathParts = path.split('/').filter((part) => !!part);
+    if (pathParts.length === 0) {
+      return this._listProjects();
+    }
+    if (pathParts.length === 1) {
+      return this._listDatasets(pathParts[0]);
+    }
+    if (pathParts.length === 2) {
+      return this._listTables(pathParts[0], pathParts[1]);
+    }
+    throw new BigQueryMethodNotYetImplemented('listing datasets');
+  }
+
+  /**
+   * Creates a new notebook or directory.
+   * @param itemType type of the created item, can be 'notebook' or 'directory'
+   */
+  public create(itemType: DatalabFileType, path?: string): Promise<DatalabFile> {
+    itemType; path; // Make compiler happy until we implement this function.
+    throw new BigQueryMethodNotYetImplemented('create');
+  }
+
+  /**
+   * Renames an item
+   * @param oldPath source path of the existing item
+   * @param newPath destination path of the renamed item
+   */
+  public rename(oldPath: string, newPath: string): Promise<DatalabFile> {
+    oldPath; newPath; // Make compiler happy until we implement this function.
+    throw new BigQueryMethodNotYetImplemented('rename');
+  }
+
+  /**
+   * Deletes an item
+   * @param path item path to delete
+   */
+  public delete(path: string): Promise<boolean> {
+    path; // Make compiler happy until we implement this function.
+    throw new BigQueryMethodNotYetImplemented('delete');
+  }
+
+  /*
+   * Copies an item from source to destination. Item name collisions at the destination
+   * are handled by BigQuery.
+   * @param path path to copied item
+   * @param destinationDirectory directory to copy the item into
+   */
+  public copy(path: string, destinationDirectory: string): Promise<DatalabFile> {
+    path; destinationDirectory; // Make compiler happy until we implement this function.
+    throw new BigQueryMethodNotYetImplemented('copy');
+  }
+
+  private _listProjects(): Promise<DatalabFile[]> {
+    return GapiManager.listBigQueryProjects()
+      .then((response: HttpResponse<gapi.client.bigquery.ListProjectsResponse>) => {
+        const projects = response.result.projects || [];
+        return projects.map(
+            this._bqProjectToDatalabFile.bind(this)) as DatalabFile[];
+      })
+      .catch((e) => { console.error(e); throw e;});
+  }
+
+  private _listDatasets(projectId: string): Promise<DatalabFile[]> {
+    return GapiManager.listBigQueryDatasets(projectId, '')
+      .then((response: HttpResponse<gapi.client.bigquery.ListDatasetsResponse>) => {
+        const datasets = response.result.datasets || [];
+        return datasets.map(
+            this._bqDatasetToDatalabFile.bind(this)) as DatalabFile[];
+      })
+      .catch((e) => { console.error(e); throw e;});
+  }
+
+  private _listTables(projectId: string, datasetId: string): Promise<DatalabFile[]> {
+    return GapiManager.listBigQueryTables(projectId, datasetId)
+      .then((response: HttpResponse<gapi.client.bigquery.ListTablesResponse>) => {
+        const tables = response.result.tables || [];
+        return tables.map(
+            this._bqTableToDatalabFile.bind(this)) as DatalabFile[];
+      })
+      .catch((e) => { console.error(e); throw e;});
+  }
+
+  private _bqProjectToDatalabFile(bqProject: gapi.client.bigquery.ProjectResource): DatalabFile {
+    return {
+      name: bqProject.projectReference.projectId,
+      path: bqProject.projectReference.projectId,
+      status: DatalabFileStatus.IDLE,
+      type: DatalabFileType.DIRECTORY,
+    } as DatalabFile;
+  };
+
+  private _bqDatasetToDatalabFile(bqDataset: gapi.client.bigquery.DatasetResource): DatalabFile {
+    return {
+      name: bqDataset.datasetReference.datasetId,
+      path: bqDataset.datasetReference.projectId + '/' + bqDataset.datasetReference.datasetId,
+      status: DatalabFileStatus.IDLE,
+      type: DatalabFileType.DIRECTORY,
+    } as DatalabFile;
+  };
+
+  private _bqTableToDatalabFile(bqTable: gapi.client.bigquery.TableResource): DatalabFile {
+    return {
+      name: bqTable.tableReference.tableId,
+      path: bqTable.tableReference.projectId + '/' +
+          bqTable.tableReference.datasetId + '/' + bqTable.tableReference.tableId,
+      status: DatalabFileStatus.IDLE,
+      type: DatalabFileType.FILE,
+    } as DatalabFile;
+  };
+}

--- a/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
@@ -16,10 +16,21 @@
  * Dependency custom element for ApiManager
  */
 const FILE_MANAGER_ELEMENT = {
+  bigquery: {
+    name: 'bigquery',
+    path: 'modules/bigquery-file-manager/bigquery-file-manager.html',
+    type: BigQueryFileManager,
+  },
   jupyter: {
+    name: 'jupyter',
     path: 'modules/jupyter-file-manager/jupyter-file-manager.html',
     type: JupyterFileManager,
   },
+};
+
+enum FileManagerType {
+  BIG_QUERY,  // bigquery
+  JUPYTER,    // jupyter
 };
 
 /**
@@ -29,21 +40,30 @@ const FILE_MANAGER_ELEMENT = {
 // environment
 class FileManagerFactory {
 
-  private static _fileManager: FileManager;
+  private static _fileManagers: { [fileManagerType: string] : FileManager } = {};
 
+  /** Get the default FileManager. */
   public static getInstance() {
-    if (!FileManagerFactory._fileManager) {
-      const backendType = FileManagerFactory._getBackendType();
-
-      Polymer.importHref(backendType.path, undefined, undefined, true);
-      FileManagerFactory._fileManager = new backendType.type();
-    }
-
-    return FileManagerFactory._fileManager;
+    return FileManagerFactory.getInstanceForType(FileManagerType.JUPYTER);
   }
 
-  private static _getBackendType() {
-    return FILE_MANAGER_ELEMENT.jupyter;
+  public static getInstanceForType(fileManagerType: FileManagerType) {
+    const backendType = FileManagerFactory._getBackendType(fileManagerType);
+    if (!FileManagerFactory._fileManagers[backendType.name]) {
+
+      Polymer.importHref(backendType.path, undefined, undefined, true);
+      FileManagerFactory._fileManagers[fileManagerType] = new backendType.type();
+    }
+
+    return FileManagerFactory._fileManagers[fileManagerType];
+  }
+
+  private static _getBackendType(fileManagerType: FileManagerType) {
+    switch (fileManagerType) {
+      case FileManagerType.BIG_QUERY: return FILE_MANAGER_ELEMENT.bigquery;
+      case FileManagerType.JUPYTER: return FILE_MANAGER_ELEMENT.jupyter;
+      default: throw new Error('Unknown FileManagerType');
+    }
   }
 }
 

--- a/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
@@ -29,8 +29,8 @@ const FILE_MANAGER_ELEMENT = {
 };
 
 enum FileManagerType {
-  BIG_QUERY,  // bigquery
-  JUPYTER,    // jupyter
+  BIG_QUERY,
+  JUPYTER,
 };
 
 /**
@@ -47,11 +47,18 @@ class FileManagerFactory {
     return FileManagerFactory.getInstanceForType(FileManagerType.JUPYTER);
   }
 
+  public static fileManagerNameToType(name: string): FileManagerType {
+    switch (name) {
+      case 'bigquery': return FileManagerType.BIG_QUERY;
+      case 'jupyter': return FileManagerType.JUPYTER;
+      default: throw new Error('unknown FileManagerType name ' + name);
+    }
+  }
+
   public static getInstanceForType(fileManagerType: FileManagerType) {
     const backendType = FileManagerFactory._getBackendType(fileManagerType);
     if (!FileManagerFactory._fileManagers[backendType.name]) {
 
-      Polymer.importHref(backendType.path, undefined, undefined, true);
       FileManagerFactory._fileManagers[fileManagerType] = new backendType.type();
     }
 

--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -119,8 +119,11 @@ class GapiManager {
    */
   public static listBigQueryProjects():
       Promise<gapi.client.HttpRequestFulfilled<gapi.client.bigquery.ListProjectsResponse>> {
+    const request = {
+      maxResults: 1000,
+    };
     return this._loadBigQuery()
-      .then(() => gapi.client.bigquery.projects.list());
+      .then(() => gapi.client.bigquery.projects.list(request));
   }
 
   /**
@@ -133,6 +136,7 @@ class GapiManager {
       Promise<gapi.client.HttpRequestFulfilled<gapi.client.bigquery.ListDatasetsResponse>> {
     const request = {
       filter,
+      maxResults: 1000,
       projectId,
     };
     return GapiManager._loadBigQuery()
@@ -147,6 +151,7 @@ class GapiManager {
       Promise<gapi.client.HttpRequestFulfilled<gapi.client.bigquery.ListTablesResponse>> {
     const request = {
       datasetId,
+      maxResults: 1000,
       projectId,
     };
     return GapiManager._loadBigQuery()
@@ -246,7 +251,8 @@ class GapiManager {
 
   private static _loadBigQuery(): Promise<void> {
     return this.loadGapi()
-      .then(() => gapi.client.load('bigquery', 'v2'));
+      .then(() => gapi.client.load('bigquery', 'v2'))
+      .then(() => GapiManager.grantScope(GapiScopes.BIGQUERY));
   }
 
   private static _getScopeString(scope: GapiScopes): string {

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.html
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.html
@@ -13,7 +13,7 @@ the License.
 -->
 
 <link rel="import" href="../api-manager-factory/api-manager-factory.html">
-<link rel="import" href="../settings-manager/settings-manager.html">
+<link rel="import" href="../session-manager/session-manager.html">
 <link rel="import" href="../file-manager/file-manager.html">
 
 <script src="jupyter-file-manager.js"></script>

--- a/sources/web/datalab/polymer/polymer.json
+++ b/sources/web/datalab/polymer/polymer.json
@@ -2,13 +2,14 @@
   "entrypoint": "index.html",
   "shell": "components/datalab-app/datalab-app.html",
   "fragments": [
+    "components/data-browser/data-browser.html",
     "components/datalab-data/datalab-data.html",
     "components/datalab-editor/datalab-editor.html",
-    "components/file-browser/file-browser.html",
     "components/datalab-sessions/datalab-sessions.html",
     "components/datalab-sidebar/datalab-sidebar.html",
     "components/datalab-terminal/datalab-terminal.html",
-    "components/datalab-toolbar/datalab-toolbar.html"
+    "components/datalab-toolbar/datalab-toolbar.html",
+    "components/file-browser/file-browser.html"
   ],
   "sources": [
     "modules/**/*.js",

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -37,10 +37,13 @@ describe('<file-browser>', () => {
     ApiManagerFactory.getInstance().getBasePath = () => {
       return Promise.resolve('');
     };
-    FileManagerFactory.getInstance().list = (path: string) => {
-      assert(path === startuppath, 'listFilesAsync should be called with the startup path');
-      return Promise.resolve(mockFiles);
-    };
+    const mockFileManager = {
+      list: (path: string) => {
+        assert(path === startuppath, 'listFilesAsync should be called with the startup path');
+        return Promise.resolve(mockFiles);
+      },
+    } as FileManager;
+    FileManagerFactory.getInstance = () => { return mockFileManager; }
   });
 
   beforeEach((done: () => any) => {

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -39,11 +39,13 @@ describe('<file-browser>', () => {
     };
     const mockFileManager = {
       list: (path: string) => {
+        console.log('== path is', path, ', startuppath is ', startuppath)
         assert(path === startuppath, 'listFilesAsync should be called with the startup path');
         return Promise.resolve(mockFiles);
       },
     } as FileManager;
     FileManagerFactory.getInstance = () => { return mockFileManager; }
+    FileManagerFactory.getInstanceForType = (_) => { return mockFileManager; }
   });
 
   beforeEach((done: () => any) => {

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -175,6 +175,7 @@ export function isExperimentalResource(pathname: string) {
   const experimentalUiEnabled = process.env.DATALAB_EXPERIMENTAL_UI;
   return experimentalUiEnabled === 'true' && (
       pathname.indexOf('/data') === 0 ||
+      pathname.indexOf('/data2') === 0 ||
       pathname === '/files' ||
       // /files/path?download=true is used to download files from Jupyter
       // TODO: use a different API to download files when we have a content service.
@@ -212,6 +213,7 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
       response.end();
       return;
     } else if (pathname === '/data' ||
+        pathname === '/data2' ||
         pathname === '/files' ||
         pathname === '/sessions' ||
         pathname === '/terminal') {


### PR DESCRIPTION
This PR starts the implementation of a new data browser to replace the current Data tab. This implementation uses the file-browser element along with the new BigQueryFileManager.

Since this does not yet implement the preview capability of the current Data tab, I am not yet replacing the current Data tab, but rather adding a new "/data2" path that links to this new data browser. Once it has the preview capability of the current Data tab, we can move it to /data and remove the old Data tab implementation.

Still TODO: remove the Status column, implement preview for tables, add a filter input field, display appropriate icons.

This example shows a project (jimmc-datalab) and a BigQuery dataset (test) with the two BigQuery tables in that dataset.
![data2-tab](https://user-images.githubusercontent.com/116825/29235628-31ff2ff0-7eb5-11e7-96e6-76f8a79c8036.png)
