### PR TITLE
Breadcrumbs as an element

### DIFF
--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
@@ -81,7 +81,7 @@ the License.
     <div id="breadcrumb">
       <!--Always show a '/' crumb for home-->
       <div>
-        <a id="home-crumb" href="#" on-click="_crumbClicked">/</a>
+        <a id="home-crumb" href="#" on-click="_rootClicked">/</a>
       </div>
       <template id="breadcrumbsTemplate" is="dom-repeat" items={{crumbs}}>
         <div>

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
@@ -45,10 +45,10 @@ the License.
         height: 100%;
         color: var(--selection-fg-color);
       }
-      #breadcrumb div.crumb:first-child a, #ellipsisCrumb a {
+      #homeCrumb a, #ellipsisCrumb a {
         padding-left: 15px !important;
       }
-      #breadcrumb div.crumb:first-child a:before, #ellipsisCrumb a:before {
+      #homeCrumb a:before, #ellipsisCrumb a:before {
         border: none !important;
       }
       #breadcrumb div.crumb a:before, #breadcrumb div.crumb a:after {
@@ -81,18 +81,21 @@ the License.
         padding-right: 15px;
         margin-right: 0px;
       }
+      #breadcrumb div.crumb:nth-last-child(2) a:hover {
+        border-right: 1px solid var(--border-color);
+      }
       #breadcrumb div.crumb:nth-last-child(2) a:after {
         border: none;
       }
     </style>
 
     <div id="breadcrumb">
+      <div id="ellipsisCrumb" class="crumb hidden" on-click="_ellipsisClicked">
+        <a href="#">...</a>
+      </div>
       <!--Always show a '/' crumb for home-->
       <div class="crumb" id="homeCrumb">
         <a href="#" on-click="_rootClicked">/</a>
-      </div>
-      <div id="ellipsisCrumb" class="crumb hidden" on-click="_ellipsisClicked">
-        <a href="#">...</a>
       </div>
       <template id="breadcrumbsTemplate" is="dom-repeat" items={{_visibleCrumbs}}>
         <div class="crumb part" on-click="_crumbClicked">

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
@@ -20,10 +20,13 @@ the License.
     <style include="datalab-shared-styles">
       #breadcrumb {
         user-select: none;
-        margin-left: 15px;
       }
-      #ellipsisCrumb {
-        width: 30px;
+      #homeCrumb, #ellipsisCrumb {
+        width: 55px;
+      }
+      #ellipsisCrumb a {
+        font-weight: bolder;
+        box-shadow: inset 10px 0px 7px -8px var(--selection-bg-color);
       }
       #breadcrumb div.crumb {
         float: left;
@@ -37,16 +40,16 @@ the License.
         background-color: var(--primary-bg-color);
         text-decoration: none;
         position: relative;
-        line-height: 46px;
+        line-height: 48px;
         margin-right: 25px;
         height: 100%;
         color: var(--selection-fg-color);
       }
-      #breadcrumb div.crumb:first-child a {
-        padding-left: 15px;
+      #breadcrumb div.crumb:first-child a, #ellipsisCrumb a {
+        padding-left: 15px !important;
       }
-      #breadcrumb div.crumb:first-child a:before {
-        border: none;
+      #breadcrumb div.crumb:first-child a:before, #ellipsisCrumb a:before {
+        border: none !important;
       }
       #breadcrumb div.crumb a:before, #breadcrumb div.crumb a:after {
         color: var(--primary-bg-color);
@@ -76,6 +79,7 @@ the License.
       }
       #breadcrumb div.crumb:nth-last-child(2) a {
         padding-right: 15px;
+        margin-right: 0px;
       }
       #breadcrumb div.crumb:nth-last-child(2) a:after {
         border: none;
@@ -84,15 +88,15 @@ the License.
 
     <div id="breadcrumb">
       <!--Always show a '/' crumb for home-->
-      <div class="crumb">
-        <a id="home-crumb" href="#" on-click="_rootClicked">/</a>
+      <div class="crumb" id="homeCrumb">
+        <a href="#" on-click="_rootClicked">/</a>
       </div>
-      <div id="ellipsisCrumb" class="hidden">
-        <a href="#" on-click="_ellipsisClicked">/</a>
+      <div id="ellipsisCrumb" class="crumb hidden" on-click="_ellipsisClicked">
+        <a href="#">...</a>
       </div>
       <template id="breadcrumbsTemplate" is="dom-repeat" items={{_visibleCrumbs}}>
-        <div class="crumb">
-          <a href="#" on-click="_crumbClicked">{{item}}</a>
+        <div class="crumb part" on-click="_crumbClicked">
+          <a href="#">{{item}}</a>
         </div>
       </template>
     </div>

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
@@ -30,13 +30,14 @@ the License.
       }
       #breadcrumb div.crumb {
         float: left;
+        max-width: calc(100% - 55px); /* Stretch as much as we can uptill the ellipsis div */
       }
       #breadcrumb div.hidden {
         position: absolute;
         visibility: hidden;
       }
       #breadcrumb div.crumb a {
-        display: block;
+        display: flex;
         background-color: var(--primary-bg-color);
         text-decoration: none;
         position: relative;
@@ -44,6 +45,11 @@ the License.
         margin-right: 25px;
         height: 100%;
         color: var(--selection-fg-color);
+      }
+      #breadcrumb div.crumb a div {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
       #homeCrumb a, #ellipsisCrumb a {
         padding-left: 15px !important;
@@ -99,7 +105,7 @@ the License.
       </div>
       <template id="breadcrumbsTemplate" is="dom-repeat" items={{crumbs}}>
         <div class="crumb part" on-click="_crumbClicked">
-          <a href="#">{{item}}</a>
+          <a href="#"><div>{{item}}</div></a>
         </div>
       </template>
     </div>

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
@@ -30,7 +30,7 @@ the License.
       }
       #breadcrumb div.crumb {
         float: left;
-        max-width: calc(100% - 55px); /* Stretch as much as we can uptill the ellipsis div */
+        max-width: calc(100% - 55px); /* Stretch as much as we can until the ellipsis div */
       }
       #breadcrumb div.hidden {
         position: absolute;
@@ -100,6 +100,7 @@ the License.
         <a href="#">...</a>
       </div>
       <!--Always show a '/' crumb for home-->
+      <!-- TODO: Consider making this crumb customizable -->
       <div class="crumb" id="homeCrumb">
         <a href="#" on-click="_rootClicked">/</a>
       </div>

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
@@ -1,0 +1,96 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
+
+<dom-module id="bread-crumbs">
+  <template>
+
+    <style include="datalab-shared-styles">
+      #breadcrumb {
+        user-select: none;
+        list-style: none;
+        display: inline-block;
+        flex-grow: 1;
+      }
+      #breadcrumb div {
+        float: left;
+        height: 100%;
+      }
+      #breadcrumb div a {
+        display: block;
+        background-color: var(--primary-bg-color);
+        text-decoration: none;
+        position: relative;
+        line-height: 46px;
+        margin-right: 25px;
+        height: 100%;
+        color: var(--selection-fg-color);
+      }
+      #breadcrumb div:first-child a {
+        padding-left: 15px;
+      }
+      #breadcrumb div:first-child a:before {
+        border: none;
+      }
+      #breadcrumb div a:before, #breadcrumb div a:after {
+        color: var(--primary-bg-color);
+        content: "";
+        position: absolute;
+        border: 0 solid var(--primary-bg-color);
+        border-width: 24px 12px;
+      }
+      #breadcrumb div a:before {
+        left: -24px;
+        border-left-color: transparent;
+      }
+      #breadcrumb div a:after {
+        left: 100%;
+        border-color: var(--border-color);
+        border-left-color: var(--primary-bg-color);
+      }
+      #breadcrumb div a:hover {
+        background-color: var(--secondary-bg-color);
+      }
+      #breadcrumb div a:hover:before {
+        border-color: var(--secondary-bg-color);
+        border-left-color: transparent;
+      }
+      #breadcrumb div a:hover:after {
+        border-left-color: var(--secondary-bg-color);
+      }
+      #breadcrumb div:nth-last-child(2) a {
+        padding-right: 15px;
+      }
+      #breadcrumb div:nth-last-child(2) a:after {
+        border: none;
+      }
+    </style>
+
+    <div id="breadcrumb">
+      <!--Always show a '/' crumb for home-->
+      <div>
+        <a id="home-crumb" href="#" on-click="_crumbClicked">/</a>
+      </div>
+      <template id="breadcrumbsTemplate" is="dom-repeat" items={{crumbs}}>
+        <div>
+          <a href="#" on-click="_crumbClicked">{{item}}</a>
+        </div>
+      </template>
+    </div>
+
+  </template>
+</dom-module>
+
+<script src="bread-crumbs.js"></script>

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
@@ -20,15 +20,19 @@ the License.
     <style include="datalab-shared-styles">
       #breadcrumb {
         user-select: none;
-        list-style: none;
-        display: inline-block;
-        flex-grow: 1;
+        margin-left: 15px;
       }
-      #breadcrumb div {
+      #ellipsisCrumb {
+        width: 30px;
+      }
+      #breadcrumb div.crumb {
         float: left;
-        height: 100%;
       }
-      #breadcrumb div a {
+      #breadcrumb div.hidden {
+        position: absolute;
+        visibility: hidden;
+      }
+      #breadcrumb div.crumb a {
         display: block;
         background-color: var(--primary-bg-color);
         text-decoration: none;
@@ -38,53 +42,56 @@ the License.
         height: 100%;
         color: var(--selection-fg-color);
       }
-      #breadcrumb div:first-child a {
+      #breadcrumb div.crumb:first-child a {
         padding-left: 15px;
       }
-      #breadcrumb div:first-child a:before {
+      #breadcrumb div.crumb:first-child a:before {
         border: none;
       }
-      #breadcrumb div a:before, #breadcrumb div a:after {
+      #breadcrumb div.crumb a:before, #breadcrumb div.crumb a:after {
         color: var(--primary-bg-color);
         content: "";
         position: absolute;
         border: 0 solid var(--primary-bg-color);
         border-width: 24px 12px;
       }
-      #breadcrumb div a:before {
+      #breadcrumb div.crumb a:before {
         left: -24px;
         border-left-color: transparent;
       }
-      #breadcrumb div a:after {
+      #breadcrumb div.crumb a:after {
         left: 100%;
         border-color: var(--border-color);
         border-left-color: var(--primary-bg-color);
       }
-      #breadcrumb div a:hover {
+      #breadcrumb div.crumb a:hover {
         background-color: var(--secondary-bg-color);
       }
-      #breadcrumb div a:hover:before {
+      #breadcrumb div.crumb a:hover:before {
         border-color: var(--secondary-bg-color);
         border-left-color: transparent;
       }
-      #breadcrumb div a:hover:after {
+      #breadcrumb div.crumb a:hover:after {
         border-left-color: var(--secondary-bg-color);
       }
-      #breadcrumb div:nth-last-child(2) a {
+      #breadcrumb div.crumb:nth-last-child(2) a {
         padding-right: 15px;
       }
-      #breadcrumb div:nth-last-child(2) a:after {
+      #breadcrumb div.crumb:nth-last-child(2) a:after {
         border: none;
       }
     </style>
 
     <div id="breadcrumb">
       <!--Always show a '/' crumb for home-->
-      <div>
+      <div class="crumb">
         <a id="home-crumb" href="#" on-click="_rootClicked">/</a>
       </div>
-      <template id="breadcrumbsTemplate" is="dom-repeat" items={{crumbs}}>
-        <div>
+      <div id="ellipsisCrumb" class="hidden">
+        <a href="#" on-click="_ellipsisClicked">/</a>
+      </div>
+      <template id="breadcrumbsTemplate" is="dom-repeat" items={{_visibleCrumbs}}>
+        <div class="crumb">
           <a href="#" on-click="_crumbClicked">{{item}}</a>
         </div>
       </template>

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
@@ -97,7 +97,7 @@ the License.
       <div class="crumb" id="homeCrumb">
         <a href="#" on-click="_rootClicked">/</a>
       </div>
-      <template id="breadcrumbsTemplate" is="dom-repeat" items={{_visibleCrumbs}}>
+      <template id="breadcrumbsTemplate" is="dom-repeat" items={{crumbs}}>
         <div class="crumb part" on-click="_crumbClicked">
           <a href="#">{{item}}</a>
         </div>

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
@@ -46,10 +46,17 @@ class BreadCrumbsElement extends Polymer.Element {
   }
 
   _resizeHandler() {
-    const container = this.$.breadcrumb as HTMLDivElement;
-    const maxWidth = container.offsetWidth - 30;
+    // Let the items render first, before hiding overflowing items
+    Polymer.dom.flush();
 
-    const children = container.querySelectorAll('div.crumb') as NodeListOf<HTMLDivElement>;
+    const container = this.$.breadcrumb as HTMLDivElement;
+    const maxWidth = container.offsetWidth - 55;
+
+    const children = container.querySelectorAll('div.part') as NodeListOf<HTMLDivElement>;
+
+    if (!children.length) {
+      return;
+    }
 
     // Find the index of the last breadcrumb we can fit, starting from the right
     // We must fit at least the right-most child, so this is the starting point
@@ -66,16 +73,18 @@ class BreadCrumbsElement extends Polymer.Element {
       }
     }
 
-    // If there are crumbs that we hid, show the ellipsis crumb
-    if (lastVisibleChild < children.length - 1) {
-      this.$.ellipsisCrumb.classList.remove('hidden');
-    } else {
-      this.$.ellipsisCrumb.classList.add('hidden');
-    }
-
     // Hide all breadcrumbs to the left of the last visible index
     for (let i = 0; i < lastVisibleChild; ++i) {
       children[i].classList.add('hidden');
+    }
+
+    // If we managed to show all crumbs, hide the ellipsis div
+    if (lastVisibleChild === 0) {
+      this.$.ellipsisCrumb.classList.add('hidden');
+      this.$.homeCrumb.classList.remove('hidden');
+    } else {
+      this.$.ellipsisCrumb.classList.remove('hidden');
+      this.$.homeCrumb.classList.add('hidden');
     }
   }
 

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
@@ -24,9 +24,19 @@
   */
 class BreadCrumbsElement extends Polymer.Element {
 
+  /**
+   * Array of path parts to display as breadcrumbs.
+   */
   public crumbs: string[];
 
-  private lastVisibleIndex: number;
+  /**
+   * Index of the last path link that was fit in the breadcrumbs bar.
+   */
+  public lastVisibleIndex: number;
+
+  // Length of the first crumb, which is either the home crumb (/), or ellipsis
+  // crumb (...).
+  private readonly _ellipsisCrumbWidth = 55;
 
   static get is() { return 'bread-crumbs'; }
 
@@ -55,7 +65,7 @@ class BreadCrumbsElement extends Polymer.Element {
     Polymer.dom.flush();
 
     const container = this.$.breadcrumb as HTMLDivElement;
-    const maxWidth = container.offsetWidth - 55;
+    const maxWidth = container.offsetWidth - this._ellipsisCrumbWidth;
 
     const children = container.querySelectorAll('div.part') as NodeListOf<HTMLDivElement>;
 
@@ -69,14 +79,13 @@ class BreadCrumbsElement extends Polymer.Element {
     children[this.lastVisibleIndex].classList.remove('hidden');
     let runningWidth = children[this.lastVisibleIndex].offsetWidth;
 
-    for (let i = this.lastVisibleIndex - 1; i >= 0; --i) {
-      if (runningWidth + children[i].offsetWidth < maxWidth) {
-        this.lastVisibleIndex = i;
-        children[this.lastVisibleIndex].classList.remove('hidden');
-        runningWidth += children[this.lastVisibleIndex].offsetWidth;
-      } else {
-        break;
-      }
+    // Stop when we find the first element that we cannot fit.
+    for (let i = this.lastVisibleIndex - 1;
+         i >= 0 && runningWidth + children[i].offsetWidth < maxWidth;
+         --i) {
+      this.lastVisibleIndex = i;
+      children[this.lastVisibleIndex].classList.remove('hidden');
+      runningWidth += children[this.lastVisibleIndex].offsetWidth;
     }
 
     // Hide all breadcrumbs to the left of the last visible index

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+class BreadCrumbsElement extends Polymer.Element {
+
+  public crumbs: string[];
+
+  static get is() { return 'bread-crumbs'; }
+
+  static get properties() {
+    return {
+      crumbs: {
+        observer: '_crumbsChanged',
+        type: Array,
+        value: [],
+      },
+    };
+  }
+
+  _crumbsChanged() {
+    //
+  }
+
+}
+
+customElements.define(BreadCrumbsElement.is, BreadCrumbsElement);

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
@@ -56,11 +56,11 @@ class BreadCrumbsElement extends Polymer.Element {
     // Find the index of the last breadcrumb we can fit, starting from the right
     // We must fit at least the right-most child, so this is the starting point.
     // Always show that first child.
-    children[0].classList.remove('hidden');
     this.lastVisibleIndex = children.length - 1;
-    let runningWidth = children[children.length - 1].offsetWidth;
+    children[this.lastVisibleIndex].classList.remove('hidden');
+    let runningWidth = children[this.lastVisibleIndex].offsetWidth;
 
-    for (let i = children.length - 2; i >= 0; --i) {
+    for (let i = this.lastVisibleIndex - 1; i >= 0; --i) {
       const child = children[i];
       if (runningWidth + child.offsetWidth < maxWidth) {
         runningWidth += child.offsetWidth;

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
@@ -16,16 +16,12 @@ class BreadCrumbsElement extends Polymer.Element {
 
   public crumbs: string[];
 
-  private _visibleCrumbs: string[];
+  private lastVisibleIndex: number;
 
   static get is() { return 'bread-crumbs'; }
 
   static get properties() {
     return {
-      _visibleCrumbs: {
-        type: Array,
-        value: [],
-      },
       crumbs: {
         observer: '_crumbsChanged',
         type: Array,
@@ -41,7 +37,6 @@ class BreadCrumbsElement extends Polymer.Element {
   }
 
   _crumbsChanged() {
-    this._visibleCrumbs = this.crumbs;
     this._resizeHandler();
   }
 
@@ -59,27 +54,30 @@ class BreadCrumbsElement extends Polymer.Element {
     }
 
     // Find the index of the last breadcrumb we can fit, starting from the right
-    // We must fit at least the right-most child, so this is the starting point
-    let lastVisibleChild = children.length - 1;
+    // We must fit at least the right-most child, so this is the starting point.
+    // Always show that first child.
+    children[0].classList.remove('hidden');
+    this.lastVisibleIndex = children.length - 1;
     let runningWidth = children[children.length - 1].offsetWidth;
+
     for (let i = children.length - 2; i >= 0; --i) {
       const child = children[i];
       if (runningWidth + child.offsetWidth < maxWidth) {
         runningWidth += child.offsetWidth;
         child.classList.remove('hidden');
-        lastVisibleChild = i;
+        this.lastVisibleIndex = i;
       } else {
         break;
       }
     }
 
     // Hide all breadcrumbs to the left of the last visible index
-    for (let i = 0; i < lastVisibleChild; ++i) {
+    for (let i = 0; i < this.lastVisibleIndex; ++i) {
       children[i].classList.add('hidden');
     }
 
     // If we managed to show all crumbs, hide the ellipsis div
-    if (lastVisibleChild === 0) {
+    if (this.lastVisibleIndex === 0) {
       this.$.ellipsisCrumb.classList.add('hidden');
       this.$.homeCrumb.classList.remove('hidden');
     } else {
@@ -94,6 +92,11 @@ class BreadCrumbsElement extends Polymer.Element {
       const ev = new ItemClickEvent('crumbClicked', { detail: {index} });
       this.dispatchEvent(ev);
     }
+  }
+
+  _ellipsisClicked() {
+    const ev = new ItemClickEvent('crumbClicked', { detail: {index: this.lastVisibleIndex - 1} });
+    this.dispatchEvent(ev);
   }
 
   _rootClicked() {

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
@@ -21,15 +21,22 @@ class BreadCrumbsElement extends Polymer.Element {
   static get properties() {
     return {
       crumbs: {
-        observer: '_crumbsChanged',
         type: Array,
         value: [],
       },
     };
   }
 
-  _crumbsChanged() {
-    //
+  _crumbClicked(e: MouseEvent) {
+    const index = this.$.breadcrumbsTemplate.indexForElement(e.target);
+    if (index !== null) {
+      const ev = new ItemClickEvent('crumbClicked', { detail: {index} });
+      this.dispatchEvent(ev);
+    }
+  }
+
+  _rootClicked() {
+    this.dispatchEvent(new ItemClickEvent('rootClicked'));
   }
 
 }

--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
@@ -12,6 +12,16 @@
  * the License.
  */
 
+ /**
+  * Breadcrumb element for Datalab. It takes an array of strings that are
+  * displayed as a horizontal list of links representing a POSIX-like path. A
+  * root link is always displayed at the beginning of the list. Clicking a link
+  * dispatches a 'crumbClicked' custom event that contains the index of the
+  * clicked item. Overflowing links will be hidden from the left side, and an
+  * ellipsis link appears when this is the case. Clicking the ellipsis
+  * dispatches the custom event with the index before the last visible item.
+  * Clicking the root link dispatches a 'rootClicked' custom event.
+  */
 class BreadCrumbsElement extends Polymer.Element {
 
   public crumbs: string[];
@@ -55,17 +65,15 @@ class BreadCrumbsElement extends Polymer.Element {
 
     // Find the index of the last breadcrumb we can fit, starting from the right
     // We must fit at least the right-most child, so this is the starting point.
-    // Always show that first child.
     this.lastVisibleIndex = children.length - 1;
     children[this.lastVisibleIndex].classList.remove('hidden');
     let runningWidth = children[this.lastVisibleIndex].offsetWidth;
 
     for (let i = this.lastVisibleIndex - 1; i >= 0; --i) {
-      const child = children[i];
-      if (runningWidth + child.offsetWidth < maxWidth) {
-        runningWidth += child.offsetWidth;
-        child.classList.remove('hidden');
+      if (runningWidth + children[i].offsetWidth < maxWidth) {
         this.lastVisibleIndex = i;
+        children[this.lastVisibleIndex].classList.remove('hidden');
+        runningWidth += children[this.lastVisibleIndex].offsetWidth;
       } else {
         break;
       }

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -106,6 +106,7 @@ the License.
         min-width: 35px;
         margin: 0px;
         border-radius: 0px;
+        flex: 0 0 auto;
       }
       .navbar-button[disabled] {
         color: var(--disabled-fg-color);

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -135,7 +135,7 @@ the License.
         border-left: 1px solid var(--border-color);
         line-height: 48px;
       }
-      bread-crumbs {
+      #breadCrumbs {
         flex: 1 1 auto;
       }
     </style>
@@ -234,7 +234,7 @@ the License.
           <iron-icon icon="refresh"></iron-icon>
         </paper-button>
         <div class="vseparator"></div>
-        <bread-crumbs crumbs={{_currentCrumbs}}></bread-crumbs>
+        <bread-crumbs id="breadCrumbs" crumbs={{_currentCrumbs}}></bread-crumbs>
         <paper-button id="toggleDetails" class="navbar-button" on-click="_toggleDetailsPane"
                       hidden$="{{small}}">
           <iron-icon icon="visibility"></iron-icon>

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -13,6 +13,7 @@ the License.
 -->
 
 <link rel="import" href="../../components/base-dialog/base-dialog.html">
+<link rel="import" href="../../components/bread-crumbs/bread-crumbs.html">
 <link rel="import" href="../../components/details-pane/details-pane.html">
 <link rel="import" href="../../components/input-dialog/input-dialog.html">
 <link rel="import" href="../../components/item-list/item-list.html">
@@ -134,63 +135,8 @@ the License.
         border-left: 1px solid var(--border-color);
         line-height: 48px;
       }
-      #breadcrumb {
-        user-select: none;
-        list-style: none;
-        display: inline-block;
-        flex-grow: 1;
-      }
-      #breadcrumb div {
-        float: left;
-        height: 100%;
-      }
-      #breadcrumb div a {
-        display: block;
-        background-color: var(--primary-bg-color);
-        text-decoration: none;
-        position: relative;
-        line-height: 46px;
-        margin-right: 25px;
-        height: 100%;
-        color: var(--selection-fg-color);
-      }
-      #breadcrumb div:first-child a {
-        padding-left: 15px;
-      }
-      #breadcrumb div:first-child a:before {
-        border: none;
-      }
-      #breadcrumb div a:before, #breadcrumb div a:after {
-        color: var(--primary-bg-color);
-        content: "";
-        position: absolute;
-        border: 0 solid var(--primary-bg-color);
-        border-width: 24px 12px;
-      }
-      #breadcrumb div a:before {
-        left: -24px;
-        border-left-color: transparent;
-      }
-      #breadcrumb div a:after {
-        left: 100%;
-        border-color: var(--border-color);
-        border-left-color: var(--primary-bg-color);
-      }
-      #breadcrumb div a:hover {
-        background-color: var(--secondary-bg-color);
-      }
-      #breadcrumb div a:hover:before {
-        border-color: var(--secondary-bg-color);
-        border-left-color: transparent;
-      }
-      #breadcrumb div a:hover:after {
-        border-left-color: var(--secondary-bg-color);
-      }
-      #breadcrumb div:nth-last-child(2) a {
-        padding-right: 15px;
-      }
-      #breadcrumb div:nth-last-child(2) a:after {
-        border: none;
+      bread-crumbs {
+        flex: 1 1 auto;
       }
     </style>
 
@@ -288,17 +234,7 @@ the License.
           <iron-icon icon="refresh"></iron-icon>
         </paper-button>
         <div class="vseparator"></div>
-        <div id="breadcrumb">
-          <!--Always show a '/' crumb for home-->
-          <div>
-            <a id="home-crumb" href="#" on-click="_crumbClicked">/</a>
-          </div>
-          <template id="breadcrumbsTemplate" is="dom-repeat" items={{_currentCrumbs}}>
-            <div>
-              <a href="#" on-click="_crumbClicked">{{item}}</a>
-            </div>
-          </template>
-        </div>
+        <bread-crumbs crumbs={{_currentCrumbs}}></bread-crumbs>
         <paper-button id="toggleDetails" class="navbar-button" on-click="_toggleDetailsPane"
                       hidden$="{{small}}">
           <iron-icon icon="visibility"></iron-icon>

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -235,7 +235,7 @@ the License.
           <iron-icon icon="refresh"></iron-icon>
         </paper-button>
         <div class="vseparator"></div>
-        <bread-crumbs id="breadCrumbs" crumbs={{_currentCrumbs}}></bread-crumbs>
+        <bread-crumbs id="breadCrumbs"></bread-crumbs>
         <paper-button id="toggleDetails" class="navbar-button" on-click="_toggleDetailsPane"
                       hidden$="{{small}}">
           <iron-icon icon="visibility"></iron-icon>

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -161,9 +161,11 @@ class FileBrowserElement extends Polymer.Element {
       const index = e.detail.index;
       const pathTokens = this._splitCurrentPath();
       this.currentPath = pathTokens.slice(0, index + 1).join('/');
+      this._pushNewPath();
     });
     this.$.breadCrumbs.addEventListener('rootClicked', () => {
       this.currentPath = '';
+      this._pushNewPath();
     });
 
     // TODO: Using a ready promise might be common enough a need that we should
@@ -247,14 +249,10 @@ class FileBrowserElement extends Polymer.Element {
   /**
    * Updates the breadcrumbs array and calls _fetchFileList.
    */
-  _currentPathChanged(_: string, oldValue: string) {
+  _currentPathChanged() {
     // Ignore inital '/'
     if (this.currentPath.startsWith('/')) {
       this.currentPath = this.currentPath.substr(1);
-    }
-    // Except on initialization, push the current path to path history
-    if (oldValue !== undefined) {
-      this._pushNewPath();
     }
 
     this.$.breadCrumbs.crumbs = this._splitCurrentPath();
@@ -304,6 +302,7 @@ class FileBrowserElement extends Polymer.Element {
     }
     if (clickedItem.type === DatalabFileType.DIRECTORY) {
       this.currentPath = clickedItem.path;
+      this._pushNewPath();
     } else if (clickedItem.type === DatalabFileType.NOTEBOOK) {
       this._getNotebookUrlPrefix()
         .then((prefix) => window.open(prefix + '/' + clickedItem.path, '_blank'));
@@ -867,7 +866,8 @@ class FileBrowserElement extends Polymer.Element {
     (this.$.files as ItemListElement).columns = this.small ? ['Name'] : ['Name', 'Status'];
 
     this._fetching = false;
-    return this._fetchFileList();
+    return this._fetchFileList()
+      .then(() => this._pushNewPath());
   }
 
 }

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -248,8 +248,8 @@ class FileBrowserElement extends Polymer.Element {
    * Updates the breadcrumbs array and calls _fetchFileList.
    */
   _currentPathChanged(_: string, oldValue: string) {
-    // On initialization, push the current path to path history
-    if (oldValue === undefined) {
+    // Except on initialization, push the current path to path history
+    if (oldValue !== undefined) {
       this._pushNewPath();
     }
 
@@ -300,7 +300,6 @@ class FileBrowserElement extends Polymer.Element {
     }
     if (clickedItem.type === DatalabFileType.DIRECTORY) {
       this.currentPath = clickedItem.path;
-      this._pushNewPath();
     } else if (clickedItem.type === DatalabFileType.NOTEBOOK) {
       this._getNotebookUrlPrefix()
         .then((prefix) => window.open(prefix + '/' + clickedItem.path, '_blank'));

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -248,6 +248,10 @@ class FileBrowserElement extends Polymer.Element {
    * Updates the breadcrumbs array and calls _fetchFileList.
    */
   _currentPathChanged(_: string, oldValue: string) {
+    // Ignore inital '/'
+    if (this.currentPath.startsWith('/')) {
+      this.currentPath = this.currentPath.substr(1);
+    }
     // Except on initialization, push the current path to path history
     if (oldValue !== undefined) {
       this._pushNewPath();

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -168,7 +168,7 @@ class FileBrowserElement extends Polymer.Element {
           FileManagerFactory.fileManagerNameToType(this.fileManagerType));
     }
 
-    this.$.breadCrumbs.addEventListener('crumbClicked', (e: CustomEvent) => {
+    this.$.breadCrumbs.addEventListener('crumbClicked', (e: ItemClickEvent) => {
       const index = e.detail.index;
       const pathTokens = this._splitCurrentPath();
       this.currentPath = pathTokens.slice(0, index + 1).join('/');

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -145,6 +145,17 @@ class FileBrowserElement extends Polymer.Element {
 
     super.ready();
 
+    this.$.breadCrumbs.addEventListener('crumbClicked', (e: ItemClickEvent) => {
+      const index = e.detail.index;
+      const pathTokens = this._splitCurrentPath();
+      this.currentPath = pathTokens.slice(0, index + 1).join('/');
+      this._pushNewPath();
+    });
+    this.$.breadCrumbs.addEventListener('rootClicked', () => {
+      this.currentPath = '';
+      this._pushNewPath();
+    });
+
     this._apiManager = ApiManagerFactory.getInstance();
 
     if (!this.fileManagerType) {
@@ -261,14 +272,10 @@ class FileBrowserElement extends Polymer.Element {
   }
 
   _splitCurrentPath() {
-    const pathTokens = this.currentPath.split('/');
-
-    // Splitting a path starting with '/' puts an initial empty element in the array,
-    // which we're not interested in. For example, for /datalab/docs, we only want
-    // ['datalab', 'docs'].
-    if (pathTokens[0] === '') {
-      pathTokens.splice(0, 1);
-    }
+    // When splitting the path, we're not interested in empty elements in the
+    // array that might result from an initial '/', or a double '//'. For
+    // example, for /datalab/docs, we only want ['datalab', 'docs'].
+    const pathTokens = this.currentPath.split('/').filter((p) => !!p);
     return pathTokens;
   }
 

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
@@ -113,7 +113,7 @@ class JupyterFileManager implements FileManager {
       method: 'POST',
       parameters: JSON.stringify({
         ext: 'ipynb',
-        type: itemType,
+        type: this._datalabTypeToJupyterType(itemType),
       }),
       successCodes: [201],
     };
@@ -192,6 +192,19 @@ class JupyterFileManager implements FileManager {
     };
 
     return apiManager.sendRequestAsync(destinationDirectory, xhrOptions);
+  }
+
+  private _datalabTypeToJupyterType(type: DatalabFileType) {
+    switch (type) {
+      case DatalabFileType.DIRECTORY:
+        return 'directory';
+      case DatalabFileType.NOTEBOOK:
+        return 'notebook';
+      case DatalabFileType.FILE:
+        return 'file';
+      default:
+        throw new Error('Unknown file type: ' + type);
+    }
   }
 
   private _jupyterTypeToDatalabType(type: string) {


### PR DESCRIPTION
Breadcrumbs were getting too complex to keep inside the file browser element. Moving them into a separate element allows for more logic, such as hiding overflowing links to the left.

![image](https://user-images.githubusercontent.com/1424661/29248764-cb452bcc-7fd4-11e7-9c3d-4aabfa0b4045.png)
![image](https://user-images.githubusercontent.com/1424661/29248772-e75bfa8e-7fd4-11e7-9fba-5a2c7efae955.png)
