### PR TITLE
Layout fixes for data page and progressbar

### DIFF
--- a/sources/web/datalab/polymer/components/data-browser/data-browser.html
+++ b/sources/web/datalab/polymer/components/data-browser/data-browser.html
@@ -13,17 +13,21 @@ the License.
 -->
 
 <link rel="import" href="../../components/file-browser/file-browser.html">
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
 
 <dom-module id="data-browser">
   <template>
     <style include="datalab-shared-styles">
+      :host {
+        display: flex;
+        flex-direction: column;
+      }
+      file-browser {
+        height: 100%;
+      }
     </style>
 
-    <div id="data-container">
-
-      <file-browser file-manager-type='bigquery' hide-toolbar></file-browser>
-
-    </div>
+    <file-browser file-manager-type='bigquery' hide-toolbar></file-browser>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -29,6 +29,8 @@ the License.
           font-family: monospace;
           font-size: var(--app-content-font-size);
         }
+        display: flex;
+        flex-direction: column;
       }
       div {
         font-family: var(--app-content-font-family);
@@ -37,10 +39,6 @@ the License.
       }
       resizable-divider {
         width: 100%;
-        height: 100%;
-      }
-      #data-container {
-        display: flex;
         height: 100%;
       }
       .resultsColumn {
@@ -89,32 +87,28 @@ the License.
       }
     </style>
 
-    <div id="data-container">
+    <resizable-divider initial-divider-position="70" minimum-width-px="200">
 
-      <resizable-divider initial-divider-position="70" minimum-width-px="200">
-
-        <div class="resultsColumn" slot="left">
-          <!-- Input box to enter search terms -->
-          <div id="search-div">
-            <iron-a11y-keys id="searchKeys" keys="enter" on-keys-pressed="_search"></iron-a11y-keys>
-            <iron-icon icon="search" id="search-icon"></iron-icon>
-            <input id="searchBox" placeholder="Search for data, then press Enter"
-                value="{{_searchValue::input}}">
-          </div>
-          <!-- List of results -->
-          <div class='results-container'>
-            <item-list id="results"></item-list>
-          </div>
+      <div class="resultsColumn" slot="left">
+        <!-- Input box to enter search terms -->
+        <div id="search-div">
+          <iron-a11y-keys id="searchKeys" keys="enter" on-keys-pressed="_search"></iron-a11y-keys>
+          <iron-icon icon="search" id="search-icon"></iron-icon>
+          <input id="searchBox" placeholder="Search for data, then press Enter"
+              value="{{_searchValue::input}}">
         </div>
-
-        <!-- Preview pane -->
-        <div id="previewPane" slot="right">
-          <table-preview id="preview"></table-preview>
+        <!-- List of results -->
+        <div class='results-container'>
+          <item-list id="results"></item-list>
         </div>
+      </div>
 
-      </resizable-divider>
+      <!-- Preview pane -->
+      <div id="previewPane" slot="right">
+        <table-preview id="preview"></table-preview>
+      </div>
 
-    </div>
+    </resizable-divider>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -94,7 +94,7 @@ the License.
       }
       .progressbar {
         width: 100%;
-        height: var(--progressbar-height);
+        flex: 0 0 var(--progressbar-height);
         --paper-progress-active-color: var(--selection-fg-color);
         --paper-progress-container-color: var(--border-color);
       }


### PR DESCRIPTION
Elements are display: inline'd by default, they need to be block or flex to fit our styles. The changes in `datalab-data` are just removing the wrapper `<data-container>` div.
Also, progressbar was getting a portion of its height because of flexbox.