### PR TITLE
Add icons for BigQuery datasets and tables.

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-icons/datalab-icons.html
+++ b/sources/web/datalab/polymer/components/datalab-icons/datalab-icons.html
@@ -19,9 +19,18 @@ the License.
     <defs>
       <g id="bq-project">
         <path d="M10.557 11.99l-1.71-2.966 1.71-3.015h3.42l1.71 3.01-1.71
-        2.964h-3.42zM4.023 16l-1.71-2.966 1.71-3.015h3.42l1.71 3.01L7.443
-        16h-3.42zm0-8.016l-1.71-2.966 1.71-3.015h3.42l1.71 3.015-1.71
-        2.966h-3.42z" />
+            2.964h-3.42zM4.023 16l-1.71-2.966 1.71-3.015h3.42l1.71 3.01L7.443
+            16h-3.42zm0-8.016l-1.71-2.966 1.71-3.015h3.42l1.71 3.015-1.71
+            2.966h-3.42z" />
+      </g>
+      <g id="bq-dataset">
+        <path d="M2 2h14v14H2V2zm2 2h10v10H4V4zm2 6h2v2H6v-2zm0-4h2v2H6V6zm4
+            4h2v2h-2v-2zm0-4h2v2h-2V6z" fill-rule="evenodd"/>
+      </g>
+      <g id="bq-table">
+        <path d="M2 2h14v14H2V2zm2 6h2v2H4V8zm0-4h10v2H4V4zm0
+            8h2v2H4v-2zm4-4h2v2H8V8zm4 0h2v2h-2V8zm-4 4h2v2H8v-2zm4
+            0h2v2h-2v-2z" fill-rule="evenodd"/>
       </g>
     </defs>
   </svg>

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -147,7 +147,7 @@ class BigQueryFileManager implements FileManager {
   private _bqDatasetToDatalabFile(bqDataset: gapi.client.bigquery.DatasetResource): DatalabFile {
     const path = bqDataset.datasetReference.projectId + '/' + bqDataset.datasetReference.datasetId;
     return new BigQueryFile({
-      icon: 'folder',   // TODO(jimmc) - make a custom icon
+      icon: 'datalab-icons:bq-dataset',
       id: new DatalabFileId(path, FileManagerType.BIG_QUERY),
       name: bqDataset.datasetReference.datasetId,
       status: DatalabFileStatus.IDLE,
@@ -159,7 +159,7 @@ class BigQueryFileManager implements FileManager {
     const path = bqTable.tableReference.projectId + '/' +
           bqTable.tableReference.datasetId + '/' + bqTable.tableReference.tableId;
     return new BigQueryFile({
-      icon: 'list',   // TODO(jimmc) - make a custom icon
+      icon: 'datalab-icons:bq-table',
       id: new DatalabFileId(path, FileManagerType.BIG_QUERY),
       name: bqTable.tableReference.tableId,
       status: DatalabFileStatus.IDLE,


### PR DESCRIPTION
BQ Dataset in data browser:
![bq-dataset-icon](https://user-images.githubusercontent.com/116825/29730716-38972d0e-8996-11e7-9d2e-50525856d88e.png)

BQ Table in data browser:
![bg-table-icon](https://user-images.githubusercontent.com/116825/29730723-3d6ddbfc-8996-11e7-94ee-359f94357bd6.png)
