### PR TITLE
Implement inline details showing BigQuery sample data in file browser

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
@@ -81,7 +81,10 @@ class SessionsElement extends Polymer.Element implements DatalabPageElement {
     }
 
     (this.$.sessions as ItemListElement).rows = this._sessionList.map((session) => {
-      return new ItemListRow([session.notebook.path, ''], 'editor:insert-drive-file');
+      return new ItemListRow({
+          columns: [session.notebook.path, ''],
+          icon: 'editor:insert-drive-file',
+      });
     });
   }
 

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -16,6 +16,7 @@ the License.
 <link rel="import" href="../../components/bread-crumbs/bread-crumbs.html">
 <link rel="import" href="../../components/datalab-page/datalab-page.html">
 <link rel="import" href="../../components/input-dialog/input-dialog.html">
+<link rel="import" href="../../components/inline-details-pane/inline-details-pane.html">
 <link rel="import" href="../../components/item-list/item-list.html">
 <link rel="import" href="../../components/preview-pane/preview-pane.html">
 <link rel="import" href="../../components/resizable-divider/resizable-divider.html">

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -172,6 +172,9 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
     super.ready();
 
+    const filesElement = this.$.files as ItemListElement;
+    filesElement.inlineDetailsMode = InlineDetailsDisplay.SINGLE_SELECT;
+
     this.$.breadCrumbs.addEventListener('crumbClicked', (e: ItemClickEvent) => {
       // Take the default root file into account, increment clicked index by one.
       this._pathHistoryIndex = e.detail.index + 1;

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -343,7 +343,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       return detailsPane;
     };
     (this.$.files as ItemListElement).rows = this._fileList.map((file) => {
-      const createDetailsElement = file.getPreviewName() ?
+      const createDetailsElement = file.getInlineDetailsName() ?
           () => createDetailsPaneFromFile(file) : undefined;
       const row = new ItemListRow({
           columns: [file.name, Utils.getFileStatusString(file.status || DatalabFileStatus.IDLE)],

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -333,9 +333,14 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * the created list to the item-list to render.
    */
   _drawFileList() {
-    (this.$.files as ItemListElement).rows = this._fileList.map((file) =>
-        new ItemListRow([file.name, Utils.getFileStatusString(file.status || DatalabFileStatus.IDLE)],
-                        file.icon));
+    (this.$.files as ItemListElement).rows = this._fileList.map((file) => {
+      const row = new ItemListRow({
+          columns: [file.name, Utils.getFileStatusString(file.status || DatalabFileStatus.IDLE)],
+          detailsName: file.getPreviewName(),
+          icon: file.icon,
+      });
+      return row;
+    });
   }
 
   /**

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -336,10 +336,19 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * the created list to the item-list to render.
    */
   _drawFileList() {
+    const createDetailsElementFromFile = (file: DatalabFile) => {
+      const previewName = file.getPreviewName();
+      const detailsElement = document.createElement('span') as Polymer.Element;
+      detailsElement.innerHTML =
+          'Details for file ' + file.name + ' as preview ' + previewName;
+      return detailsElement;
+    };
     (this.$.files as ItemListElement).rows = this._fileList.map((file) => {
+      const createDetailsElement = file.getPreviewName() ?
+          () => createDetailsElementFromFile(file) : undefined;
       const row = new ItemListRow({
           columns: [file.name, Utils.getFileStatusString(file.status || DatalabFileStatus.IDLE)],
-          detailsName: file.getPreviewName(),
+          createDetailsElement,
           icon: file.icon,
       });
       return row;

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -336,16 +336,15 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * the created list to the item-list to render.
    */
   _drawFileList() {
-    const createDetailsElementFromFile = (file: DatalabFile) => {
-      const previewName = file.getPreviewName();
-      const detailsElement = document.createElement('span') as Polymer.Element;
-      detailsElement.innerHTML =
-          'Details for file ' + file.name + ' as preview ' + previewName;
-      return detailsElement;
+    const createDetailsPaneFromFile = (file: DatalabFile) => {
+      const detailsPane = document.createElement('inline-details-pane'
+          ) as InlineDetailsPaneElement;
+      detailsPane.file = file;
+      return detailsPane;
     };
     (this.$.files as ItemListElement).rows = this._fileList.map((file) => {
       const createDetailsElement = file.getPreviewName() ?
-          () => createDetailsElementFromFile(file) : undefined;
+          () => createDetailsPaneFromFile(file) : undefined;
       const row = new ItemListRow({
           columns: [file.name, Utils.getFileStatusString(file.status || DatalabFileStatus.IDLE)],
           createDetailsElement,

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -173,7 +173,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     super.ready();
 
     const filesElement = this.$.files as ItemListElement;
-    filesElement.inlineDetailsMode = InlineDetailsDisplay.SINGLE_SELECT;
+    filesElement.inlineDetailsMode = InlineDetailsDisplayMode.SINGLE_SELECT;
 
     this.$.breadCrumbs.addEventListener('crumbClicked', (e: ItemClickEvent) => {
       // Take the default root file into account, increment clicked index by one.

--- a/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.html
+++ b/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.html
@@ -35,7 +35,6 @@ the License.
     <div id="container" hidden$="{{!file}}">
       <iron-pages id="inline-details" selected="{{details}}" attr-for-selected="name">
         <table-inline-details class="inline-details" name="table" file="{{file}}" active="{{active}}"></table-inline-details>
-        <text-inline-details class="inline-details" name="text" file="{{file}}" active="{{active}}"></text-inline-details>
       </iron-pages>
     </div>
   </template>

--- a/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.html
+++ b/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.html
@@ -26,11 +26,6 @@ the License.
         display: flex;
         flex-direction: column;
       }
-      .placeholder {
-        padding: 15px;
-        text-align: center;
-        color: var(--neutral-fg-color);
-      }
     </style>
     <div id="container" hidden$="{{!file}}">
       <iron-pages id="inline-details" selected="{{details}}" attr-for-selected="name">

--- a/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.html
+++ b/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.html
@@ -1,0 +1,44 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
+
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
+<link rel="import" href="../../modules/file-manager-factory/file-manager-factory.html">
+
+<dom-module id="inline-details-pane">
+  <template>
+    <style include="datalab-shared-styles">
+      #container {
+        height: 100%;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+      }
+      .placeholder {
+        padding: 15px;
+        text-align: center;
+        color: var(--neutral-fg-color);
+      }
+    </style>
+    <div id="container" hidden$="{{!file}}">
+      <iron-pages id="inline-details" selected="{{details}}" attr-for-selected="name">
+        <table-inline-details class="inline-details" name="table" file="{{file}}" active="{{active}}"></table-inline-details>
+        <text-inline-details class="inline-details" name="text" file="{{file}}" active="{{active}}"></text-inline-details>
+      </iron-pages>
+    </div>
+  </template>
+</dom-module>
+
+<script src="inline-details-pane.js"></script>

--- a/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.ts
+++ b/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.ts
@@ -69,9 +69,7 @@ class InlineDetailsPaneElement extends Polymer.Element {
       return;
     }
 
-    // TODO - use file.getInlineDetailsName instead of getPreviewName */
-    this.details = this.file.getPreviewName();
-
+    this.details = this.file.getInlineDetailsName();
     if (this.details) {
       const elName = this.details + '-inline-details';
       const pageUrl = this.resolveUrl('../' + elName + '/' + elName + '.html');

--- a/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.ts
+++ b/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+// Instead of writing a .d.ts file containing this one line.
+declare function marked(markdown: string): string;
+
+/**
+ * InlineDetails pane element for Datalab.
+ * This element is designed to be displayed in a side bar that displays more
+ * information about a selected file.
+ */
+class InlineDetailsPaneElement extends Polymer.Element {
+
+  /**
+   * Currently displayed inline-details pane name.
+   */
+  public details: string;
+
+  /**
+   * File whose details to show.
+   */
+  public file: DatalabFile;
+
+  /**
+   * Whether the pane is actively tracking selected items. This is used to avoid fetching the
+   * selected file's data if the pane is closed by the host element.
+   */
+  public active: boolean;
+
+  static get is() { return 'inline-details-pane'; }
+
+  static get properties() {
+    return {
+      active: {
+        observer: '_reloadInlineDetails',
+        type: Boolean,
+        value: true,
+      },
+      details: {
+        type: String,
+        value: '',
+      },
+      file: {
+        observer: '_reloadInlineDetails',
+        type: Object,
+        value: {},
+      },
+    };
+  }
+
+  /**
+   * Shows inline details of the selected file for known file types.
+   *
+   * TODO: Consider adding a spinning animation while this data loads.
+   */
+  _reloadInlineDetails() {
+    if (!this.file || !this.active) {
+      return;
+    }
+
+    // TODO - use file.getInlineDetailsName instead of getPreviewName */
+    this.details = this.file.getPreviewName();
+
+    if (this.details) {
+      const elName = this.details + '-inline-details';
+      const pageUrl = this.resolveUrl('../' + elName + '/' + elName + '.html');
+      Polymer.importHref(pageUrl, undefined, undefined, true);
+    }
+  }
+}
+
+customElements.define(InlineDetailsPaneElement.is, InlineDetailsPaneElement);

--- a/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.ts
+++ b/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.ts
@@ -16,9 +16,7 @@
 declare function marked(markdown: string): string;
 
 /**
- * InlineDetails pane element for Datalab.
- * This element is designed to be displayed in a side bar that displays more
- * information about a selected file.
+ * Inline details pane element for Datalab.
  */
 class InlineDetailsPaneElement extends Polymer.Element {
 
@@ -61,8 +59,6 @@ class InlineDetailsPaneElement extends Polymer.Element {
 
   /**
    * Shows inline details of the selected file for known file types.
-   *
-   * TODO: Consider adding a spinning animation while this data loads.
    */
   _reloadInlineDetails() {
     if (!this.file || !this.active) {

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -12,6 +12,8 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
+<link rel="import" href="../../modules/utils/utils.html">
+
 <link rel="import" href="../../bower_components/iron-icons/editor-icons.html">
 <link rel="import" href="../../bower_components/iron-icons/hardware-icons.html">
 <link rel="import" href="../../bower_components/paper-checkbox/paper-checkbox.html">

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -61,6 +61,9 @@ the License.
       .row[selected] > * {
         color: var(--selection-fg-color);
       }
+      .row-details {
+        padding: 0px;
+      }
       .checkbox-col {
         flex: 0 0 65px;
         padding-left: 15px;
@@ -125,6 +128,9 @@ the License.
               <span>{{column}}</span>
             </div>
           </template>
+        </paper-item>
+        <paper-item class="row-details" hidden$="{{!row.showInlineDetails}}">
+          TODO - This is the row details.
         </paper-item>
       </template>
     </div>

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -129,9 +129,7 @@ the License.
             </div>
           </template>
         </paper-item>
-        <paper-item class="row-details" hidden$="{{!row.showInlineDetails}}">
-          TODO - This is the row details.
-        </paper-item>
+        <div id="details" class="row-details" hidden$="{{!row.showInlineDetails}}"></div>
       </template>
     </div>
 

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -18,12 +18,17 @@
 class ItemListRow {
   public selected: boolean;
   public columns: string[];
+  public detailsName: string;
+  public showInlineDetails = false;
 
   private _icon: string;
 
-  constructor(columns: string[], icon: string, selected?: boolean) {
+  constructor({columns, icon, selected, detailsName}:
+      { columns: string[], icon: string,
+        selected?: boolean, detailsName?: string}) {
     this.columns = columns;
     this.selected = selected || false;
+    this.detailsName = detailsName || '';
     this._icon = icon;
   }
 
@@ -34,6 +39,21 @@ class ItemListRow {
    */
   get icon() { return this._hasLinkIcon() ? '' : this._icon; }
   get src() { return this._hasLinkIcon() ? this._icon : ''; }
+
+  /**
+   * Updates our showInlineDetails flag after a selection change.
+   */
+  _updateShowInlineDetails() {
+    if (!this.detailsName) {
+      this.showInlineDetails = false;
+      return;
+    }
+    if (!this.selected) {
+      this.showInlineDetails = false;
+      return;
+    }
+    this.showInlineDetails = true;
+  }
 
   private _hasLinkIcon() {
     return this._icon.startsWith('http://') || this._icon.startsWith('https://');
@@ -168,6 +188,9 @@ class ItemListElement extends Polymer.Element {
    */
   _selectItem(index: number) {
     this.set('rows.' + index + '.selected', true);
+    this.rows[index]._updateShowInlineDetails();
+    this.notifyPath('rows.' + index + '.showInlineDetails',
+        this.rows[index].showInlineDetails);
   }
 
   /**
@@ -176,6 +199,9 @@ class ItemListElement extends Polymer.Element {
    */
   _unselectItem(index: number) {
     this.set('rows.' + index + '.selected', false);
+    this.rows[index]._updateShowInlineDetails();
+    this.notifyPath('rows.' + index + '.showInlineDetails',
+        this.rows[index].showInlineDetails);
   }
 
   /**

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -88,6 +88,13 @@ class ItemListRow {
     if (!this._createDetailsElement) {
       return;
     }
+
+    // The list gets reused, so we need to clear potential old details.
+    while (rowDetailsElement.firstChild) {
+      rowDetailsElement.removeChild(rowDetailsElement.firstChild);
+    }
+
+    // Create and add the new details element
     this._detailsElement = this._createDetailsElement();
     rowDetailsElement.appendChild(this._detailsElement);
   }

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -253,7 +253,7 @@ class ItemListElement extends Polymer.Element {
     const previousMultiSelect = previousSelectedCount > 1;
     this.set('rows.' + index + '.selected', newValue);
     const multiSelect = this.selectedIndices.length > 1;
-    const nthDivSelector = 'div:nth-of-type(' + (index + 1) + ')';
+    const nthDivSelector = 'div.row-details:nth-of-type(' + (index + 1) + ')';
     const rowDetailsElement = this.$.listContainer.querySelector(nthDivSelector);
     this.rows[index]._updateShowInlineDetails(
         this.inlineDetailsMode, multiSelect, rowDetailsElement);
@@ -267,7 +267,7 @@ class ItemListElement extends Polymer.Element {
        */
       for (let i = 0; i < this.rows.length; i++) {
         if (i !== index) {
-          const otherNthDivSelector = 'div:nth-of-type(' + (i + 1) + ')';
+          const otherNthDivSelector = 'div.row-details:nth-of-type(' + (i + 1) + ')';
           const otherRowDetailsElement =
               this.$.listContainer.querySelector(otherNthDivSelector);
           this.rows[i]._updateShowInlineDetails(

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -39,6 +39,9 @@ the License.
       p {
         margin: 0px;
       }
+      paper-spinner {
+        --paper-spinner-stroke-width: 2px;
+      }
       .mono {
         font-family: monospace;
         white-space: pre-line;

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.html
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.html
@@ -1,0 +1,133 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
+<link rel="import" href="../../modules/api-manager-factory/api-manager-factory.html">
+<link rel="import" href="../../modules/file-manager-factory/file-manager-factory.html">
+<link rel="import" href="../../modules/template-manager/template-manager.html">
+<link rel="import" href="../../modules/utils/utils.html">
+
+<link rel="import" href="../../bower_components/paper-spinner/paper-spinner.html">
+
+<dom-module id="table-inline-details">
+  <template>
+    <style include="datalab-shared-styles">
+      #placeholder {
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+      paper-spinner {
+        --paper-spinner-stroke-width: 2px;
+      }
+      #container {
+        padding: 0px 20px;
+        height: 100%;
+        overflow-y: auto;
+        color: var(--primary-fg-color);
+      }
+      .strong {
+        font-weight: bold;
+      }
+      .description {
+        font-style: italic;
+        overflow-wrap: break-word;
+      }
+      table {
+        border-spacing: 1px;
+        padding: 0 0 4px 0;
+        width: 100%;
+      }
+      td.field {
+        padding: 10px;
+        background-color: #eee;
+        font-weight: bold;
+      }
+      td.value {
+        padding: 10px;
+        background-color: #fff;
+      }
+      .separator {
+        margin: 20px 0px;
+      }
+    </style>
+    <div id="placeholder" hidden$={{_table}}>
+      <paper-spinner active hidden$={{!_busy}}></paper-spinner>
+    </div>
+    <div id="container" hidden$={{!_table}}>
+      <br>
+      <span class="strong">Project: </span>
+      <span id="projectId">{{_table.tableReference.projectId}}</span>
+      <br>
+      <br>
+      <span class="strong">Dataset: </span>
+      <span id="datasetId">{{_table.tableReference.datasetId}}</span>
+      <br>
+      <br>
+      <div hidden$={{!_table.description}}>
+        <div class="strong">Description</div>
+        <br>
+        <div class="description">{{_table.description}}</div>
+        <br>
+      </div>
+      <table>
+        <tr>
+          <td class="field">Table Size</td>
+          <td id="tableSize" class="value">{{tableSize}}</td>
+        </tr>
+        <tr>
+          <td class="field">Long Term Storage Size</td>
+          <td id="longTermTableSize" class="value">{{longTermTableSize}}</td>
+        </tr>
+        <tr>
+          <td class="field">Number of Rows</td>
+          <td id="numRows" class="value">{{numRows}}</td>
+        </tr>
+        <tr>
+          <td class="field">Creation Time</td>
+          <td id="creationTime" class="value">{{creationTime}}</td>
+        </tr>
+        <tr>
+          <td class="field">Last Modified</td>
+          <td id="lastModifiedTime" class="value">{{lastModifiedTime}}</td>
+        </tr>
+        <tr>
+          <td class="field">Data Location</td>
+          <td id="location" class="value">{{_table.location}}</td>
+        </tr>
+        <!--TODO: Consider showing the table's label somewhere-->
+      </table>
+
+      <hr class="separator">
+
+      <div class="strong">Schema</div>
+      <br>
+
+      <table id="schema">
+        <template is="dom-repeat" items={{schemaFields}} as="field">
+          <tr>
+            <td class="field">{{field.name}}</td>
+            <td class="value">{{field.type}}</td>
+            <td class="value">{{_formatMode(field.mode)}}</td>
+            <!--TODO: Consider showing the field's description somehow-->
+          </tr>
+        </template>
+      </table>
+
+    </div>
+  </template>
+</dom-module>
+
+<script src="table-inline-details.js"></script>

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.html
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.html
@@ -63,65 +63,16 @@ the License.
         margin: 20px 0px;
       }
     </style>
-    <div id="placeholder" hidden$={{_table}}>
+    <div id="placeholder" hidden$={{_rows}}>
       <paper-spinner active hidden$={{!_busy}}></paper-spinner>
     </div>
-    <div id="container" hidden$={{!_table}}>
-      <br>
-      <span class="strong">Project: </span>
-      <span id="projectId">{{_table.tableReference.projectId}}</span>
-      <br>
-      <br>
-      <span class="strong">Dataset: </span>
-      <span id="datasetId">{{_table.tableReference.datasetId}}</span>
-      <br>
-      <br>
-      <div hidden$={{!_table.description}}>
-        <div class="strong">Description</div>
-        <br>
-        <div class="description">{{_table.description}}</div>
-        <br>
-      </div>
-      <table>
-        <tr>
-          <td class="field">Table Size</td>
-          <td id="tableSize" class="value">{{tableSize}}</td>
-        </tr>
-        <tr>
-          <td class="field">Long Term Storage Size</td>
-          <td id="longTermTableSize" class="value">{{longTermTableSize}}</td>
-        </tr>
-        <tr>
-          <td class="field">Number of Rows</td>
-          <td id="numRows" class="value">{{numRows}}</td>
-        </tr>
-        <tr>
-          <td class="field">Creation Time</td>
-          <td id="creationTime" class="value">{{creationTime}}</td>
-        </tr>
-        <tr>
-          <td class="field">Last Modified</td>
-          <td id="lastModifiedTime" class="value">{{lastModifiedTime}}</td>
-        </tr>
-        <tr>
-          <td class="field">Data Location</td>
-          <td id="location" class="value">{{_table.location}}</td>
-        </tr>
-        <!--TODO: Consider showing the table's label somewhere-->
-      </table>
-
-      <hr class="separator">
-
-      <div class="strong">Schema</div>
-      <br>
-
-      <table id="schema">
-        <template is="dom-repeat" items={{schemaFields}} as="field">
+    <div id="container" hidden$={{!_rows}}>
+      <table id="rows">
+        <template is="dom-repeat" items={{_rows}} as="row">
           <tr>
-            <td class="field">{{field.name}}</td>
-            <td class="value">{{field.type}}</td>
-            <td class="value">{{_formatMode(field.mode)}}</td>
-            <!--TODO: Consider showing the field's description somehow-->
+            <template is="dom-repeat" items={{row.f}} as="field">
+              <td class="field">{{field.v}}</td>
+            </template>
           </tr>
         </template>
       </table>

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.html
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.html
@@ -50,14 +50,14 @@ the License.
         padding: 0 0 4px 0;
         width: 100%;
       }
-      td.field {
+      th.field {
         padding: 10px;
         background-color: #eee;
         font-weight: bold;
       }
-      td.value {
+      td.field {
         padding: 10px;
-        background-color: #fff;
+        background-color: #eee;
       }
       .separator {
         margin: 20px 0px;
@@ -68,6 +68,11 @@ the License.
     </div>
     <div id="container" hidden$={{!_rows}}>
       <table id="rows">
+        <tr>
+          <template is="dom-repeat" items={{schemaFields}} as="field">
+            <th class="field">{{field.name}}<br>{{field.type}}</th>
+          </template>
+        </tr>
         <template is="dom-repeat" items={{_rows}} as="row">
           <tr>
             <template is="dom-repeat" items={{row.f}} as="field">

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.html
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.html
@@ -29,21 +29,11 @@ the License.
         justify-content: center;
         align-items: center;
       }
-      paper-spinner {
-        --paper-spinner-stroke-width: 2px;
-      }
       #container {
         padding: 0px 20px;
         height: 100%;
         overflow-y: auto;
         color: var(--primary-fg-color);
-      }
-      .strong {
-        font-weight: bold;
-      }
-      .description {
-        font-style: italic;
-        overflow-wrap: break-word;
       }
       table {
         border-spacing: 1px;
@@ -52,15 +42,12 @@ the License.
       }
       th.field {
         padding: 10px;
-        background-color: #eee;
+        background-color: var(--secondary-bg-color);
         font-weight: bold;
       }
       td.field {
         padding: 10px;
-        background-color: #eee;
-      }
-      .separator {
-        margin: 20px 0px;
+        background-color: var(--secondary-bg-color);
       }
     </style>
     <div id="placeholder" hidden$={{_table}}>
@@ -69,7 +56,7 @@ the License.
     <div id="container" hidden$={{!_table}}>
       <table id="tabledata">
         <tr class="header">
-          <template is="dom-repeat" items={{schemaFields}} as="field">
+          <template is="dom-repeat" items={{_schemaFields}} as="field">
             <th class="field">
               <span class="field-name">{{field.name}}</span><br>
               <span class="field-type">{{field.type}}</span>

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.html
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.html
@@ -63,18 +63,21 @@ the License.
         margin: 20px 0px;
       }
     </style>
-    <div id="placeholder" hidden$={{_rows}}>
+    <div id="placeholder" hidden$={{_table}}>
       <paper-spinner active hidden$={{!_busy}}></paper-spinner>
     </div>
-    <div id="container" hidden$={{!_rows}}>
-      <table id="rows">
-        <tr>
+    <div id="container" hidden$={{!_table}}>
+      <table id="tabledata">
+        <tr class="header">
           <template is="dom-repeat" items={{schemaFields}} as="field">
-            <th class="field">{{field.name}}<br>{{field.type}}</th>
+            <th class="field">
+              <span class="field-name">{{field.name}}</span><br>
+              <span class="field-type">{{field.type}}</span>
+            </th>
           </template>
         </tr>
         <template is="dom-repeat" items={{_rows}} as="row">
-          <tr>
+          <tr class="data">
             <template is="dom-repeat" items={{row.f}} as="field">
               <td class="field">{{field.v}}</td>
             </template>

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
@@ -31,6 +31,7 @@ class TableInlineDetailsElement extends Polymer.Element {
 
   private _apiManager: ApiManager;
   private _fileManager: FileManager;
+  private _rows: gapi.client.bigquery.TabledataRow[];
   private _table: gapi.client.bigquery.Table | null;
   private _busy = false;
   private readonly DEFAULT_MODE = 'NULLABLE';
@@ -39,31 +40,19 @@ class TableInlineDetailsElement extends Polymer.Element {
 
   static get properties() {
     return {
+      _rows: {
+        type: Object,
+        value: null,
+      },
       _table: {
         notify: true, // For unit tests
         type: Object,
         value: null,
       },
-      creationTime: {
-        computed: '_computeCreationTime(_table)',
-        type: String,
-      },
       file: {
         observer: '_fileChanged',
         type: Object,
         value: {},
-      },
-      lastModifiedTime: {
-        computed: '_computeLastModifiedTime(_table)',
-        type: String,
-      },
-      longTermTableSize: {
-        computed: '_computeLongTermTableSize(_table)',
-        type: String,
-      },
-      numRows: {
-        computed: '_computeNumRows(_table)',
-        type: String,
       },
       schemaFields: {
         computed: '_computeSchemaFields(_table)',
@@ -73,10 +62,6 @@ class TableInlineDetailsElement extends Polymer.Element {
         observer: '_tableIdChanged',
         type: String,
         value: '',
-      },
-      tableSize: {
-        computed: '_computeTableSize(_table)',
-        type: String,
       },
     };
   }
@@ -107,14 +92,15 @@ class TableInlineDetailsElement extends Polymer.Element {
       const datasetId = matches[2];
       const tableId = matches[3];
 
-      GapiManager.bigquery.getTableDetails(projectId, datasetId, tableId)
-        .then((response: HttpResponse<gapi.client.bigquery.Table>) => {
-          this._table = response.result;
+      GapiManager.bigquery.getTableRows(projectId, datasetId, tableId, 5)
+        .then((response: HttpResponse<gapi.client.bigquery.ListTabledataResponse>) => {
+          this._rows = response.result.rows;
         }, (errorResponse: any) =>
-            Utils.log.error('Failed to get table details: ' + errorResponse.body))
+            Utils.log.error('Failed to get table rows: ' + errorResponse.body))
         .then(() => this._busy = false);
     } else {
       this._table = null;
+      this._rows = [];
     }
   }
 

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
@@ -24,11 +24,6 @@ class TableInlineDetailsElement extends Polymer.Element {
    */
   public file: BigQueryFile;
 
-  /**
-   * Id for table whose inline-details to show.
-   */
-  public tableId: string;
-
   private _apiManager: ApiManager;
   private _fileManager: FileManager;
   private _rows: gapi.client.bigquery.TabledataRow[];
@@ -59,11 +54,6 @@ class TableInlineDetailsElement extends Polymer.Element {
         type: Object,
         value: {},
       },
-      tableId: {
-        observer: '_tableIdChanged',
-        type: String,
-        value: '',
-      },
     };
   }
 
@@ -75,23 +65,14 @@ class TableInlineDetailsElement extends Polymer.Element {
   }
 
   _fileChanged() {
-    if (this.file && this.file.id) {
-      // TODO(jimmc) - move this into BigQueryFile?
-      const path = this.file.id.path;
-      const parts = path.split('/');
-      this.tableId = parts[0] + ':' + parts[1] + '.' + parts[2];
-    } else {
-      this.tableId = '';
-    }
-  }
+    const path = this.file && this.file.id && this.file.id.path;
+    const pathParts = path ? path.split('/') : [];
 
-  _tableIdChanged() {
-    const matches = this.tableId.match(/^(.*):(.*)\.(.*)$/);
-    if (matches && matches.length === 4) { // The whole string is matched as first result
+    if (pathParts.length === 3) {
       this._busy = true;
-      const projectId = matches[1];
-      const datasetId = matches[2];
-      const tableId = matches[3];
+      const projectId = pathParts[0];
+      const datasetId = pathParts[1];
+      const tableId = pathParts[2];
 
       GapiManager.bigquery.getTableDetails(projectId, datasetId, tableId)
         .then((response: HttpResponse<gapi.client.bigquery.Table>) => {

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
@@ -41,6 +41,7 @@ class TableInlineDetailsElement extends Polymer.Element {
   static get properties() {
     return {
       _rows: {
+        notify: true, // For unit tests
         type: Object,
         value: null,
       },

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Table inline details pane element for Datalab.
+ * Displays information about the selected BigQuery table file inline in the
+ * file browser item list.
+ */
+class TableInlineDetailsElement extends Polymer.Element {
+
+  /**
+   * File whose details to show.
+   */
+  public file: BigQueryFile;
+
+  /**
+   * Id for table whose inline-details to show.
+   */
+  public tableId: string;
+
+  private _apiManager: ApiManager;
+  private _fileManager: FileManager;
+  private _table: gapi.client.bigquery.Table | null;
+  private _busy = false;
+  private readonly DEFAULT_MODE = 'NULLABLE';
+
+  static get is() { return 'table-inline-details'; }
+
+  static get properties() {
+    return {
+      _table: {
+        notify: true, // For unit tests
+        type: Object,
+        value: null,
+      },
+      creationTime: {
+        computed: '_computeCreationTime(_table)',
+        type: String,
+      },
+      file: {
+        observer: '_fileChanged',
+        type: Object,
+        value: {},
+      },
+      lastModifiedTime: {
+        computed: '_computeLastModifiedTime(_table)',
+        type: String,
+      },
+      longTermTableSize: {
+        computed: '_computeLongTermTableSize(_table)',
+        type: String,
+      },
+      numRows: {
+        computed: '_computeNumRows(_table)',
+        type: String,
+      },
+      schemaFields: {
+        computed: '_computeSchemaFields(_table)',
+        type: Array,
+      },
+      tableId: {
+        observer: '_tableIdChanged',
+        type: String,
+        value: '',
+      },
+      tableSize: {
+        computed: '_computeTableSize(_table)',
+        type: String,
+      },
+    };
+  }
+
+  constructor() {
+    super();
+
+    this._apiManager = ApiManagerFactory.getInstance();
+    this._fileManager = FileManagerFactory.getInstance();
+  }
+
+  _fileChanged() {
+    if (this.file && this.file.id) {
+      // TODO(jimmc) - move this into BigQueryFile?
+      const path = this.file.id.path;
+      const parts = path.split('/');
+      this.tableId = parts[0] + ':' + parts[1] + '.' + parts[2];
+    } else {
+      this.tableId = '';
+    }
+  }
+
+  _tableIdChanged() {
+    const matches = this.tableId.match(/^(.*):(.*)\.(.*)$/);
+    if (matches && matches.length === 4) { // The whole string is matched as first result
+      this._busy = true;
+      const projectId = matches[1];
+      const datasetId = matches[2];
+      const tableId = matches[3];
+
+      GapiManager.bigquery.getTableDetails(projectId, datasetId, tableId)
+        .then((response: HttpResponse<gapi.client.bigquery.Table>) => {
+          this._table = response.result;
+        }, (errorResponse: any) =>
+            Utils.log.error('Failed to get table details: ' + errorResponse.body))
+        .then(() => this._busy = false);
+    } else {
+      this._table = null;
+    }
+  }
+
+  _computeCreationTime(table: gapi.client.bigquery.Table | null) {
+    if (table) {
+      return new Date(parseInt(table.creationTime, 10)).toUTCString();
+    } else {
+      return '';
+    }
+  }
+
+  _computeLastModifiedTime(table: gapi.client.bigquery.Table | null) {
+    if (table) {
+      return new Date(parseInt(table.lastModifiedTime, 10)).toUTCString();
+    } else {
+      return '';
+    }
+  }
+
+  _computeNumRows(table: gapi.client.bigquery.Table | null) {
+    return table ? parseInt(table.numRows, 10).toLocaleString() : '';
+  }
+
+  _computeLongTermTableSize(table: gapi.client.bigquery.Table | null) {
+    return table ? this._bytesToReadableSize(table.numLongTermBytes) : '';
+  }
+
+  // TODO: Consider adding expanders and nested tables to make the schema viewer
+  // narrower
+  _flattenFields(fields: gapi.client.bigquery.Field[]) {
+    const flatFields: gapi.client.bigquery.Field[] = [];
+    fields.forEach((field) => {
+
+      // First push the record field itself
+      flatFields.push(field);
+
+      // Then flatten it and push its children
+      if (field.type === 'RECORD' && field.fields) {
+        // Make sure we copy the flattened nested fields before modifying their
+        // name to prepend the parent field name. This way the original name in
+        // the schema object does not change.
+        const nestedFields = [...this._flattenFields(field.fields)];
+        nestedFields.forEach((f) => {
+          const flat = {...f};
+          flat.name = field.name + '.' + f.name;
+          flatFields.push(flat);
+        });
+      }
+    });
+    return flatFields;
+  }
+
+  _computeSchemaFields(table: gapi.client.bigquery.Table | null) {
+    return table ? this._flattenFields(table.schema.fields) : [];
+  }
+
+  _computeTableSize(table: gapi.client.bigquery.Table | null) {
+    return table ? this._bytesToReadableSize(table.numBytes) : '';
+  }
+
+  /**
+   * Converts the given number of bytes into a human readable string with units
+   * and a two-decimal-point number
+   */
+  _bytesToReadableSize(bytesStr: string) {
+    const kilo = 1024;
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    let bytesLeft = parseInt(bytesStr, 10);
+    let level = 0;
+
+    while (bytesLeft >= kilo) {
+      bytesLeft /= kilo;
+      ++level;
+    }
+    return bytesLeft.toFixed(2) + ' ' + units[level];
+  }
+
+  _formatMode(mode: string) {
+    return mode || this.DEFAULT_MODE;
+  }
+
+  /**
+   * Opens the current table in the table schema template notebook.
+   */
+  async _openInNotebook() {
+
+    if (this._table) {
+      const tableName = this._table.id.replace(':', '.'); // Standard BigQuery table name
+      const template = new TableSchemaTemplate(tableName);
+
+      try {
+        const notebook = await TemplateManager.newNotebookFromTemplate(template);
+
+        if (notebook) {
+          FileManagerFactory.getInstanceForType(notebook.id.source).getNotebookUrl(notebook.id)
+            .then((url) => window.open(url, '_blank'));
+        }
+      } catch (e) {
+        Utils.showErrorDialog('Error', e.message);
+      }
+    }
+  }
+
+}
+
+customElements.define(TableInlineDetailsElement.is, TableInlineDetailsElement);

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
@@ -94,33 +94,8 @@ class TableInlineDetailsElement extends Polymer.Element {
     }
   }
 
-  // TODO: Consider adding expanders and nested tables to make the schema viewer
-  // narrower
-  _flattenFields(fields: gapi.client.bigquery.Field[]) {
-    const flatFields: gapi.client.bigquery.Field[] = [];
-    fields.forEach((field) => {
-
-      // First push the record field itself
-      flatFields.push(field);
-
-      // Then flatten it and push its children
-      if (field.type === 'RECORD' && field.fields) {
-        // Make sure we copy the flattened nested fields before modifying their
-        // name to prepend the parent field name. This way the original name in
-        // the schema object does not change.
-        const nestedFields = [...this._flattenFields(field.fields)];
-        nestedFields.forEach((f) => {
-          const flat = {...f};
-          flat.name = field.name + '.' + f.name;
-          flatFields.push(flat);
-        });
-      }
-    });
-    return flatFields;
-  }
-
   _computeSchemaFields(table: gapi.client.bigquery.Table | null) {
-    return table ? this._flattenFields(table.schema.fields) : [];
+    return table ? Utils.flattenFields(table.schema.fields) : [];
   }
 }
 

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
@@ -92,7 +92,12 @@ class TableInlineDetailsElement extends Polymer.Element {
       const datasetId = matches[2];
       const tableId = matches[3];
 
-      GapiManager.bigquery.getTableRows(projectId, datasetId, tableId, 5)
+      GapiManager.bigquery.getTableDetails(projectId, datasetId, tableId)
+        .then((response: HttpResponse<gapi.client.bigquery.Table>) => {
+          this._table = response.result;
+        }, (errorResponse: any) =>
+            Utils.log.error('Failed to get table details: ' + errorResponse.body))
+        .then(() => GapiManager.bigquery.getTableRows(projectId, datasetId, tableId, 5))
         .then((response: HttpResponse<gapi.client.bigquery.ListTabledataResponse>) => {
           this._rows = response.result.rows;
         }, (errorResponse: any) =>

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.html
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.html
@@ -29,9 +29,6 @@ the License.
         justify-content: center;
         align-items: center;
       }
-      paper-spinner {
-        --paper-spinner-stroke-width: 2px;
-      }
       #openInNotebookButton {
         background-color: var(--paper-blue-600);
         color: white;

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.ts
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.ts
@@ -149,31 +149,8 @@ class TablePreviewElement extends Polymer.Element {
 
   // TODO: Consider adding expanders and nested tables to make the schema viewer
   // narrower
-  _flattenFields(fields: gapi.client.bigquery.Field[]) {
-    const flatFields: gapi.client.bigquery.Field[] = [];
-    fields.forEach((field) => {
-
-      // First push the record field itself
-      flatFields.push(field);
-
-      // Then flatten it and push its children
-      if (field.type === 'RECORD' && field.fields) {
-        // Make sure we copy the flattened nested fields before modifying their
-        // name to prepend the parent field name. This way the original name in
-        // the schema object does not change.
-        const nestedFields = [...this._flattenFields(field.fields)];
-        nestedFields.forEach((f) => {
-          const flat = {...f};
-          flat.name = field.name + '.' + f.name;
-          flatFields.push(flat);
-        });
-      }
-    });
-    return flatFields;
-  }
-
   _computeSchemaFields(table: gapi.client.bigquery.Table | null) {
-    return table ? this._flattenFields(table.schema.fields) : [];
+    return table ? Utils.flattenFields(table.schema.fields) : [];
   }
 
   _computeTableSize(table: gapi.client.bigquery.Table | null) {

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -20,6 +20,13 @@ type ProjectResource = gapi.client.bigquery.ProjectResource;
 type TableResource = gapi.client.bigquery.TableResource;
 
 class BigQueryFile extends DatalabFile {
+  public getInlineDetailsName(): string {
+    if (this.type === DatalabFileType.FILE) {
+      return 'table';
+    }
+    return '';
+  }
+
   public getPreviewName(): string {
     if (this.type === DatalabFileType.FILE) {
       return 'table';

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -126,6 +126,10 @@ abstract class DatalabFile {
     }
     return '';
   }
+
+  public getInlineDetailsName(): string {
+    return '';
+  }
 }
 
 interface FileManager {

--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -267,6 +267,22 @@ class GapiManager {
         .then(() => gapi.client.bigquery.tables.get(request));
     }
 
+    /**
+     * Fetches table rows from BigQuery
+     */
+    public static getTableRows(projectId: string, datasetId: string,
+        tableId: string, maxResults: number):
+        Promise<gapi.client.HttpRequestFulfilled<gapi.client.bigquery.ListTabledataResponse>> {
+      const request = {
+        datasetId,
+        maxResults,
+        projectId,
+        tableId,
+      };
+      return this._load()
+        .then(() => gapi.client.bigquery.tabledata.list(request));
+    }
+
     private static _load(): Promise<void> {
       return GapiManager.loadGapi()
         .then(() => gapi.client.load('bigquery', 'v2'))

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -164,6 +164,32 @@ class Utils {
     return location.protocol + '//' + location.host + Utils.uiroot;
   }
   static uiroot = '';   // Gets set to "/exp"
+
+  /**
+   * Flattens a BigQuery table schema
+   */
+  public static flattenFields(fields: gapi.client.bigquery.Field[]) {
+    const flatFields: gapi.client.bigquery.Field[] = [];
+    fields.forEach((field) => {
+
+      // First push the record field itself
+      flatFields.push(field);
+
+      // Then flatten it and push its children
+      if (field.type === 'RECORD' && field.fields) {
+        // Make sure we copy the flattened nested fields before modifying their
+        // name to prepend the parent field name. This way the original name in
+        // the schema object does not change.
+        const nestedFields = [...Utils.flattenFields(field.fields)];
+        nestedFields.forEach((f) => {
+          const flat = {...f};
+          flat.name = field.name + '.' + f.name;
+          flatFields.push(flat);
+        });
+      }
+    });
+    return flatFields;
+  }
 }
 
 class UnsupportedMethod extends Error {

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -105,6 +105,15 @@ class Utils {
   }
 
   /**
+   * Deletes all child elements of an element.
+   */
+  public static deleteAllChildren(parent: HTMLElement) {
+    while (parent.firstChild) {
+      parent.removeChild(parent.firstChild);
+    }
+  }
+
+  /**
    * Moves all child elements from one element to another.
    * @param from element whose children to move
    * @param to destination elements where children will be moved to

--- a/sources/web/datalab/polymer/polymer.json
+++ b/sources/web/datalab/polymer/polymer.json
@@ -10,6 +10,7 @@
     "components/datalab-toolbar/datalab-toolbar.html",
     "components/file-browser/file-browser.html",
     "components/notebook-preview/notebook-preview.html",
+    "components/table-inline-details/table-inline-details.html",
     "components/table-preview/table-preview.html",
     "components/text-preview/text-preview.html"
   ],

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -12,6 +12,8 @@
  * the License.
  */
 
+class MockDatalabFile extends DatalabFile {}
+
 class MockFileManager implements FileManager {
   public get(_fileId: DatalabFileId): Promise<DatalabFile> {
     throw new UnsupportedMethod('get', this);
@@ -20,12 +22,12 @@ class MockFileManager implements FileManager {
     throw new UnsupportedMethod('getContent', this);
   }
   public async getRootFile() {
-    const file: DatalabFile = {
+    const file: DatalabFile = new MockDatalabFile({
       icon: '/',
       id: new DatalabFileId('/', FileManagerType.JUPYTER),
       name: 'root',
       type: DatalabFileType.DIRECTORY,
-    } as DatalabFile;
+    } as DatalabFile);
     return file;
   }
   public saveText(_file: DatalabFile, _content: string): Promise<DatalabFile> {
@@ -55,9 +57,9 @@ class MockFileManager implements FileManager {
     throw new UnsupportedMethod('getEditorUrl', this);
   }
   public pathToPathHistory(path: string): DatalabFile[] {
-    const datalabFile = {
+    const datalabFile = new MockDatalabFile({
       id: new DatalabFileId(path, FileManagerType.JUPYTER),
-    } as DatalabFile;
+    } as DatalabFile);
     return [datalabFile];
   }
 }
@@ -66,27 +68,28 @@ describe('<file-browser>', () => {
   let testFixture: FileBrowserElement;
   const startuppath = new DatalabFileId('testpath', FileManagerType.JUPYTER);
 
-  const mockFiles: DatalabFile[] = [{
+  const mockFiles: DatalabFile[] = [
+    new MockDatalabFile({
       icon: '',
       id: new DatalabFileId('', FileManagerType.JUPYTER),
       name: 'file1',
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
-    } as DatalabFile,
-    {
+    } as DatalabFile),
+    new MockDatalabFile({
       icon: '',
       id: new DatalabFileId('', FileManagerType.JUPYTER),
       name: 'file2',
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
-    } as DatalabFile,
-    {
+    } as DatalabFile),
+    new MockDatalabFile({
       icon: '',
       id: new DatalabFileId('', FileManagerType.JUPYTER),
       name: 'file3',
       status: DatalabFileStatus.RUNNING,
       type: DatalabFileType.DIRECTORY,
-    } as DatalabFile,
+    } as DatalabFile),
   ];
 
   before(() => {

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -317,6 +317,7 @@ describe('<item-list>', () => {
       const firstRow = getRow(0);
       const firstRowDetailsContainer = getRowDetailsContainer(0);
       firstRow.click();
+      Polymer.dom.flush();
 
       assert(!firstRowDetailsContainer.firstChild,
           'first item should not show details when clicked');
@@ -327,6 +328,7 @@ describe('<item-list>', () => {
       const fourthRow = getRow(3);
       const fourthRowDetailsContainer = getRowDetailsContainer(3);
       fourthRow.click();
+      Polymer.dom.flush();
 
       const detailsElement: HTMLElement =
           fourthRowDetailsContainer.firstChild as HTMLElement;
@@ -341,6 +343,7 @@ describe('<item-list>', () => {
       const fourthRow = getRow(3);
       const fourthRowDetailsContainer = getRowDetailsContainer(0);
       fourthRow.click();
+      Polymer.dom.flush();
 
       assert(!fourthRowDetailsContainer.firstChild,
           'fourth item should not create details element when clicked');
@@ -356,6 +359,7 @@ describe('<item-list>', () => {
       // behavior so that it figures out in advance that it should show
       // all the details.
       testFixture._unselectAll();   // Recalculate details display for all items
+      Polymer.dom.flush();
       const fourthRowDetailsContainer = getRowDetailsContainer(3);
       const fifthRowDetailsContainer = getRowDetailsContainer(3);
 
@@ -382,8 +386,9 @@ describe('<item-list>', () => {
       const fourthDetailsContainer = getRowDetailsContainer(3);
       const fifthDetailsContainer = getRowDetailsContainer(4);
       fourthRow.click();
-
       fifthRow.click();
+      Polymer.dom.flush();
+
       assert(fourthDetailsContainer.getAttribute('hidden') != null,
           'fourth details container should be hidden');
       assert(fifthDetailsContainer.getAttribute('hidden') == null,
@@ -398,8 +403,9 @@ describe('<item-list>', () => {
       const fourthDetailsContainer = getRowDetailsContainer(3);
       const fifthDetailsContainer = getRowDetailsContainer(4);
       fourthRow.click();
-
       fifthCheckbox.click();
+      Polymer.dom.flush();
+
       assert(fourthDetailsContainer.getAttribute('hidden') != null,
           'fourth details container should be hidden');
       assert(fifthDetailsContainer.getAttribute('hidden') != null,
@@ -415,6 +421,7 @@ describe('<item-list>', () => {
       const fifthDetailsContainer = getRowDetailsContainer(4);
       fourthRow.click();
       fifthCheckbox.click();
+      Polymer.dom.flush();
 
       assert(fourthDetailsContainer.getAttribute('hidden') == null,
           'fourth details container should be visible');
@@ -422,6 +429,8 @@ describe('<item-list>', () => {
           'fifth details container should be visible');
 
       fifthCheckbox.click();
+      Polymer.dom.flush();
+
       assert(fourthDetailsContainer.getAttribute('hidden') == null,
           'fourth details container should be visible');
       assert(fifthDetailsContainer.getAttribute('hidden') != null,

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -68,11 +68,16 @@ describe('<item-list>', () => {
   beforeEach(() => {
     testFixture = fixture('item-list-fixture');
     const rows = [
-      new ItemListRow(['first column 1', 'second column 1'], 'folder'),
-      new ItemListRow(['first column 2', 'second column 2'], 'folder'),
-      new ItemListRow(['first column 3', 'second column 3'], 'folder'),
-      new ItemListRow(['first column 4', 'second column 4'], 'folder'),
-      new ItemListRow(['first column 5', 'second column 5'], 'folder'),
+      new ItemListRow(
+          {columns: ['first column 1', 'second column 1'], icon: 'folder'}),
+      new ItemListRow(
+          {columns: ['first column 2', 'second column 2'], icon: 'folder'}),
+      new ItemListRow(
+          {columns: ['first column 3', 'second column 3'], icon: 'folder'}),
+      new ItemListRow(
+          {columns: ['first column 4', 'second column 4'], icon: 'folder'}),
+      new ItemListRow(
+          {columns: ['first column 5', 'second column 5'], icon: 'folder'}),
     ];
     testFixture.rows = rows;
     Polymer.dom.flush();

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -313,7 +313,7 @@ describe('<item-list>', () => {
 
   describe('inline details', () => {
     it('should not create a details element for an item without details', () => {
-      testFixture.inlineDetailsMode = InlineDetailsDisplay.SINGLE_SELECT;
+      testFixture.inlineDetailsMode = InlineDetailsDisplayMode.SINGLE_SELECT;
       const firstRow = getRow(0);
       const firstRowDetailsContainer = getRowDetailsContainer(0);
       firstRow.click();
@@ -323,7 +323,7 @@ describe('<item-list>', () => {
     });
 
     it('should create a details element for an item with details', () => {
-      testFixture.inlineDetailsMode = InlineDetailsDisplay.SINGLE_SELECT;
+      testFixture.inlineDetailsMode = InlineDetailsDisplayMode.SINGLE_SELECT;
       const fourthRow = getRow(3);
       const fourthRowDetailsContainer = getRowDetailsContainer(3);
       fourthRow.click();
@@ -337,7 +337,7 @@ describe('<item-list>', () => {
     });
 
     it('should not create a details element in NONE display mode', () => {
-      testFixture.inlineDetailsMode = InlineDetailsDisplay.NONE;
+      testFixture.inlineDetailsMode = InlineDetailsDisplayMode.NONE;
       const fourthRow = getRow(3);
       const fourthRowDetailsContainer = getRowDetailsContainer(0);
       fourthRow.click();
@@ -349,7 +349,7 @@ describe('<item-list>', () => {
     });
 
     it('should show details even when not clicked in ALL mode', () => {
-      testFixture.inlineDetailsMode = InlineDetailsDisplay.ALL;
+      testFixture.inlineDetailsMode = InlineDetailsDisplayMode.ALL;
       // TODO: the current behavior of ALL does not show all of the details when
       // the page first renders, but only displays the details when the
       // selection state for an item changes. We might want to change this
@@ -357,18 +357,26 @@ describe('<item-list>', () => {
       // all the details.
       testFixture._unselectAll();   // Recalculate details display for all items
       const fourthRowDetailsContainer = getRowDetailsContainer(3);
+      const fifthRowDetailsContainer = getRowDetailsContainer(3);
 
-      const detailsElement: HTMLElement =
+      const fourthDetailsElement: HTMLElement =
           fourthRowDetailsContainer.firstChild as HTMLElement;
-      assert(!!detailsElement,
+      assert(!!fourthDetailsElement,
           'fourth item should have details element');
       assert(fourthRowDetailsContainer.getAttribute('hidden') == null,
           'fourth details container should be visible');
+
+      const fifthDetailsElement: HTMLElement =
+          fifthRowDetailsContainer.firstChild as HTMLElement;
+      assert(!!fifthDetailsElement,
+          'fifth item should have details element');
+      assert(fifthRowDetailsContainer.getAttribute('hidden') == null,
+          'fitth details container should be visible');
     });
 
     it('should not show details for previously selected item ' +
         'in single-select mode', () => {
-      testFixture.inlineDetailsMode = InlineDetailsDisplay.SINGLE_SELECT;
+      testFixture.inlineDetailsMode = InlineDetailsDisplayMode.SINGLE_SELECT;
       const fourthRow = getRow(3);
       const fifthRow = getRow(4);
       const fourthDetailsContainer = getRowDetailsContainer(3);
@@ -384,7 +392,7 @@ describe('<item-list>', () => {
 
     it('should not show any details when multiple items selected ' +
         'in single-select mode', () => {
-      testFixture.inlineDetailsMode = InlineDetailsDisplay.SINGLE_SELECT;
+      testFixture.inlineDetailsMode = InlineDetailsDisplayMode.SINGLE_SELECT;
       const fourthRow = getRow(3);
       const fifthCheckbox = getCheckbox(4);
       const fourthDetailsContainer = getRowDetailsContainer(3);
@@ -400,7 +408,7 @@ describe('<item-list>', () => {
 
     it('should show details for multiple selected items ' +
         'in multi-select mode', () => {
-      testFixture.inlineDetailsMode = InlineDetailsDisplay.MULTIPLE_SELECT;
+      testFixture.inlineDetailsMode = InlineDetailsDisplayMode.MULTIPLE_SELECT;
       const fourthRow = getRow(3);
       const fifthCheckbox = getCheckbox(4);
       const fourthDetailsContainer = getRowDetailsContainer(3);

--- a/sources/web/datalab/polymer/test/table-inline-details-test.html
+++ b/sources/web/datalab/polymer/test/table-inline-details-test.html
@@ -19,23 +19,19 @@ the License.
 
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../../web-component-tester/browser.js"></script>
-    <script src="test-utils.js"></script>
+
+    <link rel="import" href="../components/table-inline-details/table-inline-details.html">
+    <link rel="import" href="../modules/gapi-manager/gapi-manager.html">
   </head>
   <body>
-    <script>
-      // Load and run all tests (.html, .js). Keep element tests in HTML files so we
-      // can use fixtures, and keep all other tests in javascript files
-      WCT.loadSuites([
-        'datalab-toolbar-test.html',
-        'file-browser-test.html',
-        'item-list-test.html',
-        'resizable-divider-test.html',
-        'settings-manager-test.html',
-        'table-inline-details-test.html',
-        'table-preview-test.html',
-        'timeout-manager-test.html',
-        'timeout-panel-test.html',
-      ]);
-    </script>
+
+    <test-fixture id="table-inline-details-fixture">
+      <template>
+        <table-inline-details></table-inline-details>
+      </template>
+    </test-fixture>
+
+    <script src="table-inline-details-test.js"></script>
+
   </body>
 </html>

--- a/sources/web/datalab/polymer/test/table-inline-details-test.ts
+++ b/sources/web/datalab/polymer/test/table-inline-details-test.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/*
+ * For all Polymer component testing, be sure to call Polymer's flush() after
+ * any code that will cause shadow dom redistribution, such as observed array
+ * mutation, wich is used by the dom-repeater in this case.
+ */
+
+type ListTabledataResponse = gapi.client.bigquery.ListTabledataResponse;
+
+describe('<table-inline-details>', () => {
+  let testFixture: TableInlineDetailsElement;
+
+  const mockTable: gapi.client.bigquery.Table = {
+    creationTime: '1501541271001',
+    etag: 'testEtag',
+    id: 'pid:did.tid',
+    kind: 'table',
+    labels: [{
+      name: 'label1',
+      value: 'label1val',
+    }],
+    lastModifiedTime: '1501607994768',
+    location: 'testLocation',
+    numBytes: (1024 * 1023).toString(),
+    numLongTermBytes: (1024 * 1024 * 50).toString(),
+    numRows: '1234567890',
+    schema: {
+      fields: [{
+        mode: 'mode1',
+        name: 'field1',
+        type: 'value1',
+      }, {
+        name: 'field2',
+        type: 'value2',
+      }],
+    },
+    selfLink: 'testLink',
+    tableReference: {
+      datasetId: 'did',
+      projectId: 'pid',
+      tableId: 'tid',
+    },
+    type: 'table',
+  };
+
+  const mockTabledata: ListTabledataResponse = {
+    kind: 'bigquery#tableDataList',
+    etag: 'x',
+    pageToken: '',
+    rows: [
+      {f: [{ v: 'r1f1' }, { v: 'r1f2' }]},
+      {f: [{ v: 'r2f1' }, { v: 'r2f2' }]},
+      {f: [{ v: 'r3f1' }, { v: 'r3f2' }]},
+    ],
+    totalRows: 0,
+  };
+
+  /**
+   * Rows must be recreated on each test with the fixture, to avoid state leakage.
+   */
+  beforeEach(() => {
+    GapiManager.bigquery.getTableDetails = (pid, did, tid) => {
+      assert(!!pid && !!did && !!tid,
+          'getTableDetails should be called with project, dataset, and table');
+
+      const response = {
+        result: mockTable,
+      };
+      return Promise.resolve(response) as
+          Promise<gapi.client.HttpRequestFulfilled<gapi.client.bigquery.Table>>;
+    };
+    GapiManager.bigquery.getTableRows = (pid, did, tid, _maxResults) => {
+      assert(!!pid && !!did && !!tid,
+          'getTableDetails should be called with project, dataset, and table');
+
+      const response = {
+        result: mockTabledata,
+      } as gapi.client.HttpRequestFulfilled<ListTabledataResponse>;
+      return Promise.resolve(response) as
+          Promise<gapi.client.HttpRequestFulfilled<gapi.client.bigquery.ListTabledataResponse>>;
+    };
+
+    testFixture = fixture('table-inline-details-fixture');
+    testFixture.tableId = '';
+    Polymer.dom.flush();
+  });
+
+  it('displays an empty element if no table is provided', () => {
+    assert(!testFixture.$.placeholder.hidden, 'placeholder should be shown');
+    assert(testFixture.$.container.hidden, 'container should be hidden');
+    assert(testFixture.$.placeholder.querySelector('paper-spinner'),
+        'spinner should be hidden if no table is loading');
+  });
+
+  it('loads the table schema', (done: () => null) => {
+    testFixture.addEventListener('_table-changed', () => {
+      Polymer.dom.flush();
+
+      assert(JSON.stringify((testFixture as any)._table) === JSON.stringify(mockTable),
+          'element should have fetched table info');
+
+      const schemaRow = testFixture.$.tabledata.rows[0];
+      const columns = schemaRow.querySelectorAll('th');
+      assert(columns.length === mockTable.schema.fields.length,
+          'unexpected number of schema rows');
+
+      mockTable.schema.fields.forEach((field, i) => {
+        const spans = schemaRow.children[i].querySelectorAll('span');
+        assert(spans[0].innerText === field.name, 'field name does not match');
+        assert(spans[1].innerText === field.type, 'field type does not match');
+      });
+
+      done();
+    });
+
+    testFixture.tableId = 'pid:did.tid';
+  });
+
+  it('loads the table data', (done: () => null) => {
+    testFixture.addEventListener('_rows-changed', () => {
+      Polymer.dom.flush();
+
+      assert(JSON.stringify((testFixture as any)._rows) ===
+             JSON.stringify(mockTabledata.rows),
+          'element should have fetched table rows');
+
+      const dataRows = testFixture.$.tabledata.querySelectorAll('tr.data');
+      assert(dataRows.length === mockTabledata.rows.length,
+          'unexpected number of schema rows');
+
+      mockTabledata.rows.forEach((row, r) => {
+        const dataFields = dataRows[r].querySelectorAll('td');
+        assert(dataFields.length === row.f.length,
+            'column count does not match');
+        row.f.forEach((field, f) => {
+          assert(field.v === dataFields[f].innerText, 'field data does not match');
+        });
+      });
+
+      done();
+    });
+
+    testFixture.tableId = 'pid:did.tid';
+  });
+
+});

--- a/sources/web/datalab/polymer/test/table-inline-details-test.ts
+++ b/sources/web/datalab/polymer/test/table-inline-details-test.ts
@@ -112,15 +112,16 @@ describe('<table-inline-details>', () => {
       assert(JSON.stringify((testFixture as any)._table) === JSON.stringify(mockTable),
           'element should have fetched table info');
 
-      const schemaRow = testFixture.$.tabledata.rows[0];
+      const schemaRow = testFixture.$.tabledata.querySelector('tr.header');
       const columns = schemaRow.querySelectorAll('th');
       assert(columns.length === mockTable.schema.fields.length,
           'unexpected number of schema rows');
 
       mockTable.schema.fields.forEach((field, i) => {
-        const spans = schemaRow.children[i].querySelectorAll('span');
-        assert(spans[0].innerText === field.name, 'field name does not match');
-        assert(spans[1].innerText === field.type, 'field type does not match');
+        const nameSpan = schemaRow.children[i].querySelector('span.field-name');
+        const typeSpan = schemaRow.children[i].querySelector('span.field-type');
+        assert(nameSpan.innerText === field.name, 'field name does not match');
+        assert(typeSpan.innerText === field.type, 'field type does not match');
       });
 
       done();
@@ -156,4 +157,6 @@ describe('<table-inline-details>', () => {
     testFixture.tableId = 'pid:did.tid';
   });
 
+  // TODO - after we figure out how we should deal with errors,
+  // add some tests for that here.
 });

--- a/sources/web/datalab/polymer/test/table-inline-details-test.ts
+++ b/sources/web/datalab/polymer/test/table-inline-details-test.ts
@@ -68,6 +68,16 @@ describe('<table-inline-details>', () => {
     totalRows: 0,
   };
 
+  const fileForTableId = (tableId: string) => {
+    return new BigQueryFile({
+      icon: '',
+      id: new DatalabFileId(tableId, FileManagerType.BIG_QUERY),
+      name: '/',
+      status: DatalabFileStatus.IDLE,
+      type: DatalabFileType.FILE,
+    } as DatalabFile);
+  };
+
   /**
    * Rows must be recreated on each test with the fixture, to avoid state leakage.
    */
@@ -94,7 +104,6 @@ describe('<table-inline-details>', () => {
     };
 
     testFixture = fixture('table-inline-details-fixture');
-    testFixture.tableId = '';
     Polymer.dom.flush();
   });
 
@@ -127,7 +136,7 @@ describe('<table-inline-details>', () => {
       done();
     });
 
-    testFixture.tableId = 'pid:did.tid';
+    testFixture.file = fileForTableId('pid/did/tid');
   });
 
   it('loads the table data', (done: () => null) => {
@@ -154,7 +163,7 @@ describe('<table-inline-details>', () => {
       done();
     });
 
-    testFixture.tableId = 'pid:did.tid';
+    testFixture.file = fileForTableId('pid/did/tid');
   });
 
   // TODO - after we figure out how we should deal with errors,

--- a/third_party/externs/ts/gapi/bigquery.d.ts
+++ b/third_party/externs/ts/gapi/bigquery.d.ts
@@ -8,6 +8,10 @@ declare namespace gapi.client {
       list: (request?: ListProjectsRequest) => HttpRequest<ListProjectsResponse>;
     }
 
+    const tabledata: {
+      list: (request?: ListTabledataRequest) => HttpRequest<ListTabledataResponse>;
+    }
+
     const tables: {
       list: (request?: ListTablesRequest) => HttpRequest<ListTablesResponse>;
       get: (request?: GetTableRequest) => HttpRequest<Table>;
@@ -57,6 +61,16 @@ declare namespace gapi.client {
       totalItems: number;
     }
 
+    interface ListTabledataRequest {
+      datasetId: string;
+      maxResults?: number;  // unsigned integer
+      pageToken?: string;
+      projectId: string;
+      selectedFields?: string;  // comma-separated
+      startIndex?: number;  // zero-based unsigned long
+      tableId: string;
+    }
+
     interface ListTablesRequest {
       projectId: string;
     }
@@ -65,6 +79,22 @@ declare namespace gapi.client {
       datasetId: string;
       projectId: string;
       tableId: string;
+    }
+
+    interface TabledataRowColumn {
+      v: object;
+    }
+
+    interface TabledataRow {
+      f: TabledataRowColumn[];
+    }
+
+    interface ListTabledataResponse {
+      kind: string;   // Should always be "bigquery#tableDataList"
+      etag: string;
+      pageToken: string;
+      rows: TabledataRow[];
+      totalRows: number;  // total number of rows in the table (long)
     }
 
     interface ListTablesResponse {

--- a/third_party/externs/ts/gapi/bigquery.d.ts
+++ b/third_party/externs/ts/gapi/bigquery.d.ts
@@ -82,7 +82,7 @@ declare namespace gapi.client {
     }
 
     interface TabledataRowColumn {
-      v: object;
+      v: any;
     }
 
     interface TabledataRow {


### PR DESCRIPTION
This PR implements a generic inline-details mechanism in the file browser, and a specific implementation that shows a small number of data rows when the file is a BigQuery file. This currently shows 5 rows of data. If the table is too wide, it will include a horizontal scrollbar.

At the moment, the display of the inline details is using the same algorithm as the sidebar preview, which is that it shows up if the row is the only selected row. It should be pretty easy to change this later once we figure out what UX we want to use.

![inline-details](https://user-images.githubusercontent.com/116825/30407461-2f49fd96-98ad-11e7-800b-2ed643c211bc.png)
