### PR TITLE
Make table-preview work in file-browser details-pane.

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -14,8 +14,8 @@ the License.
 
 <link rel="import" href="../../components/base-dialog/base-dialog.html">
 <link rel="import" href="../../components/bread-crumbs/bread-crumbs.html">
-<link rel="import" href="../../components/details-pane/details-pane.html">
 <link rel="import" href="../../components/input-dialog/input-dialog.html">
+<link rel="import" href="../../components/preview-pane/preview-pane.html">
 <link rel="import" href="../../components/item-list/item-list.html">
 <link rel="import" href="../../components/resizable-divider/resizable-divider.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
@@ -125,15 +125,15 @@ the License.
         flex: 1 1 auto;
         background-color: var(--primary-bg-color);
       }
-      #detailsPane {
+      #previewPane {
         background-color: var(--secondary-bg-color);
         box-shadow: inset 4px 0px 10px -3px rgba(0, 0, 0, 0.1);
         transition: width var(--app-animation-duration);
       }
-      .details-pane-enabled--true {
+      .preview-pane-enabled--true {
         width: var(--preview-pane-width);
       }
-      .details-pane-enabled--false {
+      .preview-pane-enabled--false {
         width: 0px;
       }
       .vseparator {
@@ -241,7 +241,7 @@ the License.
         </paper-button>
         <div class="vseparator"></div>
         <bread-crumbs id="breadCrumbs"></bread-crumbs>
-        <paper-button id="toggleDetails" class="navbar-button" on-click="_toggleDetailsPane"
+        <paper-button id="togglePreview" class="navbar-button" on-click="_togglePreviewPane"
                       hidden$="{{small}}">
           <iron-icon icon="visibility"></iron-icon>
         </paper-button>
@@ -254,9 +254,9 @@ the License.
       <!--File listing-->
       <div class="files-container">
         <item-list id="files" hide-header$="{{small}}" disable-selection$="{{small}}"></item-list>
-        <details-pane id="detailsPane" file="{{selectedFile}}" active="{{_isDetailsPaneEnabled}}"
-                      class$="details-pane-enabled--{{_isDetailsPaneEnabled}}">
-        </details-pane>
+        <preview-pane id="previewPane" file="{{selectedFile}}" active="{{_isPreviewPaneEnabled}}"
+                      class$="preview-pane-enabled--{{_isPreviewPaneEnabled}}">
+        </preview-pane>
       </div>
     </div>
 

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -17,6 +17,7 @@ the License.
 <link rel="import" href="../../components/details-pane/details-pane.html">
 <link rel="import" href="../../components/input-dialog/input-dialog.html">
 <link rel="import" href="../../components/item-list/item-list.html">
+<link rel="import" href="../../components/resizable-divider/resizable-divider.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 <link rel="import" href="../../modules/api-manager-factory/api-manager-factory.html">
 <link rel="import" href="../../modules/file-manager-factory/file-manager-factory.html">
@@ -42,6 +43,10 @@ the License.
         font-family: var(--app-content-font-family);
         font-size: var(--app-content-font-size);
         color: var(--primary-fg-color);
+      }
+      resizable-divider {
+        width: 100%;
+        height: 100%;
       }
       #toolbar {
         flex: 0 0 var(--toolbar-height);
@@ -252,7 +257,6 @@ the License.
         <details-pane id="detailsPane" file="{{selectedFile}}" active="{{_isDetailsPaneEnabled}}"
                       class$="details-pane-enabled--{{_isDetailsPaneEnabled}}">
         </details-pane>
-        </div>
       </div>
     </div>
 

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -15,7 +15,6 @@ the License.
 <link rel="import" href="../../components/base-dialog/base-dialog.html">
 <link rel="import" href="../../components/bread-crumbs/bread-crumbs.html">
 <link rel="import" href="../../components/datalab-page/datalab-page.html">
-<link rel="import" href="../../components/details-pane/details-pane.html">
 <link rel="import" href="../../components/input-dialog/input-dialog.html">
 <link rel="import" href="../../components/preview-pane/preview-pane.html">
 <link rel="import" href="../../components/item-list/item-list.html">

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -68,14 +68,14 @@ class FileBrowserElement extends Polymer.Element {
 
   private _addToolbarCollapseThreshold = 900;
   private _apiManager: ApiManager;
-  private _detailsPaneCollapseThreshold = 600;
+  private _previewPaneCollapseThreshold = 600;
   private _fetching: boolean;
   private _fileList: DatalabFile[];
   private _fileListFetchPromise: Promise<any>;
   private _fileListRefreshInterval = 60 * 1000;
   private _fileListRefreshIntervalHandle = 0;
   private _fileManager: FileManager;
-  private _isDetailsPaneToggledOn: boolean;
+  private _isPreviewPaneToggledOn: boolean;
   private _pathHistory: DatalabFile[];
   private _pathHistoryIndex: number;
   private _updateToolbarCollapseThreshold = 720;
@@ -93,11 +93,11 @@ class FileBrowserElement extends Polymer.Element {
         type: Array,
         value: () => [],
       },
-      _isDetailsPaneEnabled: {
-        computed: '_getDetailsPaneEnabled(small, _isDetailsPaneToggledOn)',
+      _isPreviewPaneEnabled: {
+        computed: '_getPreviewPaneEnabled(small, _isPreviewPaneToggledOn)',
         type: Boolean,
       },
-      _isDetailsPaneToggledOn: {
+      _isPreviewPaneToggledOn: {
         type: Boolean,
         value: true,
       },
@@ -625,19 +625,19 @@ class FileBrowserElement extends Polymer.Element {
   }
 
   /**
-   * Computes whether the details pane should be enabled. This depends on two values:
+   * Computes whether the preview pane should be enabled. This depends on two values:
    * whether the element has the small attribute, and whether the user has switched it
    * off manually.
    */
-  _getDetailsPaneEnabled(small: boolean, toggledOn: boolean) {
+  _getPreviewPaneEnabled(small: boolean, toggledOn: boolean) {
     return !small && toggledOn;
   }
 
   /**
-   * Switches details pane on or off.
+   * Switches preview pane on or off.
    */
-  _toggleDetailsPane() {
-    this._isDetailsPaneToggledOn = !this._isDetailsPaneToggledOn;
+  _togglePreviewPane() {
+    this._isPreviewPaneToggledOn = !this._isPreviewPaneToggledOn;
   }
 
   /**
@@ -756,9 +756,9 @@ class FileBrowserElement extends Polymer.Element {
       this.$.altUpdateToolbar.close();
     }
 
-    // Collapse the details pane
-    if (width < this._detailsPaneCollapseThreshold) {
-      this._isDetailsPaneToggledOn = false;
+    // Collapse the preview pane
+    if (width < this._previewPaneCollapseThreshold) {
+      this._isPreviewPaneToggledOn = false;
     }
   }
 

--- a/sources/web/datalab/polymer/components/notebook-preview/notebook-preview.html
+++ b/sources/web/datalab/polymer/components/notebook-preview/notebook-preview.html
@@ -12,37 +12,30 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
-<link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
-
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 <link rel="import" href="../../modules/file-manager-factory/file-manager-factory.html">
 
-<dom-module id="details-pane">
+<dom-module id="notebook-preview">
   <template>
     <style include="datalab-shared-styles">
-      #container {
-        height: 100%;
+      #previewHtml {
+        background-color: var(--primary-bg-color);
+        padding: 10px;
+        margin: 10px;
         overflow-y: auto;
-        display: flex;
-        flex-direction: column;
+        overflow-x: hidden;
+        box-shadow: 5px 5px 10px -3px rgba(0, 0, 0, 0.1);
       }
-      .placeholder {
+      .message {
         padding: 15px;
         text-align: center;
         color: #777;
       }
     </style>
-    <div id="container" hidden$="{{!file}}">
-      <iron-pages id="preview" selected="{{preview}}" attr-for-selected="name">
-        <notebook-preview class="preview" name="notebook" file="{{file}}" active="{{active}}"></notebook-preview>
-        <table-preview class="preview" name="table" file="{{file}}" active="{{active}}"></table-preview>
-        <text-preview class="preview" name="text" file="{{file}}" active="{{active}}"></text-preview>
-      </iron-pages>
-      <div class="placeholder">
-        {{_message}}
-      </div>
-    </div>
+    <div id="previewHtml"></div>
+    <div class="message">{{_message}}</div>
   </template>
 </dom-module>
 
-<script src="details-pane.js"></script>
+<script src="../../bower_components/marked/lib/marked.js"></script>
+<script src="notebook-preview.js"></script>

--- a/sources/web/datalab/polymer/components/notebook-preview/notebook-preview.ts
+++ b/sources/web/datalab/polymer/components/notebook-preview/notebook-preview.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+// Instead of writing a .d.ts file containing this one line.
+declare function marked(markdown: string): string;
+
+/**
+ * Notebook preview element for Datalab.
+ */
+class NotebookPreviewElement extends Polymer.Element {
+
+  private static _noFileMessage = 'Select an item to view its details.';
+  private static _emptyNotebookMessage = 'Empty notebook.';
+  private static _longNotebookMessage = 'Showing markdown from the first two.';
+
+  /**
+   * File whose details to show.
+   */
+  public file: DatalabFile;
+
+  /**
+   * Whether the pane is actively tracking selected items. This is used to avoid fetching the
+   * selected file's data if the pane is closed by the host element.
+   */
+  public active: boolean;
+
+  private _message = '';
+
+  static get is() { return 'notebook-preview'; }
+
+  static get properties() {
+    return {
+      _message: {
+        type: String,
+        value: '',
+      },
+      active: {
+        observer: '_reloadDetails',
+        type: Boolean,
+        value: true,
+      },
+      file: {
+        observer: '_reloadDetails',
+        type: Object,
+        value: {},
+      },
+    };
+  }
+
+  /**
+   * Loads the details of the given file in the details pane. No preview is shown if the
+   * selected item is a directory. For notebooks, the first two cells are pulled from the file,
+   * and any markdown they contain is rendered in the pane. For now, we also support other
+   * plain text files with mime type text/*, and JSON files.
+   *
+   * TODO: Consider adding a spinning animation while this data loads.
+   */
+  _reloadDetails() {
+    if (!this.file || !this.active) {
+      this._message = NotebookPreviewElement._noFileMessage;
+      return;
+    }
+
+    if (this.file.type === DatalabFileType.NOTEBOOK) {
+      const fileManager = FileManagerFactory.getInstanceForType(this.file.id.source);
+      fileManager.getContent(this.file.id)
+        .then((content: DatalabContent) => {
+
+          // If this is a notebook, get the first two cells and render any markdown in them.
+          if (content instanceof NotebookContent) {
+            if (content.cells.length === 0) {
+              this.$.previewHtml.innerHTML = '';
+              this._message = NotebookPreviewElement._emptyNotebookMessage;
+            } else {
+              const firstTwoCells = content.cells.slice(0, 2);
+
+              let markdownHtml = '';
+              firstTwoCells.forEach((cell) => {
+                if (cell.cell_type === 'markdown') {
+                  markdownHtml += marked(cell.source);
+                }
+              });
+              this.$.previewHtml.innerHTML = markdownHtml;
+              this._message = ' Notebook with ' + content.cells.length + ' cells. ';
+              if (content.cells.length > 2) {
+                this._message += NotebookPreviewElement._longNotebookMessage;
+              }
+            }
+          }
+        })
+        .catch(() => {
+          this.$.previewHtml.innerHTML = '';
+          this._message = '';
+          Utils.log.error('Could not get item details.');
+        });
+    } else {
+      this.$.previewHtml.innerHTML = '';
+      this._message = '';
+    }
+  }
+
+}
+
+customElements.define(NotebookPreviewElement.is, NotebookPreviewElement);

--- a/sources/web/datalab/polymer/components/preview-pane/preview-pane.html
+++ b/sources/web/datalab/polymer/components/preview-pane/preview-pane.html
@@ -17,7 +17,7 @@ the License.
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 <link rel="import" href="../../modules/file-manager-factory/file-manager-factory.html">
 
-<dom-module id="details-pane">
+<dom-module id="preview-pane">
   <template>
     <style include="datalab-shared-styles">
       #container {
@@ -38,11 +38,11 @@ the License.
         <table-preview class="preview" name="table" file="{{file}}" active="{{active}}"></table-preview>
         <text-preview class="preview" name="text" file="{{file}}" active="{{active}}"></text-preview>
       </iron-pages>
-      <div class="placeholder">
-        {{_message}}
+      <div class="placeholder" hidden$="{{file}}">
+        Select an item to view a preview.
       </div>
     </div>
   </template>
 </dom-module>
 
-<script src="details-pane.js"></script>
+<script src="preview-pane.js"></script>

--- a/sources/web/datalab/polymer/components/preview-pane/preview-pane.ts
+++ b/sources/web/datalab/polymer/components/preview-pane/preview-pane.ts
@@ -16,13 +16,11 @@
 declare function marked(markdown: string): string;
 
 /**
- * Details pane element for Datalab.
+ * Preview pane element for Datalab.
  * This element is designed to be displayed in a side bar that displays more
  * information about a selected file.
  */
-class DetailsPaneElement extends Polymer.Element {
-
-  private static _noFileMessage = 'Select an item to view its details.';
+class PreviewPaneElement extends Polymer.Element {
 
   /**
    * Currently displayed preview pane.
@@ -30,7 +28,7 @@ class DetailsPaneElement extends Polymer.Element {
   public preview: string;
 
   /**
-   * File whose details to show.
+   * File whose preview to show.
    */
   public file: DatalabFile;
 
@@ -40,23 +38,17 @@ class DetailsPaneElement extends Polymer.Element {
    */
   public active: boolean;
 
-  private _message = ''; // To show in the placeholder field.
-
-  static get is() { return 'details-pane'; }
+  static get is() { return 'preview-pane'; }
 
   static get properties() {
     return {
-      _message: {
-        type: String,
-        value: '',
-      },
       active: {
-        observer: '_reloadDetails',
+        observer: '_reloadPreview',
         type: Boolean,
         value: true,
       },
       file: {
-        observer: '_reloadDetails',
+        observer: '_reloadPreview',
         type: Object,
         value: {},
       },
@@ -67,22 +59,15 @@ class DetailsPaneElement extends Polymer.Element {
     };
   }
 
-  ready() {
-    this._message = DetailsPaneElement._noFileMessage;
-    super.ready();
-  }
-
   /**
    * Shows a preview of the selected file for known file types.
    *
    * TODO: Consider adding a spinning animation while this data loads.
    */
-  _reloadDetails() {
+  _reloadPreview() {
     if (!this.file || !this.active) {
-      this._message = DetailsPaneElement._noFileMessage;
       return;
     }
-    this._message = '';
 
     this.preview = this.file.getPreviewName();
 
@@ -94,4 +79,4 @@ class DetailsPaneElement extends Polymer.Element {
   }
 }
 
-customElements.define(DetailsPaneElement.is, DetailsPaneElement);
+customElements.define(PreviewPaneElement.is, PreviewPaneElement);

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.ts
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.ts
@@ -25,8 +25,9 @@ class TablePreviewElement extends Polymer.Element {
   /**
    * File whose details to show.
    */
-  public file: DatalabFile;
+  public file: BigQueryFile;
 
+  // TODO(jimmc) - once datalab-data is deleted, make this private
   /**
    * Id for table whose preview to show.
    */
@@ -93,6 +94,7 @@ class TablePreviewElement extends Polymer.Element {
 
   _fileChanged() {
     if (this.file && this.file.id) {
+      // TODO(jimmc) - move this into BigQueryFile?
       const path = this.file.id.path;
       const parts = path.split('/');
       this.tableId = parts[0] + ':' + parts[1] + '.' + parts[2];

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.ts
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.ts
@@ -23,6 +23,11 @@
 class TablePreviewElement extends Polymer.Element {
 
   /**
+   * File whose details to show.
+   */
+  public file: DatalabFile;
+
+  /**
    * Id for table whose preview to show.
    */
   public tableId: string;
@@ -45,6 +50,11 @@ class TablePreviewElement extends Polymer.Element {
       creationTime: {
         computed: '_computeCreationTime(_table)',
         type: String,
+      },
+      file: {
+        observer: '_fileChanged',
+        type: Object,
+        value: {},
       },
       lastModifiedTime: {
         computed: '_computeLastModifiedTime(_table)',
@@ -79,6 +89,16 @@ class TablePreviewElement extends Polymer.Element {
 
     this._apiManager = ApiManagerFactory.getInstance();
     this._fileManager = FileManagerFactory.getInstance();
+  }
+
+  _fileChanged() {
+    if (this.file && this.file.id) {
+      const path = this.file.id.path;
+      const parts = path.split('/');
+      this.tableId = parts[0] + ':' + parts[1] + '.' + parts[2];
+    } else {
+      this.tableId = '';
+    }
   }
 
   _tableIdChanged() {

--- a/sources/web/datalab/polymer/components/text-preview/text-preview.html
+++ b/sources/web/datalab/polymer/components/text-preview/text-preview.html
@@ -12,37 +12,29 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
-<link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
-
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 <link rel="import" href="../../modules/file-manager-factory/file-manager-factory.html">
 
-<dom-module id="details-pane">
+<dom-module id="text-preview">
   <template>
     <style include="datalab-shared-styles">
-      #container {
-        height: 100%;
+      #previewHtml {
+        background-color: var(--primary-bg-color);
+        padding: 10px;
+        margin: 10px;
         overflow-y: auto;
-        display: flex;
-        flex-direction: column;
+        overflow-x: hidden;
+        box-shadow: 5px 5px 10px -3px rgba(0, 0, 0, 0.1);
       }
-      .placeholder {
+      .message {
         padding: 15px;
         text-align: center;
         color: #777;
       }
     </style>
-    <div id="container" hidden$="{{!file}}">
-      <iron-pages id="preview" selected="{{preview}}" attr-for-selected="name">
-        <notebook-preview class="preview" name="notebook" file="{{file}}" active="{{active}}"></notebook-preview>
-        <table-preview class="preview" name="table" file="{{file}}" active="{{active}}"></table-preview>
-        <text-preview class="preview" name="text" file="{{file}}" active="{{active}}"></text-preview>
-      </iron-pages>
-      <div class="placeholder">
-        {{_message}}
-      </div>
-    </div>
+    <div id="previewHtml"></div>
+    <div class="message">{{_message}}</div>
   </template>
 </dom-module>
 
-<script src="details-pane.js"></script>
+<script src="text-preview.js"></script>

--- a/sources/web/datalab/polymer/components/text-preview/text-preview.ts
+++ b/sources/web/datalab/polymer/components/text-preview/text-preview.ts
@@ -18,13 +18,13 @@
 class TextPreviewElement extends Polymer.Element {
 
   private static _maxLinesInTextSummary = 30;
-  private static _noFileMessage = 'Select an item to view its details.';
+  private static _noFileMessage = 'Select an item to view a preview.';
   private static _emptyFileMessage = 'Empty file.';
   private static _longFileMessage = 'Showing the first ' +
       TextPreviewElement._maxLinesInTextSummary + '.';
 
   /**
-   * File whose details to show.
+   * File whose preview to show.
    */
   public file: DatalabFile;
 
@@ -45,12 +45,12 @@ class TextPreviewElement extends Polymer.Element {
         value: '',
       },
       active: {
-        observer: '_reloadDetails',
+        observer: '_reloadPreview',
         type: Boolean,
         value: true,
       },
       file: {
-        observer: '_reloadDetails',
+        observer: '_reloadPreview',
         type: Object,
         value: {},
       },
@@ -60,61 +60,41 @@ class TextPreviewElement extends Polymer.Element {
   /**
    * Previews a text file.
    */
-  _reloadDetails() {
+  _reloadPreview() {
     if (!this.file || !this.active) {
+      this.$.previewHtml.innerHTML = '';
       this._message = TextPreviewElement._noFileMessage;
       return;
     }
 
-    if (this._isPlainTextFile(this.file)) {
-      const fileManager = FileManagerFactory.getInstanceForType(this.file.id.source);
-      fileManager.getContent(this.file.id)
-        .then((content: DatalabContent) => {
+    const fileManager = FileManagerFactory.getInstanceForType(this.file.id.source);
+    fileManager.getContent(this.file.id)
+      .then((content: DatalabContent) => {
 
-          // If this is a text file, show the first N lines.
-          if (content instanceof TextContent) {
+        // If this is a text file, show the first N lines.
+        if (content instanceof TextContent) {
 
-            if (content.text.trim() === '') {
-              this.$.previewHtml.innerHTML = '';
-              this._message = TextPreviewElement._emptyFileMessage;
-            } else {
-              const lines = content.text.split('\n');
-              this._message = 'File with ' + lines.length + ' lines. ';
-              this.$.previewHtml.innerText = '\n' +
-                  lines.slice(0, TextPreviewElement._maxLinesInTextSummary).join('\n') +
-                  '\n';
-              if (lines.length > TextPreviewElement._maxLinesInTextSummary) {
-                this.$.previewHtml.innerText += '...\n\n';
-                this._message += TextPreviewElement._longFileMessage;
-              }
+          if (content.text.trim() === '') {
+            this.$.previewHtml.innerHTML = '';
+            this._message = TextPreviewElement._emptyFileMessage;
+          } else {
+            const lines = content.text.split('\n');
+            this._message = 'File with ' + lines.length + ' lines. ';
+            this.$.previewHtml.innerText = '\n' +
+                lines.slice(0, TextPreviewElement._maxLinesInTextSummary).join('\n') +
+                '\n';
+            if (lines.length > TextPreviewElement._maxLinesInTextSummary) {
+              this.$.previewHtml.innerText += '...\n\n';
+              this._message += TextPreviewElement._longFileMessage;
             }
           }
-        })
-        .catch(() => {
-          this.$.previewHtml.innerHTML = '';
-          this._message = '';
-          Utils.log.error('Could not get item details.');
-        });
-    } else {
-      this.$.previewHtml.innerHTML = '';
-      this._message = '';
-    }
-  }
-
-  /**
-   * Returns true if the contents of this file can be read as plain text.
-   * @param file object for the file whose details to display.
-   */
-  _isPlainTextFile(file: DatalabFile) {
-    if (file instanceof JupyterFile) {
-      return file &&
-            file.mimetype && (
-              file.mimetype.indexOf('text/') > -1 ||
-              file.mimetype.indexOf('application/json') > -1
-            );
-    } else {
-      return false;
-    }
+        }
+      })
+      .catch(() => {
+        this.$.previewHtml.innerHTML = '';
+        this._message = '';
+        Utils.log.error('Could not get text preview.');
+      });
   }
 
 }

--- a/sources/web/datalab/polymer/components/text-preview/text-preview.ts
+++ b/sources/web/datalab/polymer/components/text-preview/text-preview.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Text preview element for Datalab.
+ */
+class TextPreviewElement extends Polymer.Element {
+
+  private static _maxLinesInTextSummary = 30;
+  private static _noFileMessage = 'Select an item to view its details.';
+  private static _emptyFileMessage = 'Empty file.';
+  private static _longFileMessage = 'Showing the first ' +
+      TextPreviewElement._maxLinesInTextSummary + '.';
+
+  /**
+   * File whose details to show.
+   */
+  public file: DatalabFile;
+
+  /**
+   * Whether the pane is actively tracking selected items. This is used to avoid fetching the
+   * selected file's data if the pane is closed by the host element.
+   */
+  public active: boolean;
+
+  private _message = '';
+
+  static get is() { return 'text-preview'; }
+
+  static get properties() {
+    return {
+      _message: {
+        type: String,
+        value: '',
+      },
+      active: {
+        observer: '_reloadDetails',
+        type: Boolean,
+        value: true,
+      },
+      file: {
+        observer: '_reloadDetails',
+        type: Object,
+        value: {},
+      },
+    };
+  }
+
+  /**
+   * Previews a text file.
+   */
+  _reloadDetails() {
+    if (!this.file || !this.active) {
+      this._message = TextPreviewElement._noFileMessage;
+      return;
+    }
+
+    if (this._isPlainTextFile(this.file)) {
+      const fileManager = FileManagerFactory.getInstanceForType(this.file.id.source);
+      fileManager.getContent(this.file.id)
+        .then((content: DatalabContent) => {
+
+          // If this is a text file, show the first N lines.
+          if (content instanceof TextContent) {
+
+            if (content.text.trim() === '') {
+              this.$.previewHtml.innerHTML = '';
+              this._message = TextPreviewElement._emptyFileMessage;
+            } else {
+              const lines = content.text.split('\n');
+              this._message = 'File with ' + lines.length + ' lines. ';
+              this.$.previewHtml.innerText = '\n' +
+                  lines.slice(0, TextPreviewElement._maxLinesInTextSummary).join('\n') +
+                  '\n';
+              if (lines.length > TextPreviewElement._maxLinesInTextSummary) {
+                this.$.previewHtml.innerText += '...\n\n';
+                this._message += TextPreviewElement._longFileMessage;
+              }
+            }
+          }
+        })
+        .catch(() => {
+          this.$.previewHtml.innerHTML = '';
+          this._message = '';
+          Utils.log.error('Could not get item details.');
+        });
+    } else {
+      this.$.previewHtml.innerHTML = '';
+      this._message = '';
+    }
+  }
+
+  /**
+   * Returns true if the contents of this file can be read as plain text.
+   * @param file object for the file whose details to display.
+   */
+  _isPlainTextFile(file: DatalabFile) {
+    if (file instanceof JupyterFile) {
+      return file &&
+            file.mimetype && (
+              file.mimetype.indexOf('text/') > -1 ||
+              file.mimetype.indexOf('application/json') > -1
+            );
+    } else {
+      return false;
+    }
+  }
+
+}
+
+customElements.define(TextPreviewElement.is, TextPreviewElement);

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -13,15 +13,6 @@
  */
 
 class BigQueryFile extends DatalabFile {
-  constructor(obj: DatalabFile) {
-    super();
-    this.icon = obj.icon;
-    this.name = obj.name;
-    this.id = obj.id;
-    this.status = obj.status;
-    this.type = obj.type;
-  }
-
   public getPreviewName(): string {
     if (this.type == DatalabFileType.FILE) {
       return 'table';

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -13,6 +13,21 @@
  */
 
 class BigQueryFile extends DatalabFile {
+  constructor(obj: DatalabFile) {
+    super();
+    this.icon = obj.icon;
+    this.name = obj.name;
+    this.id = obj.id;
+    this.status = obj.status;
+    this.type = obj.type;
+  }
+
+  public getPreviewName(): string {
+    if (this.type == DatalabFileType.FILE) {
+      return 'table';
+    }
+    return '';
+  }
 }
 
 /**
@@ -118,46 +133,46 @@ class BigQueryFileManager implements FileManager {
 
   private _bqRootDatalabFile(): DatalabFile {
     const path = '/';
-    return {
+    return new BigQueryFile({
       icon: '',
       id: new DatalabFileId(path, FileManagerType.BIG_QUERY),
       name: '/',
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.FILE,
-    } as DatalabFile;
+    } as DatalabFile);
   }
 
   private _bqProjectToDatalabFile(bqProject: gapi.client.bigquery.ProjectResource): DatalabFile {
     const path = bqProject.projectReference.projectId;
-    return {
+    return new BigQueryFile({
       icon: 'datalab-icons:bq-project',
       id: new DatalabFileId(path, FileManagerType.BIG_QUERY),
       name: bqProject.projectReference.projectId,
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
-    } as DatalabFile;
+    } as DatalabFile);
   }
 
   private _bqDatasetToDatalabFile(bqDataset: gapi.client.bigquery.DatasetResource): DatalabFile {
     const path = bqDataset.datasetReference.projectId + '/' + bqDataset.datasetReference.datasetId;
-    return {
+    return new BigQueryFile({
       icon: 'folder',   // TODO(jimmc) - make a custom icon
       id: new DatalabFileId(path, FileManagerType.BIG_QUERY),
       name: bqDataset.datasetReference.datasetId,
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
-    } as DatalabFile;
+    } as DatalabFile);
   }
 
   private _bqTableToDatalabFile(bqTable: gapi.client.bigquery.TableResource): DatalabFile {
     const path = bqTable.tableReference.projectId + '/' +
           bqTable.tableReference.datasetId + '/' + bqTable.tableReference.tableId;
-    return {
+    return new BigQueryFile({
       icon: 'list',   // TODO(jimmc) - make a custom icon
       id: new DatalabFileId(path, FileManagerType.BIG_QUERY),
       name: bqTable.tableReference.tableId,
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.FILE,
-    } as DatalabFile;
+    } as DatalabFile);
   }
 }

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -28,7 +28,7 @@ class DriveFileManager implements FileManager {
   private static readonly _directoryMimeType = 'application/vnd.google-apps.folder';
 
   private static _upstreamToDriveFile(file: gapi.client.drive.File) {
-    const datalabFile: DriveFile = {
+    const datalabFile: DriveFile = new DriveFile({
       icon: file.iconLink,
       id: new DatalabFileId(file.id, FileManagerType.DRIVE),
       name: file.name,
@@ -36,7 +36,7 @@ class DriveFileManager implements FileManager {
       type: file.mimeType === DriveFileManager._directoryMimeType ?
                               DatalabFileType.DIRECTORY :
                               DatalabFileType.FILE,
-    };
+    } as DatalabFile);
     return datalabFile;
   }
   public get(_fileId: DatalabFileId): Promise<DatalabFile> {

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -131,6 +131,16 @@ abstract class DatalabFile {
   status?: DatalabFileStatus;
   type: DatalabFileType;
 
+  constructor(obj?: DatalabFile) {
+    if (obj) {
+      this.icon = obj.icon;
+      this.name = obj.name;
+      this.id = obj.id;
+      this.status = obj.status;
+      this.type = obj.type;
+    }
+  }
+
   public getPreviewName(): string {
     if (this.type == DatalabFileType.NOTEBOOK) {
       return 'notebook';

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -130,6 +130,13 @@ abstract class DatalabFile {
   name: string;
   status?: DatalabFileStatus;
   type: DatalabFileType;
+
+  public getPreviewName(): string {
+    if (this.type == DatalabFileType.NOTEBOOK) {
+      return 'notebook';
+    }
+    return '';
+  }
 }
 
 interface FileManager {

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
@@ -25,6 +25,20 @@ class JupyterFile extends DatalabFile {
   mimetype?: string;
   path: string;
   writable?: boolean;
+
+  public getPreviewName(): string {
+    const superPreview = super.getPreviewName();
+    if (superPreview) {
+      return superPreview;
+    }
+    if (this.mimetype && (
+        this.mimetype.indexOf('text/') > -1 ||
+        this.mimetype.indexOf('application/json') > -1
+    )) {
+      return 'text';
+    }
+    return '';
+  }
 }
 
 /**

--- a/sources/web/datalab/polymer/polymer.json
+++ b/sources/web/datalab/polymer/polymer.json
@@ -9,7 +9,10 @@
     "components/datalab-sidebar/datalab-sidebar.html",
     "components/datalab-terminal/datalab-terminal.html",
     "components/datalab-toolbar/datalab-toolbar.html",
-    "components/file-browser/file-browser.html"
+    "components/file-browser/file-browser.html",
+    "components/notebook-preview/notebook-preview.html",
+    "components/table-preview/table-preview.html",
+    "components/text-preview/text-preview.html"
   ],
   "sources": [
     "modules/**/*.js",

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -25,7 +25,7 @@ class MockFileManager implements FileManager {
       id: new DatalabFileId('/', FileManagerType.JUPYTER),
       name: 'root',
       type: DatalabFileType.DIRECTORY,
-    };
+    } as DatalabFile;
     return file;
   }
   public saveText(_file: DatalabFile, _content: string): Promise<DatalabFile> {
@@ -66,19 +66,21 @@ describe('<file-browser>', () => {
       name: 'file1',
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
-    }, {
+    } as DatalabFile,
+    {
       icon: '',
       id: new DatalabFileId('', FileManagerType.JUPYTER),
       name: 'file2',
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
-    }, {
+    } as DatalabFile,
+    {
       icon: '',
       id: new DatalabFileId('', FileManagerType.JUPYTER),
       name: 'file3',
       status: DatalabFileStatus.RUNNING,
       type: DatalabFileType.DIRECTORY,
-    }
+    } as DatalabFile,
   ];
 
   before(() => {


### PR DESCRIPTION
This PR refactors the details pane to generalize it so that it can display additional types, then adds in the existing table-preview pane so that we can show a preview of BigQuery tables in the file browser. 