### PR TITLE
Fix empty notebook template

### DIFF
--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -72,7 +72,14 @@ class DatalabFileId {
 }
 
 class NotebookContent {
-  public static EMPTY_NOTEBOOK_CONTENT = '{"cells": []}';
+  public static EMPTY_NOTEBOOK_CONTENT = `{
+    "cells": [
+    ],
+    "metadata": {},
+    "nbformat": 4,
+    "nbformat_minor": 0
+  }
+  `;
 
   public cells: NotebookCell[];
   metadata?: object;

--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -179,6 +179,7 @@ class GapiManager {
       const apiManager = ApiManagerFactory.getInstance();
       const xhrOptions: XhrOptions = {
         headers: {Authorization: 'Bearer ' + GapiManager._accessToken.access_token},
+        noCache: true,
       };
       const file: gapi.client.drive.File = await apiManager.sendRequestAsync(
             'https://www.googleapis.com/drive/v2/files/' + id,


### PR DESCRIPTION
Empty template was missing a few arguments required by the parser.