### PR TITLE
Create a new browser instance for each test

### DIFF
--- a/test/notebook/test_spec.js
+++ b/test/notebook/test_spec.js
@@ -91,16 +91,6 @@ function testNotebook(driver, path, ignoreList = [], done) {
           });
         });
     })
-    .then(function() {
-      // saving the notebook avoids having to deal with an alert when navigating away
-      return driver.executeScript('Jupyter.notebook.save_notebook();')
-      .then(driver.wait(function() {
-        return driver.executeScript('return Jupyter.notebook.dirty')
-          .then(function(dirty) {
-            return dirty === false;
-          });
-      }, 2000));
-    })
     .finally(function() {
       since('"expect" for output.name was not executed')
           .expect(testComplete).toBe(true);
@@ -112,10 +102,10 @@ describe('Notebook tests', function() {
 
   let driver;
 
-  beforeAll(function() {
+  beforeEach(function() {
     driver = createDriver();
   });
-  afterAll(function() {
+  afterEach(function() {
     releaseDriver(driver);
   });
 


### PR DESCRIPTION
This should help with the notebook test flakiness. Reusing the same browser object meant navigating away from notebooks after running them, which often failed because of the confirmation popup, which in turn wasn't getting dismissed properly because of timing issues.
This PR creates a new browser for each notebook.