### PR TITLE
Skip basepath for settings requests

### DIFF
--- a/sources/web/datalab/polymer/modules/base-api-manager/base-api-manager.ts
+++ b/sources/web/datalab/polymer/modules/base-api-manager/base-api-manager.ts
@@ -74,7 +74,7 @@ interface ApiManager {
    * base path, and expecting a JSON response. This method returns immediately
    * with a promise that resolves with the parsed object when the request completes.
    */
-  sendRequestAsync(url: string, options?: XhrOptions): Promise<any>;
+  sendRequestAsync(url: string, options?: XhrOptions, prependBasepath?: boolean): Promise<any>;
 
   /**
    * Sends an XMLHttpRequest to the specified URL, adding the required
@@ -98,14 +98,22 @@ abstract class BaseApiManager implements ApiManager {
 
   public abstract getBasePath(): Promise<string>;
 
-  public async sendRequestAsync(url: string, options?: XhrOptions): Promise<string> {
+  public async sendRequestAsync(url: string, options?: XhrOptions, prependBasepath = true)
+      : Promise<any> {
     const basepath = await this.getBasePath();
-    return this._xhrJsonAsync(basepath + url, options);
+    if (prependBasepath) {
+      url = basepath + url;
+    }
+    return this._xhrJsonAsync(url, options);
   }
 
-  public async sendTextRequestAsync(url: string, options?: XhrOptions): Promise<string> {
+  public async sendTextRequestAsync(url: string, options?: XhrOptions, prependBasepath = true)
+      : Promise<string> {
     const basepath = await this.getBasePath();
-    return this._xhrTextAsync(basepath + url, options);
+    if (prependBasepath) {
+      url = basepath + url;
+    }
+    return this._xhrTextAsync(url, options);
   }
 
   public getServiceUrl(serviceId: ServiceId): string {

--- a/sources/web/datalab/polymer/modules/base-api-manager/base-api-manager.ts
+++ b/sources/web/datalab/polymer/modules/base-api-manager/base-api-manager.ts
@@ -100,8 +100,8 @@ abstract class BaseApiManager implements ApiManager {
 
   public async sendRequestAsync(url: string, options?: XhrOptions, prependBasepath = true)
       : Promise<any> {
-    const basepath = await this.getBasePath();
     if (prependBasepath) {
+      const basepath = await this.getBasePath();
       url = basepath + url;
     }
     return this._xhrJsonAsync(url, options);
@@ -109,8 +109,8 @@ abstract class BaseApiManager implements ApiManager {
 
   public async sendTextRequestAsync(url: string, options?: XhrOptions, prependBasepath = true)
       : Promise<string> {
-    const basepath = await this.getBasePath();
     if (prependBasepath) {
+      const basepath = await this.getBasePath();
       url = basepath + url;
     }
     return this._xhrTextAsync(url, options);

--- a/sources/web/datalab/polymer/modules/settings-manager/settings-manager.ts
+++ b/sources/web/datalab/polymer/modules/settings-manager/settings-manager.ts
@@ -71,7 +71,7 @@ class SettingsManager {
     const apiManager = ApiManagerFactory.getInstance();
     const requestUrl = apiManager.getServiceUrl(ServiceId.USER_SETTINGS) +
         '?key=' + setting + '&value=' + value;
-    return apiManager.sendRequestAsync(requestUrl, xhrOptions);
+    return apiManager.sendRequestAsync(requestUrl, xhrOptions, false /* prependBasepath*/);
   }
 
   /**
@@ -116,7 +116,8 @@ class SettingsManager {
    */
   private static _getUserSettingsAsync() {
     const apiManager = ApiManagerFactory.getInstance();
-    return apiManager.sendRequestAsync(apiManager.getServiceUrl(ServiceId.USER_SETTINGS));
+    return apiManager.sendRequestAsync(apiManager.getServiceUrl(ServiceId.USER_SETTINGS),
+                                       undefined, false /* prependBasepath*/);
   }
 
   /**
@@ -124,7 +125,8 @@ class SettingsManager {
    */
   private static _getAppSettingsAsync() {
     const apiManager = ApiManagerFactory.getInstance();
-    return apiManager.sendRequestAsync(apiManager.getServiceUrl(ServiceId.APP_SETTINGS));
+    return apiManager.sendRequestAsync(apiManager.getServiceUrl(ServiceId.APP_SETTINGS),
+                                       undefined, false /* prependBasepath*/);
   }
 
 }


### PR DESCRIPTION
Settings manager shouldn't care about basepath. For now the frontend server will serve those immediately, and this might change later.