### PR TITLE
Use resizable divider on preview pane in file browser.

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
+++ b/sources/web/datalab/polymer/components/datalab-data/datalab-data.html
@@ -88,7 +88,7 @@ the License.
       }
     </style>
 
-    <resizable-divider initial-divider-position="70" minimum-width-px="200">
+    <resizable-divider divider-position="70" minimum-width-px="200">
 
       <div class="resultsColumn" slot="left">
         <!-- Input box to enter search terms -->

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -254,9 +254,8 @@ the License.
 
       <!--File listing-->
       <resizable-divider id="filesContainer" class="files-container"
-          divider-position="{{_dividerPosition}}" minimum-width-px="0"
-          hide-right="{{!_isPreviewPaneToggledOn}}"
-        >
+          divider-position="{{_dividerPosition}}"
+          hide-right="{{!_isPreviewPaneToggledOn}}">
         <item-list id="files" slot="left" hide-header$="{{small}}" disable-selection$="{{small}}"></item-list>
         <preview-pane id="previewPane" slot="right" file="{{selectedFile}}" active="{{_isPreviewPaneEnabled}}"
                       class$="preview-pane-enabled--{{_isPreviewPaneEnabled}}">

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -253,12 +253,15 @@ the License.
       </paper-progress>
 
       <!--File listing-->
-      <div class="files-container">
-        <item-list id="files" hide-header$="{{small}}" disable-selection$="{{small}}"></item-list>
-        <preview-pane id="previewPane" file="{{selectedFile}}" active="{{_isPreviewPaneEnabled}}"
+      <resizable-divider id="filesContainer" class="files-container"
+          divider-position="{{_dividerPosition}}" minimum-width-px="0"
+          hide-right="{{!_isPreviewPaneToggledOn}}"
+        >
+        <item-list id="files" slot="left" hide-header$="{{small}}" disable-selection$="{{small}}"></item-list>
+        <preview-pane id="previewPane" slot="right" file="{{selectedFile}}" active="{{_isPreviewPaneEnabled}}"
                       class$="preview-pane-enabled--{{_isPreviewPaneEnabled}}">
         </preview-pane>
-      </div>
+      </resizable-divider>
     </div>
 
   </template>

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -68,6 +68,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
   private _addToolbarCollapseThreshold = 900;
   private _apiManager: ApiManager;
+  private _dividerPosition: number;
   private _previewPaneCollapseThreshold = 600;
   private _fetching: boolean;
   private _fileList: DatalabFile[];
@@ -85,6 +86,11 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
   static get properties() {
     return {
+      _dividerPosition: {
+        observer: '_dividerPositionChanged',
+        type: Number,
+        value: 70,
+      },
       _fetching: {
         type: Boolean,
         value: false,
@@ -291,7 +297,8 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
   /**
    * Called when the selection changes on the item list. If exactly one file
-   * is selected, sets the selectedFile property to the selected file object.
+   * is selected, sets the selectedFile property to the selected file object
+   * and opens the preview pane.
    */
   _handleSelectionChanged() {
     const selectedIndices = (this.$.files as ItemListElement).selectedIndices;
@@ -630,6 +637,18 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
   }
 
   /**
+   * Gets called when the divider position changes, to update ToggledOn
+   * if the user moves the position to or from 100%.
+   */
+  _dividerPositionChanged() {
+    if (this._dividerPosition === 100 && this._isPreviewPaneToggledOn) {
+      this._isPreviewPaneToggledOn = false;
+    } else if (this._dividerPosition < 100 && !this._isPreviewPaneToggledOn) {
+      this._isPreviewPaneToggledOn = true;
+    }
+  }
+
+  /**
    * Computes whether the preview pane should be enabled. This depends on two values:
    * whether the element has the small attribute, and whether the user has switched it
    * off manually.
@@ -767,6 +786,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     }
 
     (this.$.breadCrumbs as BreadCrumbsElement).resizeHandler();
+    (this.$.filesContainer as ResizableDividerElement).resizeHandler();
   }
 
   /**

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -297,8 +297,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
   /**
    * Called when the selection changes on the item list. If exactly one file
-   * is selected, sets the selectedFile property to the selected file object
-   * and opens the preview pane.
+   * is selected, sets the selectedFile property to the selected file object.
    */
   _handleSelectionChanged() {
     const selectedIndices = (this.$.files as ItemListElement).selectedIndices;

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -29,8 +29,13 @@ the License.
       }
       .pane {
         overflow: auto;
-        width: 50%;
+        height: 100%;
+        width: calc(50% - var(--divider-half-width));
         user-select: none;
+      }
+      .right {
+        position: absolute;
+        left: calc(50% + var(--divider-half-width));
       }
       /**
        * Slotted elements should fill the content slots, and be border-boxed so
@@ -51,24 +56,24 @@ the License.
         top: 0px;
         bottom: 0px;
         left: calc(50% - var(--divider-half-width));
-        right: calc(50% + var(--divider-half-width));
         width: calc(2 * var(--divider-half-width));
+        background-color: var(--selection-bg-color);
       }
       #divider.active {
         user-select: none;
-        background-color: var(--selection-bg-color);
+        background-color: var(--border-color);
       }
     </style>
 
     <div id="container">
 
-      <div id="leftPane" class="pane">
+      <div id="leftPane" class="pane left">
         <slot name="left"></slot>
       </div>
 
       <div id="divider" on-mousedown="{{_mouseDownHandler}}"></div>
 
-      <div id="rightPane" class="pane">
+      <div id="rightPane" class="pane right">
         <slot name="right"></slot>
       </div>
 

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
@@ -48,11 +48,11 @@ class ResizableDividerElement extends Polymer.Element {
     return {
       dividerPosition: {
         notify: true,
-        observer: '_dividerMoved',
+        observer: '_dividerPositionChanged',
         type: Number,
       },
       hideRight: {
-        observer: '_hideChanged',
+        observer: '_hideRightChanged',
         type: Boolean,
         value: false,
       },
@@ -76,12 +76,12 @@ class ResizableDividerElement extends Polymer.Element {
     this._dividerWidth = divider.getBoundingClientRect().width;
 
     // Initialize the divider position.
-    this._dividerMoved();
+    // this._dividerPositionChanged();
     this._readyDone = true;
   }
 
   resizeHandler() {
-    this._dividerMoved();
+    this._dividerPositionChanged();
   }
 
   _mouseDownHandler() {
@@ -106,17 +106,17 @@ class ResizableDividerElement extends Polymer.Element {
     const container = this.$.container as HTMLDivElement;
     const containerRect = container.getBoundingClientRect();
     const newLeftPaneWidth = event.clientX - containerRect.left;
-    const fullWidthLessDivider = containerRect.width - this._dividerWidth;
-    const newPosition = newLeftPaneWidth * 100 / fullWidthLessDivider;
+    const widthMinusDivider = containerRect.width - this._dividerWidth;
+    const newPosition = newLeftPaneWidth * 100 / widthMinusDivider;
     this.dividerPosition =
         (newPosition < 0) ? 0 : (newPosition > 100) ? 100 : newPosition;
-    // Let observer call _dividerMoved
+    // Let observer call _dividerPositionChanged
   }
 
   /**
    * Calculate the new divider position after hideRight changes.
    */
-  _hideChanged() {
+  _hideRightChanged() {
     if (!this._readyDone) {
       return;   // Leave divider position unchanged on startup
     } else if (this.hideRight) {
@@ -138,14 +138,14 @@ class ResizableDividerElement extends Polymer.Element {
   /**
    * Calculates and sets the new widths of the two panes after the divider moved.
    */
-  _dividerMoved() {
+  _dividerPositionChanged() {
     const container = this.$.container as HTMLDivElement;
     const containerRect = container.getBoundingClientRect();
-    const fullWidthLessDivider = containerRect.width - this._dividerWidth;
+    const widthMinusDivider = containerRect.width - this._dividerWidth;
     const dividerPosition =
         this.dividerPosition > -1 ? this.dividerPosition : 50;
     const newPos =
-        containerRect.left + (fullWidthLessDivider * dividerPosition / 100);
+        containerRect.left + (widthMinusDivider * dividerPosition / 100);
     const divider = this.$.divider as HTMLDivElement;
     const leftPane = this.$.leftPane as HTMLDivElement;
     const rightPane = this.$.rightPane as HTMLDivElement;
@@ -156,11 +156,11 @@ class ResizableDividerElement extends Polymer.Element {
     // If either pane is getting too small, make it minimum width
     // TODO: Check whether minimum width makes sense here, and bail out if it's
     // larger than half the container width
-    if (newLeftPaneWidth < this.minimumWidthPx) {
+    if (newLeftPaneWidth > 0 && newLeftPaneWidth < this.minimumWidthPx) {
       newLeftPaneWidth = this.minimumWidthPx;
       newRightPaneWidth =
           containerRect.width - newLeftPaneWidth - this._dividerWidth;
-    } else if (newRightPaneWidth < this.minimumWidthPx) {
+    } else if (newRightPaneWidth > 0 && newRightPaneWidth < this.minimumWidthPx) {
       newRightPaneWidth = this.minimumWidthPx;
       newLeftPaneWidth =
           containerRect.width - newRightPaneWidth - this._dividerWidth;

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
@@ -40,7 +40,6 @@ class ResizableDividerElement extends Polymer.Element {
   private _dividerWidth: number;
   private _lastMouseDownPosition: number;
   private _lastMouseUpPosition: number;
-  private _readyDone = false;
 
   static get is() { return 'resizable-divider'; }
 
@@ -74,10 +73,6 @@ class ResizableDividerElement extends Polymer.Element {
 
     divider.addEventListener('mousedown', this._boundMouseDownHandler);
     this._dividerWidth = divider.getBoundingClientRect().width;
-
-    // Initialize the divider position.
-    // this._dividerPositionChanged();
-    this._readyDone = true;
   }
 
   resizeHandler() {
@@ -116,8 +111,8 @@ class ResizableDividerElement extends Polymer.Element {
   /**
    * Calculate the new divider position after hideRight changes.
    */
-  _hideRightChanged() {
-    if (!this._readyDone) {
+  _hideRightChanged(_: boolean, oldValue: boolean) {
+    if (oldValue === undefined) {
       return;   // Leave divider position unchanged on startup
     } else if (this.hideRight) {
       this.dividerPosition = 100;

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
@@ -24,20 +24,37 @@ class ResizableDividerElement extends Polymer.Element {
   public minimumWidthPx: number;
 
   /**
-   * Initial position of the divider in percentage. Defaults to 50(%);
+   * Position of the divider in percentage. Defaults to 50(%);
    */
-  public initialDividerPosition: number;
+  public dividerPosition = 50;
+
+  /**
+   * Set to true to hide the right-hand pane.
+   */
+  public hideRight: boolean;
 
   private _boundMouseDownHandler: EventListenerOrEventListenerObject;
   private _boundMouseupHandler: EventListenerOrEventListenerObject;
   private _boundMouseMoveHandler: EventListenerOrEventListenerObject;
+  private _defaultUnhidePosition = 75;
+  private _dividerWidth: number;
+  private _lastMouseDownPosition: number;
+  private _lastMouseUpPosition: number;
+  private _readyDone = false;
+
   static get is() { return 'resizable-divider'; }
 
   static get properties() {
     return {
-      initialDividerPosition: {
+      dividerPosition: {
+        notify: true,
+        observer: '_dividerMoved',
         type: Number,
-        value: 50,
+      },
+      hideRight: {
+        observer: '_hideChanged',
+        type: Boolean,
+        value: false,
       },
       minimumWidthPx: {
         type: Number,
@@ -54,15 +71,17 @@ class ResizableDividerElement extends Polymer.Element {
     this._boundMouseMoveHandler = this._mouseMoveHandler.bind(this);
 
     const divider = this.$.divider as HTMLDivElement;
-    const container = this.$.container as HTMLDivElement;
 
     divider.addEventListener('mousedown', this._boundMouseDownHandler);
+    this._dividerWidth = divider.getBoundingClientRect().width;
 
-    // Initialize the divider position. We need to calculate this initial
-    // position relative to the container element.
-    const containerRect = container.getBoundingClientRect();
-    const pos = containerRect.left + (containerRect.width * this.initialDividerPosition / 100);
-    this._resizePanes(pos);
+    // Initialize the divider position.
+    this._dividerMoved();
+    this._readyDone = true;
+  }
+
+  resizeHandler() {
+    this._dividerMoved();
   }
 
   _mouseDownHandler() {
@@ -71,6 +90,7 @@ class ResizableDividerElement extends Polymer.Element {
 
     // Style the divider while dragging
     this.$.divider.classList.add('active');
+    this._lastMouseDownPosition = this.dividerPosition;
   }
 
   _mouseUpHandler() {
@@ -79,40 +99,77 @@ class ResizableDividerElement extends Polymer.Element {
 
     // stop styling the handle as active because dragging is done
     this.$.divider.classList.remove('active');
+    this._lastMouseUpPosition = this.dividerPosition;
   }
 
   _mouseMoveHandler(event: MouseEvent) {
-    this._resizePanes(event.clientX);
+    const container = this.$.container as HTMLDivElement;
+    const containerRect = container.getBoundingClientRect();
+    const newLeftPaneWidth = event.clientX - containerRect.left;
+    const fullWidthLessDivider = containerRect.width - this._dividerWidth;
+    const newPosition = newLeftPaneWidth * 100 / fullWidthLessDivider;
+    this.dividerPosition =
+        (newPosition < 0) ? 0 : (newPosition > 100) ? 100 : newPosition;
+    // Let observer call _dividerMoved
   }
 
   /**
-   * Calculates and sets the new widths of the two panes.
+   * Calculate the new divider position after hideRight changes.
    */
-  _resizePanes(newPos: number) {
+  _hideChanged() {
+    if (!this._readyDone) {
+      return;   // Leave divider position unchanged on startup
+    } else if (this.hideRight) {
+      this.dividerPosition = 100;
+    } else {
+      // Make the right pane visible
+      if (this._lastMouseUpPosition > 0 &&
+          this._lastMouseUpPosition < 100) {
+        this.dividerPosition = this._lastMouseUpPosition;
+      } else if (this._lastMouseDownPosition > 0 &&
+                 this._lastMouseDownPosition < 100) {
+        this.dividerPosition = this._lastMouseDownPosition;
+      } else {
+        this.dividerPosition = this._defaultUnhidePosition;
+      }
+    }
+  }
+
+  /**
+   * Calculates and sets the new widths of the two panes after the divider moved.
+   */
+  _dividerMoved() {
     const container = this.$.container as HTMLDivElement;
+    const containerRect = container.getBoundingClientRect();
+    const fullWidthLessDivider = containerRect.width - this._dividerWidth;
+    const dividerPosition =
+        this.dividerPosition > -1 ? this.dividerPosition : 50;
+    const newPos =
+        containerRect.left + (fullWidthLessDivider * dividerPosition / 100);
     const divider = this.$.divider as HTMLDivElement;
     const leftPane = this.$.leftPane as HTMLDivElement;
     const rightPane = this.$.rightPane as HTMLDivElement;
 
-    const containerRect = container.getBoundingClientRect();
-
     let newLeftPaneWidth = newPos - containerRect.left;
-    let newRightPaneWidth = containerRect.right - newPos;
+    let newRightPaneWidth = containerRect.right - newPos - this._dividerWidth;
 
     // If either pane is getting too small, make it minimum width
     // TODO: Check whether minimum width makes sense here, and bail out if it's
     // larger than half the container width
     if (newLeftPaneWidth < this.minimumWidthPx) {
       newLeftPaneWidth = this.minimumWidthPx;
-      newRightPaneWidth = containerRect.width - newLeftPaneWidth;
+      newRightPaneWidth =
+          containerRect.width - newLeftPaneWidth - this._dividerWidth;
     } else if (newRightPaneWidth < this.minimumWidthPx) {
       newRightPaneWidth = this.minimumWidthPx;
-      newLeftPaneWidth = containerRect.width - newRightPaneWidth;
+      newLeftPaneWidth =
+          containerRect.width - newRightPaneWidth - this._dividerWidth;
     }
 
-    leftPane.style.width = newLeftPaneWidth / containerRect.width * 100 + '%';
-    rightPane.style.width = newRightPaneWidth / containerRect.width * 100 + '%';
+    leftPane.style.width = newLeftPaneWidth + 'px';
     divider.style.left = leftPane.style.width;
+    rightPane.style.width = newRightPaneWidth + 'px';
+    rightPane.style.left = (newLeftPaneWidth + this._dividerWidth) + 'px';
   }
 
 }

--- a/sources/web/datalab/polymer/test/resizable-divider-test.html
+++ b/sources/web/datalab/polymer/test/resizable-divider-test.html
@@ -38,7 +38,7 @@ the License.
     <div id="container">
       <test-fixture id="resizable-divider-fixture">
         <template>
-            <resizable-divider>
+            <resizable-divider divider-position="50%">
               <div slot="left">
                 <div id="left-pane">
                   left pane

--- a/sources/web/datalab/polymer/test/resizable-divider-test.ts
+++ b/sources/web/datalab/polymer/test/resizable-divider-test.ts
@@ -65,26 +65,30 @@ describe('<resizable-divider>', () => {
   it('shows left pane to the left of the right pane, and divider in between', () => {
     const offset = testFixture.getBoundingClientRect().left;
     assert(left.getBoundingClientRect().left === offset, 'left pane should stick to the left');
-    assert(left.getBoundingClientRect().right === offset + 200,
-        'left pane should extend all the way to the middle of the container');
+    assert(left.getBoundingClientRect().right === offset + 195,
+        'left pane should extend to the divider');
 
-    assert(divider.getBoundingClientRect().left === offset + 200,
-        'divider should start at the middle of the container');
+    assert(divider.getBoundingClientRect().left === offset + 195,
+        'divider should start to the right of the left pane');
+    assert(divider.getBoundingClientRect().right === offset + 205,
+        'divider should have the right width');
 
-    assert(right.getBoundingClientRect().left === offset + 200,
-        'right pane should start at the middle of the container');
-    assert(right.getBoundingClientRect().left === offset + 200,
+    assert(right.getBoundingClientRect().left === offset + 205,
+        'right pane should start to the right of the divider');
+    assert(right.getBoundingClientRect().right === offset + 400,
         'right pane stick to the right of the container');
   });
 
   it('makes child panes fill height', () => {
-    assert(left.getBoundingClientRect().height === 800, 'left pane should be fill the height');
-    assert(right.getBoundingClientRect().height === 800, 'right pane should be fill the height');
+    assert(left.getBoundingClientRect().height === 800, 'left pane should fill the height');
+    assert(right.getBoundingClientRect().height === 800, 'right pane should fill the height');
   });
 
   it('shows panes with half the element width by default', () => {
-    assert(left.getBoundingClientRect().width === 200, 'left pane should be half the width');
-    assert(right.getBoundingClientRect().width === 200, 'right pane should be half the width');
+    assert(left.getBoundingClientRect().width === 195,
+        'left pane should be half the width less divider half-width');
+    assert(right.getBoundingClientRect().width === 195,
+        'right pane should be half the width less divider half-width');
   });
 
   it('resizes panes when divider is dragged', () => {
@@ -94,12 +98,12 @@ describe('<resizable-divider>', () => {
 
     dragAndDrop(divider, x, y, x - 100, y + 300);
 
-    assert(left.getBoundingClientRect().width === 100,
-        'left pane should be 100px after resizing');
-    assert(right.getBoundingClientRect().width === 300,
-        'right pane should be 100px after resizing');
-    assert(divider.getBoundingClientRect().left === offset + 100,
-        'divider should move with mouse when resizing');
+    assert(left.getBoundingClientRect().width === 95,
+        'left pane should be 95px after resizing');
+    assert(right.getBoundingClientRect().width === 295,
+        'right pane should be 295px after resizing');
+    assert(divider.getBoundingClientRect().left === offset + 95,
+        'divider should move with mouse.x when resizing');
   });
 
 });


### PR DESCRIPTION
* Use resizable divider in file-browser element
* Make divider always visible to give the user an affordance
* Update file-browser visibility button to work with resizable divider
* Allow right pane in file browser to be opened and closed either using the visibility icon or by sliding the divider

This is what the divider now looks like in the file browser. It changes to a slightly different shade when active. We can improve the visuals later.
![resizable-divider](https://user-images.githubusercontent.com/116825/29897681-f57e2b94-8d96-11e7-83a3-30e50b2688fb.png)
