### PR TITLE
Disable Jupyter keyboard bindings in dialogs.

### DIFF
--- a/sources/web/datalab/static/appbar.js
+++ b/sources/web/datalab/static/appbar.js
@@ -118,7 +118,8 @@ define(['idle-timeout', 'util'], function(idleTimeout, util) {
       var dialogOptions = {
         title: 'About Google Cloud Datalab',
         body: $(dialogContent),
-        buttons: { 'OK': {} }
+        buttons: { 'OK': {} },
+        keyboard_manager: IPython.keyboard_manager,
       };
       dialog.modal(dialogOptions);
     }
@@ -205,7 +206,8 @@ define(['idle-timeout', 'util'], function(idleTimeout, util) {
         dialog.modal({
           title: 'Settings',
           body: $(markup),
-          buttons: { Close: {} }
+          buttons: { Close: {} },
+          keyboard_manager: IPython.keyboard_manager,
         });
       });
     });

--- a/sources/web/datalab/static/idle-timeout.js
+++ b/sources/web/datalab/static/idle-timeout.js
@@ -53,6 +53,7 @@ define(['base/js/dialog', 'base/js/events', 'util'], function(dialog, events, ut
       title: 'Idle timeout exceeded',
       body: shutdownMsg,
       buttons: { 'Close': {} },
+      keyboard_manager: IPython.keyboard_manager,
     });
     timeoutInfo.enabled = false;  // Don't show this message more than once.
   }

--- a/sources/web/datalab/static/notebook-list.js
+++ b/sources/web/datalab/static/notebook-list.js
@@ -91,7 +91,8 @@ define(['util'], (util) => {
                       .text(e.message || e)),
               buttons: {
                 OK: { 'class': 'btn-primary' }
-              }
+              },
+              keyboard_manager: IPython.keyboard_manager,
           });
         });
       e.target.blur();


### PR DESCRIPTION
This fixes the problem where some keys, such as 0, would not work in dialogs, such as the idle timeout field in the settings dialog, when used in a notebook tab.