### PR TITLE
Use the same service urls for all ApiManagers

### DIFF
--- a/sources/web/datalab/polymer/modules/base-api-manager/base-api-manager.ts
+++ b/sources/web/datalab/polymer/modules/base-api-manager/base-api-manager.ts
@@ -98,16 +98,35 @@ abstract class BaseApiManager implements ApiManager {
 
   public abstract getBasePath(): Promise<string>;
 
-  public abstract getServiceUrl(_: ServiceId): string;
-
-  public sendRequestAsync(url: string, options?: XhrOptions) {
-    return this.getBasePath()
-      .then((base: string) => this._xhrJsonAsync(base + url, options));
+  public async sendRequestAsync(url: string, options?: XhrOptions): Promise<string> {
+    const basepath = await this.getBasePath();
+    return this._xhrJsonAsync(basepath + url, options);
   }
 
-  public sendTextRequestAsync(url: string, options?: XhrOptions): Promise<string> {
-    return this.getBasePath()
-      .then((base: string) => this._xhrTextAsync(base + url, options));
+  public async sendTextRequestAsync(url: string, options?: XhrOptions): Promise<string> {
+    const basepath = await this.getBasePath();
+    return this._xhrTextAsync(basepath + url, options);
+  }
+
+  public getServiceUrl(serviceId: ServiceId): string {
+    switch (serviceId) {
+      case ServiceId.APP_SETTINGS:
+        return '/api/settings';
+      case ServiceId.BASE_PATH:
+        return '/api/basepath';
+      case ServiceId.CONTENT:
+        return '/api/contents';
+      case ServiceId.SESSIONS:
+        return '/api/sessions';
+      case ServiceId.TERMINALS:
+        return '/api/terminals';
+      case ServiceId.TIMEOUT:
+        return '/_timeout';
+      case ServiceId.USER_SETTINGS:
+        return '/_settings';
+      default:
+        throw new Error('Unknown service id: ' + serviceId);
+    }
   }
 
   /**

--- a/sources/web/datalab/polymer/modules/daas-api-manager/daas-api-manager.ts
+++ b/sources/web/datalab/polymer/modules/daas-api-manager/daas-api-manager.ts
@@ -23,11 +23,6 @@ interface XssiResponse {
 // DaaS is Datalab as a Service
 class DaasApiManager extends BaseApiManager {
 
-  /**
-   * URL for retrieving the base path
-   */
-  private readonly _basepathApiUrl = '/api/basepath';
-
   private _basepathPromise: Promise<string>;
 
   /**
@@ -36,8 +31,9 @@ class DaasApiManager extends BaseApiManager {
   private _xsrfToken = '';
 
   public getBasePath(): Promise<string> {
+    const basePathUrl = this.getServiceUrl(ServiceId.BASE_PATH);
     if (!this._basepathPromise) {
-      this._basepathPromise = this._xhrTextAsync(this._basepathApiUrl)
+      this._basepathPromise = this._xhrTextAsync(basePathUrl)
         .then((response: string) => {
           // The server may add the xssiPrefix to the response to prevent.
           // it being parsed as if it were a javascript file.
@@ -68,7 +64,7 @@ class DaasApiManager extends BaseApiManager {
                 noCache: true,
                 parameters: formData,
               };
-              return this._xhrTextAsync(this._basepathApiUrl, xhrOptions)
+              return this._xhrTextAsync(basePathUrl, xhrOptions)
                 .then((basePathResponse: string) => {
                   if (!basePathResponse.startsWith(xssiPrefix)) {
                     // The server didn't give us a basepath, even after we sent
@@ -87,9 +83,5 @@ class DaasApiManager extends BaseApiManager {
         });
     }
     return this._basepathPromise;
-  }
-
-  public getServiceUrl(_: ServiceId): string {
-    throw new Error('Not implemented');
   }
 }

--- a/sources/web/datalab/polymer/modules/jupyter-api-manager/jupyter-api-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-api-manager/jupyter-api-manager.ts
@@ -27,25 +27,4 @@ class JupyterApiManager extends BaseApiManager {
     }
     return this._basepathPromise;
   }
-
-  public getServiceUrl(serviceId: ServiceId): string {
-    switch (serviceId) {
-      case ServiceId.APP_SETTINGS:
-        return '/api/settings';
-      case ServiceId.BASE_PATH:
-        return '/api/basepath';
-      case ServiceId.CONTENT:
-        return '/api/contents';
-      case ServiceId.SESSIONS:
-        return '/api/sessions';
-      case ServiceId.TERMINALS:
-        return '/api/terminals';
-      case ServiceId.TIMEOUT:
-        return '/_timeout';
-      case ServiceId.USER_SETTINGS:
-        return '/_settings';
-      default:
-        throw new Error('Unknown service id: ' + serviceId);
-    }
-  }
 }

--- a/sources/web/datalab/polymer/modules/settings-manager/settings-manager.ts
+++ b/sources/web/datalab/polymer/modules/settings-manager/settings-manager.ts
@@ -125,6 +125,6 @@ class SettingsManager {
   private static _getAppSettingsAsync() {
     const apiManager = ApiManagerFactory.getInstance();
     return apiManager.sendRequestAsync(apiManager.getServiceUrl(ServiceId.APP_SETTINGS));
-}
+  }
 
 }


### PR DESCRIPTION
Until we have a need to branch these off, all types of ApiManagers should use the same service urls. This way if we do need to change one or more we can just extend the base class.