### PR TITLE
Improve idle shutdown message, change minimum to 5m.

### DIFF
--- a/sources/web/datalab/idleTimeout.ts
+++ b/sources/web/datalab/idleTimeout.ts
@@ -24,7 +24,7 @@ import url = require('url');
 import userManager = require('./userManager');
 
 const idleCheckIntervalSeconds = 10;    // Seconds to wait between idle checks
-const idleTimeoutMinSeconds = 60;   // Don't allow setting a timeout less than one minute
+const idleTimeoutMinSeconds = 300;   // Don't allow setting a timeout less than 5 minutes
 
 let idleTimeoutEnabled = true;  // Allow user to enable and disable the timeout
 let idleTimeoutSeconds = 0;   // Shutdown after being idle this long; turned off if 0 or NaN

--- a/sources/web/datalab/static/idle-timeout.js
+++ b/sources/web/datalab/static/idle-timeout.js
@@ -48,7 +48,8 @@ define(['base/js/dialog', 'base/js/events', 'util'], function(dialog, events, ut
   function _alertIdleShutdown() {
     util.debug.log('Idle timeout exceeded');
     const shutdownMsg = ('The datalab server shut down after exceeding the idle timeout of ' +
-        _secondsToString(timeoutInfo.idleTimeoutSeconds));
+        _secondsToString(timeoutInfo.idleTimeoutSeconds) +
+        '.\nUse the "datalab connect" command to restart it and reconnect.');
     dialog.modal({
       title: 'Idle timeout exceeded',
       body: shutdownMsg,


### PR DESCRIPTION
This is how the dialog now appears after the client detects that the server has shut down:
![idle-timeout-shutdown-message](https://user-images.githubusercontent.com/116825/29288869-506e71bc-80ef-11e7-932f-46ecca20d474.png)
