### PR TITLE
Fix height problem for divider in file-browser.

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -101,7 +101,6 @@ the License.
       #file-picker {
         display: flex;
         flex-direction: column;
-        flex: 1 1 auto;
         height: 100%;
       }
       #navbar {

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -102,6 +102,7 @@ the License.
         display: flex;
         flex-direction: column;
         flex: 1 1 auto;
+        height: 100%;
       }
       #navbar {
         display: flex;


### PR DESCRIPTION
This makes the divider container in the file-browser full height.

Before:
![divider-before](https://user-images.githubusercontent.com/116825/30183752-6c150c8e-93d0-11e7-9be5-0e91acf9ba24.png)

After:
![divider-after](https://user-images.githubusercontent.com/116825/30183749-68167f14-93d0-11e7-80cb-32fa8b82ebf6.png)
