### PR TITLE
Remove dynamic loading for ApiManager elements

### DIFF
--- a/sources/web/datalab/polymer/modules/api-manager-factory/api-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/api-manager-factory/api-manager-factory.ts
@@ -17,11 +17,9 @@
  */
 const API_MANAGER_ELEMENT = {
   daas: {
-    path: 'modules/daas-api-manager/daas-api-manager.html',
     type: DaasApiManager,
   },
   jupyter: {
-    path: 'modules/jupyter-api-manager/jupyter-api-manager.html',
     type: JupyterApiManager
   },
 };
@@ -38,8 +36,7 @@ class ApiManagerFactory {
   public static getInstance() {
     if (!ApiManagerFactory._apiManager) {
       const backendType = ApiManagerFactory._getBackendType();
-
-      Polymer.importHref(backendType.path, undefined, undefined, true);
+      // TODO: Consider loading the api manager elements dynamically on demand
       ApiManagerFactory._apiManager = new backendType.type();
     }
 


### PR DESCRIPTION
Fixes https://github.com/googledatalab/datalab/issues/1581.

So far, we haven't needed the lazy loading optimization of ApiManager elements, removing it for now.