### PR TITLE
Update app-route version to get fix for disappearing query parameters.

### DIFF
--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -3,7 +3,7 @@
   "main": "index.html",
   "dependencies": {
     "app-layout": "PolymerElements/app-layout#^2.0.0",
-    "app-route": "PolymerElements/app-route#^2.0.0",
+    "app-route": "PolymerElements/app-route#^2.0.2",
     "codemirror": "^5.27.2",
     "iron-a11y-keys": "PolymerElements/iron-a11y-keys#^2.0.0",
     "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^2.0.0",
@@ -23,7 +23,7 @@
     "paper-spinner": "PolymerElements/paper-spinner#^2.0.0",
     "paper-toast": "PolymerElements/paper-toast#^2.0.0",
     "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.0",
-    "polymer": "Polymer/polymer#^2.0.1",
+    "polymer": "Polymer/polymer#^2.0.2",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.9",
     "xterm.js": "^2.7.0"
   },


### PR DESCRIPTION
See https://github.com/PolymerElements/app-route/issues/192
and https://github.com/PolymerElements/app-route/pull/211/files

Polymer bug #192 is that query parameters specified in the URL get stripped off by app-location.