### PR TITLE
Add datalab-icons element for SVGs

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-icons/datalab-icons.html
+++ b/sources/web/datalab/polymer/components/datalab-icons/datalab-icons.html
@@ -1,0 +1,28 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../bower_components/iron-iconset-svg/iron-iconset-svg.html">
+
+<iron-iconset-svg name="datalab-icons">
+  <svg>
+    <defs>
+      <g id="bq-project">
+        <path d="M10.557 11.99l-1.71-2.966 1.71-3.015h3.42l1.71 3.01-1.71
+        2.964h-3.42zM4.023 16l-1.71-2.966 1.71-3.015h3.42l1.71 3.01L7.443
+        16h-3.42zm0-8.016l-1.71-2.966 1.71-3.015h3.42l1.71 3.015-1.71
+        2.966h-3.42z" />
+      </g>
+    </defs>
+  </svg>
+</iron-iconset-svg>


### PR DESCRIPTION
This can contain any SVG icons we want to add for upcoming work.
For now it only has one icon as an example, for BigQuery project.