### PR TITLE
Remove basepath from notebook and editor urls

### DIFF
--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -102,18 +102,12 @@ class DriveFileManager implements FileManager {
   }
 
   public async getEditorUrl(fileId: DatalabFileId) {
-    // Files that are stored on the VM require the basepath.
-    const apiManager = ApiManagerFactory.getInstance();
-    const basepath = await apiManager.getBasePath();
-    return location.protocol + '//' + location.host + basepath +
+    return location.protocol + '//' + location.host +
         '/editor?file=' + fileId.toQueryString();
   }
 
   public async getNotebookUrl(fileId: DatalabFileId): Promise<string> {
-    // Notebooks that are stored on the VM require the basepath.
-    const apiManager = ApiManagerFactory.getInstance();
-    const basepath = await apiManager.getBasePath();
-    return location.protocol + '//' + location.host + basepath +
+    return location.protocol + '//' + location.host +
         '/notebook#fileId=' + fileId.toQueryString();
   }
 }

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
@@ -313,17 +313,15 @@ class JupyterFileManager implements FileManager {
   }
 
   public async getNotebookUrl(fileId: DatalabFileId) {
-    // Notebooks that are stored on the VM require the basepath.
-    const apiManager = ApiManagerFactory.getInstance();
-    const basepath = await apiManager.getBasePath();
-    return location.protocol + '//' + location.host + basepath + '/notebooks/' + fileId.path;
+    // TODO: We will need to get the base path when loading files
+    // from a VM running Datalab with Jupyter.
+    return location.protocol + '//' + location.host + '/notebooks/' + fileId.path;
   }
 
   public async getEditorUrl(fileId: DatalabFileId) {
-    // Files that are stored on the VM require the basepath.
-    const apiManager = ApiManagerFactory.getInstance();
-    const basepath = await apiManager.getBasePath();
-    return location.protocol + '//' + location.host + basepath + '/editor?file=' +
+    // TODO: We will need to get the base path when loading notebooks
+    // from a VM running Datalab with Jupyter.
+    return location.protocol + '//' + location.host + '/editor?file=' +
         fileId.toQueryString();
   }
 }


### PR DESCRIPTION
When we can load notebooks/files from a hosted Datalab instance using its Jupyter interface, we'll need to add these again appropriately.