### PR TITLE
Use ?file querystring for file id

### DIFF
--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -142,6 +142,6 @@ class DriveFileManager implements FileManager {
 
   public async getNotebookUrl(fileId: DatalabFileId): Promise<string> {
     return location.protocol + '//' + location.host +
-        '/notebook#fileId=' + fileId.toQueryString();
+        '/notebook?file=' + fileId.toQueryString();
   }
 }


### PR DESCRIPTION
This switches to using the same querystring parameter `file` for the notebook editor that we use elsewhere.