### PR TITLE
Add file name filters in drive list

### DIFF
--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -60,9 +60,15 @@ class DriveFileManager implements FileManager {
   }
 
   public async list(fileId: DatalabFileId): Promise<DatalabFile[]> {
+    const whitelistFilePredicates = [
+      'name contains \'.ipynb\'',
+      'name contains \'.txt\'',
+      'mimeType = \'application/vnd.google-apps.folder\'',
+    ];
     const queryPredicates = [
       '"' + fileId.path + '" in parents',
       'trashed = false',
+      '(' + whitelistFilePredicates.join(' or ') + ')',
     ];
     const fileFields = [
       'createdTime',


### PR DESCRIPTION
This filters the files displayed by the DriveFileManager to be just .ipynb and .txt files for now, and directories.