### PR TITLE
Fix lazy loading of page elements

### DIFF
--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.ts
@@ -50,17 +50,11 @@ class BreadCrumbsElement extends Polymer.Element {
     };
   }
 
-  ready() {
-    super.ready();
-
-    window.addEventListener('resize', () => this._resizeHandler());
-  }
-
   _crumbsChanged() {
-    this._resizeHandler();
+    this.resizeHandler();
   }
 
-  _resizeHandler() {
+  resizeHandler() {
     // Let the items render first, before hiding overflowing items
     Polymer.dom.flush();
 

--- a/sources/web/datalab/polymer/components/data-browser/data-browser.ts
+++ b/sources/web/datalab/polymer/components/data-browser/data-browser.ts
@@ -18,7 +18,7 @@
 /**
  * Data Browser element for Datalab.
  */
-class DataBrowserElement extends Polymer.Element implements DatalabPageElement {
+class DataBrowserElement extends Polymer.Element {
 
   public resizeHandler = null;
   public focusHandler = null;

--- a/sources/web/datalab/polymer/components/data-browser/data-browser.ts
+++ b/sources/web/datalab/polymer/components/data-browser/data-browser.ts
@@ -18,7 +18,7 @@
 /**
  * Data Browser element for Datalab.
  */
-class DataBrowserElement extends Polymer.Element {
+class DataBrowserElement extends Polymer.Element implements DatalabPageElement {
 
   public resizeHandler = null;
   public focusHandler = null;

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -75,6 +75,7 @@ the License.
         <div class="datalab-main-content">
           <iron-pages id="pages" selected="{{page}}" attr-for-selected="name"
                       fallback-selection="files">
+            <!-- Elements here must implement the DatalabPageElement interface -->
             <data-browser class="page" name="data2"></data-browser>
             <datalab-data class="page" name="data"></datalab-data>
             <file-browser class="page" name="files"></file-browser>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -73,8 +73,7 @@ the License.
       <div class="datalab-contents">
         <datalab-sidebar class="datalab-sidebar" page={{page}}></datalab-sidebar>
         <div class="datalab-main-content">
-          <iron-pages id="pages" selected="{{page}}" attr-for-selected="name"
-                      fallback-selection="files">
+          <iron-pages id="pages" selected="{{page}}" attr-for-selected="name">
             <!-- Elements here must implement the DatalabPageElement interface -->
             <data-browser class="page" name="data2"></data-browser>
             <datalab-data class="page" name="data"></datalab-data>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -120,27 +120,28 @@ class DatalabAppElement extends Polymer.Element {
    * the browser pre-load all the pages on the first request.
    */
   _pageChanged(newPage: string, oldPage: string) {
-    // Build the path using the page name as suffix for directory
-    // and file names.
     if (newPage) {
+      // Lazy load the requested page. Build the path using the page's element
+      // name.
       const newElement = this._getPageElement(newPage);
       const elName = newElement.tagName.toLowerCase();
       const resolvedPageUrl = this.resolveUrl('../' + elName + '/' + elName + '.html');
-      Polymer.importHref(resolvedPageUrl, undefined, undefined, true);
 
-      if (newElement.focusHandler) {
-        newElement.focusHandler();
-      }
-      if (newElement.resizeHandler) {
-        newElement.resizeHandler();
-      }
+      Polymer.importHref(resolvedPageUrl, () => {
+        // After the element has loaded, call proper event handlers on it.
+        if (newElement.focusHandler) {
+          newElement.focusHandler();
+        }
+        if (newElement.resizeHandler) {
+          newElement.resizeHandler();
+        }
+      }, undefined, true);
+
     }
 
     if (oldPage) {
       const oldElement = this._getPageElement(oldPage);
-      // Call proper event handlers on changed pages.
-      // TODO: Explore making all datalab pages extend a custom element that has
-      // these event handlers defined to keep things consistent and get rid of the checks.
+      // Call proper event handlers on old page, which should already exist.
       if (oldElement && oldElement.blurHandler) {
         oldElement.blurHandler();
       }

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -52,7 +52,7 @@ class DatalabAppElement extends Polymer.Element {
     // Set the pattern once to be the current document pathname.
     this.rootPattern = (new URL(this.rootPath)).pathname;
 
-    this._boundResizeHandler = this._resizeHandler.bind(this);
+    this._boundResizeHandler = this.resizeHandler.bind(this);
     window.addEventListener('resize', this._boundResizeHandler, true);
 
     const apiManager = ApiManagerFactory.getInstance();
@@ -123,27 +123,25 @@ class DatalabAppElement extends Polymer.Element {
   _pageChanged(newPage: string, oldPage: string) {
     // Build the path using the page name as suffix for directory
     // and file names.
-    const el = this.$.pages.querySelector('[name=' + newPage + ']') as HTMLElement;
-    const elName = el.tagName.toLowerCase();
-    const resolvedPageUrl = this.resolveUrl('../' + elName + '/' + elName + '.html');
-    Polymer.importHref(resolvedPageUrl, undefined, undefined, true);
-
     const newElement = this._getPageElement(newPage);
     const oldElement = this._getPageElement(oldPage);
+    const elName = newElement.tagName.toLowerCase();
+    const resolvedPageUrl = this.resolveUrl('../' + elName + '/' + elName + '.html');
+    Polymer.importHref(resolvedPageUrl, undefined, undefined, true);
 
     // Call proper event handlers on changed pages.
     // TODO: Explore making all datalab pages extend a custom element that has
     // these event handlers defined to keep things consistent and get rid of the checks.
     if (newElement) {
-      if (newElement._focusHandler) {
-        newElement._focusHandler();
+      if (newElement.focusHandler) {
+        newElement.focusHandler();
       }
-      if (newElement._resizeHandler) {
-        newElement._resizeHandler();
+      if (newElement.resizeHandler) {
+        newElement.resizeHandler();
       }
     }
-    if (oldElement && oldElement._blurHandler) {
-      oldElement._blurHandler();
+    if (oldElement && oldElement.blurHandler) {
+      oldElement.blurHandler();
     }
 
   }
@@ -153,17 +151,16 @@ class DatalabAppElement extends Polymer.Element {
    * @param pageName name of the page whose element to return
    */
   _getPageElement(pageName: string) {
-    const elName = 'datalab-' + pageName;
-    return this.$.pages.items.find((element: HTMLElement) => element.localName === elName);
+    return this.$.pages.querySelector('[name=' + pageName + ']') as DatalabPageElement;
   }
 
   /**
    * If the selected page has a resize handler, calls it.
    */
-  _resizeHandler() {
+  resizeHandler() {
     const selectedPage = this.$.pages.selectedItem;
-    if (selectedPage && selectedPage._resizeHandler) {
-      selectedPage._resizeHandler();
+    if (selectedPage && selectedPage.resizeHandler) {
+      selectedPage.resizeHandler();
     }
   }
 

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -75,7 +75,7 @@ class DatalabAppElement extends Polymer.Element {
       page: {
         observer: '_pageChanged',
         type: String,
-        value: 'files',
+        value: '',
       },
       rootPattern: String,
       routeData: Object,
@@ -110,8 +110,7 @@ class DatalabAppElement extends Polymer.Element {
    * so it can be used by other elements.
    */
   _routePageChanged(page: string) {
-    // Defaults to the files view
-    this.page = page || 'files';
+    this.page = page;
   }
 
   /**
@@ -123,16 +122,12 @@ class DatalabAppElement extends Polymer.Element {
   _pageChanged(newPage: string, oldPage: string) {
     // Build the path using the page name as suffix for directory
     // and file names.
-    const newElement = this._getPageElement(newPage);
-    const oldElement = this._getPageElement(oldPage);
-    const elName = newElement.tagName.toLowerCase();
-    const resolvedPageUrl = this.resolveUrl('../' + elName + '/' + elName + '.html');
-    Polymer.importHref(resolvedPageUrl, undefined, undefined, true);
+    if (newPage) {
+      const newElement = this._getPageElement(newPage);
+      const elName = newElement.tagName.toLowerCase();
+      const resolvedPageUrl = this.resolveUrl('../' + elName + '/' + elName + '.html');
+      Polymer.importHref(resolvedPageUrl, undefined, undefined, true);
 
-    // Call proper event handlers on changed pages.
-    // TODO: Explore making all datalab pages extend a custom element that has
-    // these event handlers defined to keep things consistent and get rid of the checks.
-    if (newElement) {
       if (newElement.focusHandler) {
         newElement.focusHandler();
       }
@@ -140,10 +135,16 @@ class DatalabAppElement extends Polymer.Element {
         newElement.resizeHandler();
       }
     }
-    if (oldElement && oldElement.blurHandler) {
-      oldElement.blurHandler();
-    }
 
+    if (oldPage) {
+      const oldElement = this._getPageElement(oldPage);
+      // Call proper event handlers on changed pages.
+      // TODO: Explore making all datalab pages extend a custom element that has
+      // these event handlers defined to keep things consistent and get rid of the checks.
+      if (oldElement && oldElement.blurHandler) {
+        oldElement.blurHandler();
+      }
+    }
   }
 
   /**

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -12,6 +12,7 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
+<link rel="import" href="../../components/datalab-page/datalab-page.html">
 <link rel="import" href="../../components/item-list/item-list.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 <link rel="import" href="../../components/table-preview/table-preview.html">

--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.ts
@@ -26,7 +26,11 @@ interface Result {
  * Data element for Datalab.
  * Contains a form for initial user input, and a list of results.
  */
-class DataElement extends Polymer.Element {
+class DataElement extends Polymer.Element implements DatalabPageElement {
+
+  public resizeHandler = null;
+  public focusHandler = null;
+  public blurHandler = null;
 
   private _resultsList: Result[];
   private _searchValue: string;

--- a/sources/web/datalab/polymer/components/datalab-page/datalab-page.html
+++ b/sources/web/datalab/polymer/components/datalab-page/datalab-page.html
@@ -12,21 +12,4 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
-<link rel="import" href="../../components/datalab-page/datalab-page.html">
-<link rel="import" href="../../components/file-browser/file-browser.html">
-
-<dom-module id="data-browser">
-  <template>
-    <style include="datalab-shared-styles">
-    </style>
-
-    <div id="data-container">
-
-      <file-browser file-manager-type='bigquery' hide-toolbar></file-browser>
-
-    </div>
-
-  </template>
-</dom-module>
-
-<script src="data-browser.js"></script>
+<script src="datalab-page.js"></script>

--- a/sources/web/datalab/polymer/components/datalab-page/datalab-page.ts
+++ b/sources/web/datalab/polymer/components/datalab-page/datalab-page.ts
@@ -12,20 +12,14 @@
  * the License.
  */
 
-/// <reference path="../input-dialog/input-dialog.ts" />
-/// <reference path="../item-list/item-list.ts" />
-
 /**
- * Data Browser element for Datalab.
+ * Interface for an element that is shown as a navigation page in Datalab.
+ * These elements can support resizing, focusing, and blurring, and so must
+ * define the functions below if that functionality is needed, otherwise
+ * explicitly set it to null.
  */
-class DataBrowserElement extends Polymer.Element implements DatalabPageElement {
-
-  public resizeHandler = null;
-  public focusHandler = null;
-  public blurHandler = null;
-
-  static get is() { return 'data-browser'; }
-
+interface DatalabPageElement extends Polymer.Element {
+  resizeHandler: (() => void) | null;
+  focusHandler: (() => void) | null;
+  blurHandler: (() => void) | null;
 }
-
-customElements.define(DataBrowserElement.is, DataBrowserElement);

--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.html
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.html
@@ -12,8 +12,9 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
-<link rel="import" href="../../components/shared-styles/shared-styles.html">
+<link rel="import" href="../../components/datalab-page/datalab-page.html">
 <link rel="import" href="../../components/item-list/item-list.html">
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
 <link rel="import" href="../../modules/session-manager/session-manager.html">
 
 <link rel="import" href="../../bower_components/iron-icon/iron-icon.html">

--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
@@ -19,12 +19,14 @@
  * Contains an item-list element to display sessions, a toolbar to interact with these sessions,
  * a progress bar that appears while loading the list
  */
-class SessionsElement extends Polymer.Element {
+class SessionsElement extends Polymer.Element implements DatalabPageElement {
 
   /**
    * The currently selected session if exactly one is selected, or null if none is.
    */
   public selectedSession: Session | null;
+
+  public resizeHandler = null;
 
   private _sessionList: Session[];
   private _fetching: boolean;
@@ -65,7 +67,7 @@ class SessionsElement extends Polymer.Element {
                                     this._handleSelectionChanged.bind(this));
     }
 
-    this._focusHandler();
+    this.focusHandler();
   }
 
   /**
@@ -162,7 +164,7 @@ class SessionsElement extends Polymer.Element {
   /**
    * Starts auto refreshing the session list, and also triggers an immediate refresh.
    */
-  _focusHandler() {
+  focusHandler() {
     // Refresh the session list periodically as long as the document has focus.
     // Note that we don't rely solely on the interval to keep the list in sync,
     // the refresh also happens when the sessions page gains focus, which is
@@ -184,7 +186,7 @@ class SessionsElement extends Polymer.Element {
    * Stops the auto refresh of the session list. This happens when the user moves
    * away from the page.
    */
-  _blurHandler() {
+  blurHandler() {
     if (this._sessionListRefreshIntervalHandle) {
       clearInterval(this._sessionListRefreshIntervalHandle);
       this._sessionListRefreshIntervalHandle = 0;

--- a/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.html
+++ b/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.html
@@ -12,6 +12,7 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
+<link rel="import" href="../../components/datalab-page/datalab-page.html">
 <link rel="import" href="../../modules/terminal-manager/terminal-manager.html">
 
 <dom-module id="datalab-terminal">

--- a/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.ts
+++ b/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.ts
@@ -34,7 +34,10 @@ declare class Terminal {
  * If the user closes the terminal session, either by typing 'exit' or ctrl+d, this
  * element will automatically reset the terminal.
  */
-class TerminalElement extends Polymer.Element {
+class TerminalElement extends Polymer.Element implements DatalabPageElement {
+
+  public focusHandler = null;
+  public blurHandler = null;
 
   private _xterm: Terminal;
   private _wsConnection: WebSocket;
@@ -97,7 +100,7 @@ class TerminalElement extends Polymer.Element {
 
       // Now, create the front-end terminal.
       this._xterm.open(this.$.theTerminal, true);
-      this._resizeHandler();
+      this.resizeHandler();
     };
   }
 
@@ -105,7 +108,7 @@ class TerminalElement extends Polymer.Element {
    * On window resize, both front-end and Jupyter terminal instances need to be resized and
    * kept in sync, otherwise line wrapping issues will happen.
    */
-  _resizeHandler() {
+  resizeHandler() {
     if (this._xterm) {
       const rows = this.$.theTerminal.clientHeight / this._charHeight;
       const cols = this.$.theTerminal.clientWidth / this._charWidth;

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -14,6 +14,7 @@ the License.
 
 <link rel="import" href="../../components/base-dialog/base-dialog.html">
 <link rel="import" href="../../components/bread-crumbs/bread-crumbs.html">
+<link rel="import" href="../../components/datalab-page/datalab-page.html">
 <link rel="import" href="../../components/details-pane/details-pane.html">
 <link rel="import" href="../../components/input-dialog/input-dialog.html">
 <link rel="import" href="../../components/item-list/item-list.html">

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -32,7 +32,7 @@
  * and no selection. It also doesn't do anything when a file is double clicked.
  * This is meant to be used for browsing only, such as the case for picking files or directories.
  */
-class FileBrowserElement extends Polymer.Element {
+class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
   private static readonly _deleteListLimit = 10;
 
@@ -734,7 +734,7 @@ class FileBrowserElement extends Polymer.Element {
    * Called on window.resize, collapses elements to keep the element usable
    * on small screens.
    */
-  _resizeHandler() {
+  resizeHandler() {
     const width = this.$.toolbar.clientWidth;
     // Collapse the add buttons on the toolbar
     if (width < this._addToolbarCollapseThreshold) {
@@ -760,12 +760,14 @@ class FileBrowserElement extends Polymer.Element {
     if (width < this._detailsPaneCollapseThreshold) {
       this._isDetailsPaneToggledOn = false;
     }
+
+    (this.$.breadCrumbs as BreadCrumbsElement).resizeHandler();
   }
 
   /**
    * Starts auto refreshing the file list, and also triggers an immediate refresh.
    */
-  _focusHandler() {
+  focusHandler() {
     // Refresh the file list periodically as long as the document is focused.
     // Note that we don't rely solely on the interval to keep the list in sync,
     // the refresh also happens after file operations, and when the files page
@@ -785,7 +787,7 @@ class FileBrowserElement extends Polymer.Element {
    * Stops the auto refresh of the file list. This happens when the user moves
    * away from the page.
    */
-  _blurHandler() {
+  blurHandler() {
     if (this._fileListRefreshIntervalHandle) {
       clearInterval(this._fileListRefreshIntervalHandle);
       this._fileListRefreshIntervalHandle = 0;
@@ -822,8 +824,8 @@ class FileBrowserElement extends Polymer.Element {
   }
 
   private _finishLoadingFiles() {
-    this._resizeHandler();
-    this._focusHandler();
+    this.resizeHandler();
+    this.focusHandler();
 
     const filesElement = this.shadowRoot.querySelector('#files');
     if (filesElement) {


### PR DESCRIPTION
This PR fixes the following:
- The `file-browser` element was being loaded automatically, even if has never been switched to. This was caused by the fallback attributes and logic.
- Page elements (e.g. files, sessions, terminal.. etc) now implement an interface that defines event handlers for resize, focus, and blur. This way they are more consistent, and don't need to add their own event listeners on document/window. There's unfortunately no way to enforce this within the HTML, so I put a comment there.