### PR TITLE
Add notebook app<->datalab app communication shim

### DIFF
--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.html
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.html
@@ -60,5 +60,4 @@ the License.
   </template>
 </dom-module>
 
-<script src="https://apis.google.com/js/api.js"></script>
 <script src="auth-panel.js"></script>

--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.html
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.html
@@ -16,4 +16,5 @@ the License.
 <link rel="import" href="../../modules/settings-manager/settings-manager.html">
 <link rel="import" href="../../modules/utils/utils.html">
 
+<script src="https://apis.google.com/js/api.js"></script>
 <script src="gapi-manager.js"></script>

--- a/sources/web/datalab/polymer/notebook.html
+++ b/sources/web/datalab/polymer/notebook.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport"
+          content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+    <title>Google Cloud Datalab</title>
+    <link rel="shortcut icon" href="images/favicon.ico">
+
+    <link id="themeStylesheet" rel="stylesheet" href="index.light.css">
+    <link rel="import" href="modules/api-manager-factory/api-manager-factory.html">
+    <link rel="import" href="modules/utils/utils.html">
+  </head>
+  <body>
+    <style>
+      body {
+        margin: 0px;
+        padding: 0px;
+        height: 100%;
+      }
+      iframe {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        border: none;
+      }
+    </style>
+
+    <iframe id="editor" sandbox="allow-scripts allow-same-origin"></iframe>
+
+    <script src="notebook.js"></script>
+  </body>
+</html>

--- a/sources/web/datalab/polymer/notebook.ts
+++ b/sources/web/datalab/polymer/notebook.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * This file contains communication logic between the notebook editor and the
+ * rest of the UI components. The notebook editor app will send messages across
+ * the iframe boundary using postMessage. Messages have a defined structure,
+ * and will trigger this code to call methods in the rest of the UI components
+ * to act according to the requested action.
+ */
+enum IframeMessageCommand {
+  UPLOAD_USER_CREDS,
+}
+
+interface IframeMessage {
+  command: IframeMessageCommand;
+  arguments: any;
+}
+
+function processMessageEvent(e: MessageEvent) {
+  if (!e.data || !e.data.hasOwnProperty('command')) {
+    Utils.log.error('Received unknown message: ', e.data);
+    return;
+  }
+
+  const message = e.data as IframeMessage;
+
+  if (message.command === IframeMessageCommand.UPLOAD_USER_CREDS) {
+    ApiManagerFactory.getInstance().uploadOauthAccessToken();
+  } else {
+    Utils.log.error('Received unknown message command: ', message.command);
+    return;
+  }
+}
+
+const params = new URLSearchParams(window.location.search);
+if (params.has('file')) {
+  const iframe = document.querySelector('#editor') as HTMLIFrameElement;
+  // Currently this is one-directional, iframe wrapper querystring -> iframe hash param.
+  // We will need to change this if the editor is allowed to change the id of the
+  // open file, for example in the case of Jupyter files where the id is the file path.
+  if (iframe) {
+    window.top.addEventListener('message', processMessageEvent);
+    iframe.src = '/notebookeditor#fileId=' + params.get('file');
+  }
+}

--- a/sources/web/datalab/polymer/polymer.json
+++ b/sources/web/datalab/polymer/polymer.json
@@ -14,11 +14,13 @@
     "components/text-preview/text-preview.html"
   ],
   "sources": [
-    "modules/**/*.js",
-    "images/**/*",
     "editor.html",
     "editor.js",
-    "index.*.css"
+    "images/**/*",
+    "index.*.css",
+    "modules/**/*.js",
+    "notebook.html",
+    "notebook.js"
   ],
   "extraDependencies": [
     "bower_components/codemirror/addon/**",


### PR DESCRIPTION
This PR adds a notebook editor wrapper as an entry point, and a simple one-directional communication layer to listen for commands coming from the notebook editor. For now the only command it listens for is to upload user credentials.