### PR TITLE
Fix clicking breadcrumbs

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -149,7 +149,8 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     super.ready();
 
     this.$.breadCrumbs.addEventListener('crumbClicked', (e: ItemClickEvent) => {
-      this._pathHistoryIndex = e.detail.index;
+      // Take the default root file into account, increment clicked index by one.
+      this._pathHistoryIndex = e.detail.index + 1;
     });
     this.$.breadCrumbs.addEventListener('rootClicked', () => {
       this._pathHistoryIndex = 0;


### PR DESCRIPTION
The last refactor brought about this bug, since we're now loading the root file by default in the breadcrumb array, indices should be shifted by one when clicked.