### PR TITLE
Use visibility-off icon when preview pane is open.

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -245,7 +245,8 @@ the License.
         <bread-crumbs id="breadCrumbs"></bread-crumbs>
         <paper-button id="togglePreview" class="navbar-button" on-click="_togglePreviewPane"
                       hidden$="{{small}}">
-          <iron-icon icon="visibility"></iron-icon>
+          <iron-icon icon="visibility" hidden$="{{_isPreviewPaneToggledOn}}"></iron-icon>
+          <iron-icon icon="visibility-off" hidden$="{{!_isPreviewPaneToggledOn}}"></iron-icon>
         </paper-button>
       </div>
 


### PR DESCRIPTION
Preview pane closed (uses the same icon as before):
![preview-closed](https://user-images.githubusercontent.com/116825/30234233-1e1676cc-94b0-11e7-8f14-f127a7499e09.png)

Preview page open (uses the other icon to close the preview pane):
![preview-open](https://user-images.githubusercontent.com/116825/30234236-23ee12d0-94b0-11e7-8801-380a894cae45.png)
