### PR TITLE
Use redirect instead of popup for gapi auth

### DIFF
--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -383,6 +383,7 @@ class GapiManager {
       client_id: GapiManager._clientId,
       fetch_basic_profile: true,
       scope: initialScopeString,
+      ux_mode: 'redirect',
     })
     // .init does not return a catch-able promise
     .then(() => {


### PR DESCRIPTION
Popups aren't good web citizens.

Note that we'll need to whitelist our possible origins and redirect urls in order for this to work. If you're developing locally using your own oauth client ID, make sure `localhost:8081` (or whatever port you're using) is in the authorized origins, and `localhost:8081/*` is in the authorized redirect URIs.