### PR TITLE
CSS fixes

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -79,6 +79,9 @@ the License.
         box-shadow: -3px 3px 10px -3px rgba(0, 0, 0, 0.3);
         z-index: 3;
       }
+      datalab-info {
+        margin: 20px;
+      }
     </style>
 
     <app-header slot="header" fixed shadow>
@@ -116,8 +119,8 @@ the License.
         <datalab-info></datalab-info>
       </div>
       <hr>
-      <div class="dialog-buttons">
-        <paper-button dialog-dismiss raised>Close</paper-button>
+      <div class="dialog-footer">
+        <paper-button dialog-dismiss>Close</paper-button>
       </div>
     </paper-dialog>
 
@@ -128,8 +131,8 @@ the License.
         <datalab-settings id="settingsElement"></datalab-settings>
       </div>
       <hr>
-      <div class="dialog-buttons">
-        <paper-button dialog-dismiss raised>Close</paper-button>
+      <div class="dialog-footer">
+        <paper-button dialog-dismiss>Close</paper-button>
       </div>
     </paper-dialog>
 

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -72,7 +72,7 @@ the License.
         margin: 0px;
         padding: 10px;
         min-width: 150px;
-        box-shadow: -3px 3px 10px -3px rgba(0, 0, 0, 0.3);
+        box-shadow: 0px 5px 10px 0px rgba(1, 0, 0, 0.3);
       }
       #altAddToolbar > *, #altUpdateToolbar > * {
         padding: 10px 0px;

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -30,8 +30,9 @@ the License.
         font-size: var(--app-content-font-size);
         color: var(--primary-fg-color);
       }
-      #header-container {
+      #headerContainer {
         flex: 0 0 var(--toolbar-height);
+        z-index: 1;
       }
       #header {
         user-select: none;
@@ -66,7 +67,7 @@ the License.
       }
       .checkbox-col > paper-checkbox {
         --paper-checkbox-size: 15px;
-        --paper-checkbox-unchecked-color: var(--primary-fg-color);
+        --paper-checkbox-unchecked-color: var(--neutral-fg-color);
         --paper-checkbox-checked-color: var(--selection-fg-color);
       }
       .first-col {
@@ -88,7 +89,7 @@ the License.
 
     <!--Header row-->
     <!--Need this extra div because #header has a display modifier, cannot set hidden-->
-    <div class="header-container" hidden$="{{hideHeader}}">
+    <div id="headerContainer" hidden$="{{hideHeader}}">
       <div id="header">
         <div class="checkbox-col">
           <paper-checkbox id="selectAllCheckbox" on-checked-changed="_selectAllChanged"

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -129,6 +129,19 @@ class ItemListElement extends Polymer.Element {
     };
   }
 
+  ready() {
+    super.ready();
+
+    // Add box-shadow to header container on scroll
+    const container = this.$.listContainer as HTMLDivElement;
+    const headerContainer = this.$.headerContainer as HTMLDivElement;
+    container.addEventListener('scroll', () => {
+      const yOffset = Math.min(container.scrollTop / 5, 5);
+      const shadow = '0px ' + yOffset + 'px 10px -3px #ccc';
+      headerContainer.style.boxShadow = shadow;
+    });
+  }
+
   /**
    * Returns value for the computed property selectedIndices, which is the list
    * of indices of the currently selected items.

--- a/sources/web/datalab/polymer/components/notebook-preview/notebook-preview.html
+++ b/sources/web/datalab/polymer/components/notebook-preview/notebook-preview.html
@@ -29,7 +29,7 @@ the License.
       .message {
         padding: 15px;
         text-align: center;
-        color: #777;
+        color: var(--neutral-fg-color);
       }
     </style>
     <div id="previewHtml"></div>

--- a/sources/web/datalab/polymer/components/preview-pane/preview-pane.html
+++ b/sources/web/datalab/polymer/components/preview-pane/preview-pane.html
@@ -29,7 +29,7 @@ the License.
       .placeholder {
         padding: 15px;
         text-align: center;
-        color: #777;
+        color: var(--neutral-fg-color);
       }
     </style>
     <div id="container" hidden$="{{!file}}">

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -20,6 +20,7 @@ the License.
         --app-content-font-family: 'Open Sans', 'Helvetica', sans-serif;
         --app-content-font-size: 13px;
         --collapsed-sidebar-width: 65px;
+        --neutral-fg-color: #777;
         --preview-pane-width: 350px;
         --primary-text-color : var(--primary-fg-color);
         --progressbar-height: 1px;

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -79,10 +79,12 @@ the License.
         flex: 0 0 auto;
         margin: 0px;
         padding: 15px;
-        direction: rtl;
         display: flex;
-        justify-content: center;
+        justify-content: flex-end;
         color: var(--primary-fg-color);
+      }
+      .dialog-footer > paper-button:first-of-type {
+        @apply --shadow-elevation-2dp;
       }
       a {
         color: var(--selection-fg-color);
@@ -96,6 +98,7 @@ the License.
       .progressbar {
         width: 100%;
         flex: 0 0 var(--progressbar-height);
+        height: var(--progressbar-height);
         --paper-progress-active-color: var(--selection-fg-color);
         --paper-progress-container-color: var(--border-color);
       }

--- a/sources/web/datalab/polymer/components/text-preview/text-preview.html
+++ b/sources/web/datalab/polymer/components/text-preview/text-preview.html
@@ -29,7 +29,7 @@ the License.
       .message {
         padding: 15px;
         text-align: center;
-        color: #777;
+        color: var(--neutral-fg-color);
       }
     </style>
     <div id="previewHtml"></div>


### PR DESCRIPTION
- Dialog padding for the datalab info element was missing.
- Auto-raise the first button in any dialog-footer section.
- Dialog buttons should appear on the right end.
- Added box-shadow to item list as it scrolls.