### PR TITLE
Add down-arrow by Kernel choice, show ellipsis when it is changing.

### DIFF
--- a/sources/web/datalab/static/notebook-app.js
+++ b/sources/web/datalab/static/notebook-app.js
@@ -80,13 +80,21 @@ define(['appbar', 'minitoolbar', 'idle-timeout', 'util'], function(appbar, minit
           Jupyter.notebook.undelete_cell.bind(Jupyter.notebook))
     });
 
+    datalab.set_kernel = (newKernel) => {
+      const currentKernal = Jupyter.notebook.kernel.name;
+      if (newKernel !== currentKernal) {
+        $('#currentKernelName').text('...');
+        Jupyter.kernelselector.set_kernel(newKernel);
+      }
+    };
+
     events.on('kernel_connected.Kernel', function() {
       $('#currentKernelName').text(Jupyter.kernelselector.current_selection);
       $('#kernelSelectorDropdown').empty();
       Object.keys(Jupyter.kernelselector.kernelspecs).forEach(function(kernel) {
         $('#kernelSelectorDropdown').append(`
           <li>
-            <a href="#" onclick="Jupyter.kernelselector.set_kernel('` + kernel + `')">
+            <a href="#" onclick="datalab.set_kernel('` + kernel + `')">
               ` + kernel + `
             </a>
           </li>

--- a/sources/web/datalab/templates/nb.html
+++ b/sources/web/datalab/templates/nb.html
@@ -168,6 +168,7 @@
                 <i class="material-icons">track_changes</i>
                 <span class="toolbar-text">Kernel: </span>
                 <span id="currentKernelName"></span>
+                <span class="caret"></span>
               </button>
               <ul class="dropdown-menu" id="kernelSelectorDropdown">
               </ul>


### PR DESCRIPTION
This PR adds a caret to the right of the kernel name in the notebook tool bar to indicate that there is a drop-down choicelist:
![kernel-caret](https://user-images.githubusercontent.com/116825/29294102-8aa6e266-8102-11e7-804d-03bc0e00d35a.png)

When the user selects an item from that choicelist to switch kernels, the kernel name is replaced by "..." until the new kernel connects.
