### PR TITLE
Load file manager type from settings, default to drive if no setting provided

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -37,6 +37,11 @@ declare module common {
      */
     consoleLogLevel: string;
 
+    /**
+     * The default file manager type to use if none is specified.
+     */
+    defaultFileManager: string;
+
     logFilePath: string;
     logFilePeriod: string;
     logFileCount: number;

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -1,6 +1,7 @@
 {
   "consoleLogging": true,
   "consoleLogLevel": "warn",
+  "defaultFileManager": "jupyter",
   "release": "beta",
   "logFilePath": "/var/log/app_engine/custom_logs/app.log",
   "logFilePeriod": "300000ms",

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -166,15 +166,20 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     if (params.has('filemanager')) {
       this.fileManagerType = params.get('filemanager') as string;
     }
+    // If no file manager type is specified in the element's attributes, try to
+    // get it from the app settings. If it's not specified there either, default
+    // to drive.
     if (!this.fileManagerType) {
-      // TODO - This element should not have to set a default file manager type, but
-      // it is currently required to know that we should load the startuppath.
-      this.fileManagerType = 'jupyter';
-      this._fileManager = FileManagerFactory.getInstance();
-    } else {
-      this._fileManager = FileManagerFactory.getInstanceForType(
-          FileManagerFactory.fileManagerNameToType(this.fileManagerType));
+      const appSettings = await SettingsManager.getAppSettingsAsync();
+      if (appSettings.defaultFileManager) {
+        this.fileManagerType = appSettings.defaultFileManager;
+      } else {
+        this.fileManagerType = 'drive';
+      }
     }
+
+    this._fileManager = FileManagerFactory.getInstanceForType(
+        FileManagerFactory.fileManagerNameToType(this.fileManagerType));
 
     // TODO: Using a ready promise might be common enough a need that we should
     // consider adding it to a super class, maybe DatalabElement. For now, this

--- a/sources/web/datalab/polymer/test/file-browser-test.html
+++ b/sources/web/datalab/polymer/test/file-browser-test.html
@@ -27,7 +27,7 @@ the License.
 
     <test-fixture id="files-fixture">
       <template>
-        <file-browser></file-browser>
+        <file-browser file-manager-type="jupyter"></file-browser>
       </template>
     </test-fixture>
 


### PR DESCRIPTION
This PR makes drive the default file manager type if one is not specified in the app settings.