### PR TITLE
Support loading notebooks for the editor using iframe postmessage

### DIFF
--- a/sources/web/datalab/polymer/notebook.html
+++ b/sources/web/datalab/polymer/notebook.html
@@ -10,6 +10,8 @@
 
     <link id="themeStylesheet" rel="stylesheet" href="index.light.css">
     <link rel="import" href="modules/api-manager-factory/api-manager-factory.html">
+    <link rel="import" href="modules/file-manager/file-manager.html">
+    <link rel="import" href="modules/file-manager-factory/file-manager-factory.html">
     <link rel="import" href="modules/utils/utils.html">
   </head>
   <body>


### PR DESCRIPTION
This change enables the notebook editor to send a message to the main app to ask for a notebook to be loaded. The notebook is loaded using the regular code path, using `FileManagerFactory`, and its contents and metadata are sent back over the iframe communication channel to the editor.