### PR TITLE
Fix `pip install` errors on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ cache:
 
 before_install:
 - pip install -U pip
-- pip install flake8
+- pip install flake8 --user travis
 
 install:
 - cd $TRAVIS_BUILD_DIR/containers/datalab

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
   - node_modules
 
 before_install:
-- pip install -U pip
+- pip install -U pip --user travis
 - pip install flake8 --user travis
 
 install:


### PR DESCRIPTION
Travis isn't happy about the fact that we declare `node_js` to be the repo's language, then try to do `pip install`s. One fix is to change the language to `python`, but I found that using the `--user` option also fixes it, and I feel like this is a little cleaner.

For reference: https://github.com/travis-ci/travis-ci/issues/1705.