### PR TITLE
Add basepath to websocket connection

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.html
+++ b/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.html
@@ -14,6 +14,7 @@ the License.
 
 <link rel="import" href="../../components/datalab-page/datalab-page.html">
 <link rel="import" href="../../modules/terminal-manager/terminal-manager.html">
+<link rel="import" href="../../modules/api-manager-factory/api-manager-factory.html">
 
 <dom-module id="datalab-terminal">
   <link rel="import" type="css" href="../../bower_components/xterm.js/dist/xterm.css" />

--- a/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.ts
+++ b/sources/web/datalab/polymer/components/datalab-terminal/datalab-terminal.ts
@@ -69,7 +69,7 @@ class TerminalElement extends Polymer.Element implements DatalabPageElement {
    * TODO: Consider adding a loading experience while the connection is made.
    * @param terminalName name of the Jupyter terminal session to be used in websocket connection
    */
-  _initTerminal(terminalName: string) {
+  async _initTerminal(terminalName: string) {
     // Clear any older terminal elements created.
     this.$.theTerminal.innerHTML = '';
     this._xterm = new Terminal();
@@ -80,7 +80,7 @@ class TerminalElement extends Polymer.Element implements DatalabPageElement {
     if (window.hasOwnProperty('io')) {
       const w = window as any;
       w.NativeWebSocket = w.WebSocket;
-      w.WebSocket = WebSocketShim;
+      w.WebSocket = DatalabWebSocketShim;
       Utils.log.verbose('Replaced native websockets with socket.io');
     } else {
       Utils.log.error('Could not find socket.io, will not replace WebSocket. ' +
@@ -88,9 +88,11 @@ class TerminalElement extends Polymer.Element implements DatalabPageElement {
     }
 
     // First, create the connection to the Jupyter terminal.
+    const basepath = await ApiManagerFactory.getInstance().getBasePath();
     const protocol = location.protocol === 'https' ? 'wss' : 'ws';
     this._wsConnection = new WebSocket(protocol + '://' +
-                                       window.location.host +
+                                       location.host +
+                                       basepath +
                                        '/terminals/websocket/' +
                                        terminalName);
 


### PR DESCRIPTION
Base path is needed to make the websocket connection to the backend vm.
This also renames the `WebSocketShim` class and clarifies its function in comments.