### PR TITLE
Raise threshold for image diff

### DIFF
--- a/test/ui/test_spec.js
+++ b/test/ui/test_spec.js
@@ -33,7 +33,7 @@ const initTimeout = 10000;   // 10 seconds for initialization time, building the
 const scriptTimeout = 10000; // 10 seconds for running synchronous js scripts in the driver
 jasmine.DEFAULT_TIMEOUT_INTERVAL = testTimeout;
 
-const misMatchThreshold = 0;
+const misMatchThreshold = 1;
 const goldenPathPrefix = 'ui/golden/';
 const brokenPathPrefix = 'ui/broken/';
 


### PR DESCRIPTION
Minor render changes sometimes caused this. Raising to 1 until we find a better way to stabilize the ui tests, this will still catch big changes.