### PR TITLE
Highlight the visibliity icon when preview is available.

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -138,6 +138,9 @@ the License.
       .preview-pane-enabled--false {
         width: 0px;
       }
+      .visibility-highlighted--true {
+        color: var(--selection-fg-color);
+      }
       .vseparator {
         display: inline;
         border-left: 1px solid var(--border-color);
@@ -245,7 +248,8 @@ the License.
         <bread-crumbs id="breadCrumbs"></bread-crumbs>
         <paper-button id="togglePreview" class="navbar-button" on-click="_togglePreviewPane"
                       hidden$="{{small}}">
-          <iron-icon icon="visibility" hidden$="{{_isPreviewPaneToggledOn}}"></iron-icon>
+          <iron-icon icon="visibility" hidden$="{{_isPreviewPaneToggledOn}}"
+                     class$="visibility-highlighted--{{_canPreview}}"></iron-icon>
           <iron-icon icon="visibility-off" hidden$="{{!_isPreviewPaneToggledOn}}"></iron-icon>
         </paper-button>
       </div>

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -72,6 +72,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
   private _addToolbarCollapseThreshold = 900;
   private _apiManager: ApiManager;
+  private _canPreview = false;
   private _dividerPosition: number;
   private _previewPaneCollapseThreshold = 600;
   private _fetching: boolean;
@@ -91,6 +92,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
   static get properties() {
     return {
+      _canPreview: {
+        type: Boolean,
+        value: false,
+      },
       _dividerPosition: {
         observer: '_dividerPositionChanged',
         type: Number,
@@ -370,8 +375,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     const selectedIndices = (this.$.files as ItemListElement).selectedIndices;
     if (selectedIndices.length === 1) {
       this.selectedFile = this._fileList[selectedIndices[0]];
+      this._canPreview = !!this.selectedFile.getPreviewName();
     } else {
       this.selectedFile = null;
+      this._canPreview = false;
     }
   }
 


### PR DESCRIPTION
This PR changes the color of the file-browser visibility icon, which only shows when the preview pane is hidden, to the highlight color when a single item is selected in the list and that item is of a type that should show a preview when the pane is open. It does not actually generate the preview.

Nothing selected, showing visible icon without highlight (this is the same as previously):
![not-highlighted](https://user-images.githubusercontent.com/116825/30290667-0ba15a02-96e5-11e7-9c60-860b5e7ec41f.png)

One item selected (a notebook, for which we know how to do preview), showing highlighted visibility icon:
![highlighted](https://user-images.githubusercontent.com/116825/30290686-232d2b2e-96e5-11e7-91f5-b976f8d30642.png)
