### PR TITLE
Add a fake metadata server that can be used to inject credentials

### DIFF
--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -76,7 +76,7 @@ if [ "${ENABLE_USAGE_REPORTING}" = "true" ]
 then
   if [ -n "${PROJECT_ID}" ]
   then
-    export PROJECT_NUMBER=`gcloud projects describe "${PROJECT_ID}" --format 'value(projectNumber)' 2>/dev/null || true`
+    export PROJECT_NUMBER=${PROJECT_NUMBER:-`gcloud projects describe "${PROJECT_ID}" --format 'value(projectNumber)' 2>/dev/null || true`}
   fi
 fi
 

--- a/sources/web/datalab/metadata.ts
+++ b/sources/web/datalab/metadata.ts
@@ -53,8 +53,8 @@ function launchFakeServer(metadata: FakeMetadata): void {
                            metadata_host, port, JSON.stringify(metadata));
 
   const server = http.createServer((req, res) => {
-    var parsed_url = url.parse(req.url, true);
-    var urlpath = parsed_url.pathname;
+    const parsed_url = url.parse(req.url, true);
+    const urlpath = parsed_url.pathname;
     logging.getLogger().info('Service a fake metadata request at %s', urlpath);
 
     if (urlpath == '/computeMetadata/v1/project/numeric-project-id') {
@@ -86,7 +86,7 @@ function launchFakeServer(metadata: FakeMetadata): void {
       res.write(metadata.creds.scopes);
     } else if (urlpath == '/computeMetadata/v1/instance/service-accounts/default/token' ||
                urlpath == '/computeMetadata/v1/instance/service-accounts/' + metadata.creds.account + '/token') {
-      var token: any = {
+      const token: any = {
         access_token: metadata.creds.access_token,
         expires_in: metadata.creds.expires_in,
         token_type: metadata.creds.token_type,
@@ -122,7 +122,7 @@ export function init(settings: common.AppSettings): void {
 }
 
 function parseCreds(request: http.ServerRequest, callback: Function): void {
-  var body : string = "";
+  let body : string = "";
   request.on('data', function(chunk: string) { body += chunk; });
   request.on('end', function() {
     callback(JSON.parse(body));
@@ -135,8 +135,8 @@ function parseCreds(request: http.ServerRequest, callback: Function): void {
  * @param response the outgoing response.
  */
 function requestHandler(request: http.ServerRequest, response: http.ServerResponse): void {
-  var requestUrl = url.parse(request.url);
-  var path = requestUrl.pathname;
+  const requestUrl = url.parse(request.url);
+  const path = requestUrl.pathname;
   if (request.url == '/api/creds' && 'POST' == request.method) {
     parseCreds(request, function(c: any): void {
       const creds = metadata.creds;

--- a/sources/web/datalab/metadata.ts
+++ b/sources/web/datalab/metadata.ts
@@ -137,7 +137,7 @@ function parseCreds(request: http.ServerRequest, callback: Function): void {
 function requestHandler(request: http.ServerRequest, response: http.ServerResponse): void {
   var requestUrl = url.parse(request.url);
   var path = requestUrl.pathname;
-  if (request.url.indexOf('/api/creds') === 0 && 'POST' == request.method) {
+  if (request.url == '/api/creds' && 'POST' == request.method) {
     parseCreds(request, function(c: any): void {
       const creds = metadata.creds;
       for (const key of Object.keys(c)) {

--- a/sources/web/datalab/metadata.ts
+++ b/sources/web/datalab/metadata.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/// <reference path="../../../third_party/externs/ts/node/node.d.ts" />
+/// <reference path="common.d.ts" />
+
+import fs = require('fs');
+import http = require('http');
+import logging = require('./logging');
+import url = require('url');
+
+interface Creds {
+  account: string;
+  scopes: string;
+  access_token:  string;
+  expires_in: number;
+  token_type: string;
+}
+
+interface FakeMetadata {
+  project: string;
+  project_number: string;
+  creds: Creds;
+}
+
+var metadata: FakeMetadata = {
+  project: process.env.PROJECT_ID,
+  project_number: process.env.PROJECT_NUMBER,
+  creds: {
+    account: process.env.DATALAB_GIT_AUTHOR,
+    scopes: "",
+    access_token: "",
+    expires_in: 0,
+    token_type: "Bearer",
+  },
+};
+
+function launchFakeServer(metadata: FakeMetadata): void {
+  const port = 80;
+  const metadata_host = '169.254.169.254';
+  logging.getLogger().info('Starting fake metadata server at http://%s:%d with %s',
+                           metadata_host, port, JSON.stringify(metadata));
+
+  const server = http.createServer((req, res) => {
+    var parsed_url = url.parse(req.url, true);
+    var urlpath = parsed_url.pathname;
+    logging.getLogger().info('Service a fake metadata request at %s', urlpath);
+
+    if (urlpath == '/computeMetadata/v1/project/numeric-project-id') {
+      res.writeHead(200, { 'Content-Type': 'application/text' });
+      res.write(metadata.project_number);
+    } else if (urlpath == '/computeMetadata/v1/project/project-id') {
+      res.writeHead(200, { 'Content-Type': 'application/text' });
+      res.write(metadata.project);
+    } else if (urlpath == '/computeMetadata/v1/instance/service-accounts/') {
+      res.writeHead(200, { 'Content-Type': 'application/text' });
+      res.write('default/\n');
+      res.write(metadata.creds.account + '/\n');
+    } else if (urlpath == '/computeMetadata/v1/instance/service-accounts/default/' &&
+               parsed_url.query['recursive'] == "True") {
+      const accountJSON: any = {
+        aliases: ["default"],
+        email: metadata.creds.account,
+        scopes: [metadata.creds.scopes],
+      };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.write(JSON.stringify(accountJSON));
+    } else if (urlpath == '/computeMetadata/v1/instance/service-accounts/default/email' ||
+               urlpath == '/computeMetadata/v1/instance/service-accounts/' + metadata.creds.account + '/email') {
+      res.writeHead(200, { 'Content-Type': 'application/text' });
+      res.write(metadata.creds.account);
+    } else if (urlpath == '/computeMetadata/v1/instance/service-accounts/default/scopes' ||
+               urlpath == '/computeMetadata/v1/instance/service-accounts/' + metadata.creds.account + '/scopes') {
+      res.writeHead(200, { 'Content-Type': 'application/text' });
+      res.write(metadata.creds.scopes);
+    } else if (urlpath == '/computeMetadata/v1/instance/service-accounts/default/token' ||
+               urlpath == '/computeMetadata/v1/instance/service-accounts/' + metadata.creds.account + '/token') {
+      var token: any = {
+        access_token: metadata.creds.access_token,
+        expires_in: metadata.creds.expires_in,
+        token_type: metadata.creds.token_type,
+      };
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.write(JSON.stringify(token));
+    } else {
+      res.writeHead(404);
+    }
+    res.end();
+  });
+  server.listen(port, metadata_host, 511, () => {
+    // The `gcloud` tool uses a file in its config directory named 'gce' to
+    // cache whether or not it should read credentials from the metadata server.
+    //
+    // Since our fake metadata server just connected, it's possible that an
+    // earlier invocation of `gcloud` could have written that file. To account
+    // for this, we overwrite the file with the value that indicates the tool
+    // should read from the metadata server.
+    const gceFile = '/content/datalab/.config/gce'
+    fs.writeFileSync(gceFile, "True");
+  });
+}
+
+/**
+ * Initializes the Jupyter server manager.
+ */
+export function init(settings: common.AppSettings): void {
+  if (process.env.DATALAB_FAKE_METADATA_SERVER != 'true') {
+    return;
+  }
+  launchFakeServer(metadata);
+}
+
+function parseCreds(request: http.ServerRequest, callback: Function): void {
+  var body : string = "";
+  request.on('data', function(chunk: string) { body += chunk; });
+  request.on('end', function() {
+    callback(JSON.parse(body));
+  });
+}
+
+/**
+ * Implements the token submission request handling.
+ * @param request the incoming token POST request.
+ * @param response the outgoing response.
+ */
+function requestHandler(request: http.ServerRequest, response: http.ServerResponse): void {
+  var requestUrl = url.parse(request.url);
+  var path = requestUrl.pathname;
+  if (request.url.indexOf('/api/creds') === 0 && 'POST' == request.method) {
+    parseCreds(request, function(c: any): void {
+      const creds = metadata.creds;
+      for (const key of Object.keys(c)) {
+        (<any>creds)[key] = c[key];
+      }
+      response.writeHead(200, { 'Content-Type': 'text/plain' });
+      response.end('ok');
+    });
+  } else {
+    response.writeHead(404, 'Not Found', { 'Content-Type': 'text/plain' });
+    response.end();
+  }
+}
+
+/**
+ * Creates the health status request handler.
+ * @param settings configuration settings for the application.
+ * @returns the request handler to handle health requests.
+ */
+export function createHandler(settings: common.AppSettings): http.RequestHandler {
+  return requestHandler;
+}

--- a/sources/web/datalab/metadata.ts
+++ b/sources/web/datalab/metadata.ts
@@ -34,7 +34,7 @@ interface FakeMetadata {
   creds: Creds;
 }
 
-var metadata: FakeMetadata = {
+const metadata: FakeMetadata = {
   project: process.env.PROJECT_ID,
   project_number: process.env.PROJECT_NUMBER,
   creds: {
@@ -141,7 +141,7 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
     parseCreds(request, function(c: any): void {
       const creds = metadata.creds;
       for (const key of Object.keys(c)) {
-        (<any>creds)[key] = c[key];
+        (creds as any)[key] = c[key];
       }
       response.writeHead(200, { 'Content-Type': 'text/plain' });
       response.end('ok');

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -153,7 +153,7 @@ function handleRequest(request: http.ServerRequest,
     return;
   }
 
-  if (requestPath.indexOf('/api/creds') == 0) {
+  if (requestPath == '/api/creds') {
     metadataHandler(request, response);
     return;
   }

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -25,6 +25,7 @@ import jupyter = require('./jupyter');
 import logging = require('./logging');
 import idleTimeout = require('./idleTimeout');
 import fileSearch = require('./fileSearch');
+import metadata = require('./metadata');
 import net = require('net');
 import noCacheContent = require('./noCacheContent')
 import path = require('path');
@@ -40,6 +41,7 @@ import backupUtility = require('./backupUtility');
 import childProcess = require('child_process');
 
 var server: http.Server;
+var metadataHandler: http.RequestHandler;
 var healthHandler: http.RequestHandler;
 var infoHandler: http.RequestHandler;
 var settingHandler: http.RequestHandler;
@@ -148,6 +150,11 @@ function handleRequest(request: http.ServerRequest,
     else {
       noCacheContent.handleRequest(requestPath, response);
     }
+    return;
+  }
+
+  if (requestPath.indexOf('/api/creds') == 0) {
+    metadataHandler(request, response);
     return;
   }
 
@@ -338,6 +345,7 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
  */
 export function run(settings: common.AppSettings): void {
   appSettings = settings;
+  metadata.init(settings);
   userManager.init(settings);
   jupyter.init(settings);
   auth.init(settings);
@@ -345,6 +353,7 @@ export function run(settings: common.AppSettings): void {
   reverseProxy.init(settings);
   sockets.init(settings);
 
+  metadataHandler = metadata.createHandler(settings);
   healthHandler = health.createHandler(settings);
   infoHandler = info.createHandler(settings);
   settingHandler = settings_.createHandler();


### PR DESCRIPTION
To use the new metadata server, first create the docker network on which it will run:

```sh
docker network create -d bridge --internal --subnet=169.254.169.254/16 metadata
```

Then run the container:

```sh
docker run -it --rm --name=datalab \
    --add-host="metadata.google.internal:169.254.169.254" \
    -p 127.0.0.1:8081:8080 \
    --env DATALAB_FAKE_METADATA_SERVER=true \
    --env PROJECT_NUMBER=$(gcloud projects describe $(gcloud config get-value core/project) --format "value(projectNumber)") \
    --env PROJECT_ID=$(gcloud config get-value core/project) \
    datalab
```

And attach it to that network:

```sh
docker network connect --ip 169.254.169.254 metadata datalab
```

You can then push your local credentials to the container with:

```sh
curl -X POST \
    -d "{\"account\": \"$(gcloud auth list --format 'value(account)' --filter 'status:ACTIVE')\", \"scopes\": \"https://www.googleapis.com/auth/cloud-platform\", \"access_token\": \"$(gcloud auth print-access-token)\", \"expires_in\": 300, \"token_type\": \"Bearer\"}" \
    http://localhost:8081/api/creds
```

... and then code cells run inside the container will use those credentials.