### PR TITLE
Drive double click actions

### DIFF
--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -113,7 +113,7 @@ class DriveFileManager implements FileManager {
     // Notebooks that are stored on the VM require the basepath.
     const apiManager = ApiManagerFactory.getInstance();
     const basepath = await apiManager.getBasePath();
-		return location.protocol + '//' + location.host + basepath +
+    return location.protocol + '//' + location.host + basepath +
         '/notebook#fileId=' + fileId.toQueryString();
   }
 }

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -37,6 +37,9 @@ class DriveFileManager implements FileManager {
                               DatalabFileType.DIRECTORY :
                               DatalabFileType.FILE,
     } as DatalabFile);
+    if (datalabFile.name.endsWith('.ipynb')) {
+      datalabFile.type = DatalabFileType.NOTEBOOK;
+    }
     return datalabFile;
   }
   public get(_fileId: DatalabFileId): Promise<DatalabFile> {
@@ -98,11 +101,19 @@ class DriveFileManager implements FileManager {
     throw new UnsupportedMethod('copy', this);
   }
 
-  public getEditorUrl(): Promise<string> {
-    throw new UnsupportedMethod('getEditorUrl', this);
+  public async getEditorUrl(fileId: DatalabFileId) {
+    // Files that are stored on the VM require the basepath.
+    const apiManager = ApiManagerFactory.getInstance();
+    const basepath = await apiManager.getBasePath();
+    return location.protocol + '//' + location.host + basepath +
+        '/editor?file=' + fileId.toQueryString();
   }
 
-  public getNotebookUrl(): Promise<string> {
-    throw new UnsupportedMethod('getNotebookUrl', this);
+  public async getNotebookUrl(fileId: DatalabFileId): Promise<string> {
+    // Notebooks that are stored on the VM require the basepath.
+    const apiManager = ApiManagerFactory.getInstance();
+    const basepath = await apiManager.getBasePath();
+		return location.protocol + '//' + location.host + basepath +
+        '/notebook#fileId=' + fileId.toQueryString();
   }
 }

--- a/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
@@ -66,6 +66,7 @@ class FileManagerFactory {
   public static fileManagerTypetoString(type: FileManagerType) {
     switch (type) {
       case FileManagerType.BIG_QUERY: return 'bigquery';
+      case FileManagerType.DRIVE: return 'drive';
       case FileManagerType.JUPYTER: return 'jupyter';
       default: throw new Error('Unknown FileManager type: ' + type);
     }

--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.html
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.html
@@ -12,4 +12,6 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
+<link rel="import" href="../../modules/settings-manager/settings-manager.html">
+
 <script src="gapi-manager.js"></script>


### PR DESCRIPTION
Double clicking an item from a drive file browser now executes the right action.
There's still some cleanup to do here; obtaining the editor/notebook urls can be extracted outside of the individual file managers, since most of it is repeated logic.

Note this won't work on the Jupyter-based notebook editor as of now, since it uses the new notebook fileId path, which needs to be supported by the notebook editor.