### PR TITLE
Implement github file manager.

### DIFF
--- a/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
@@ -23,8 +23,13 @@ const FILE_MANAGER_ELEMENT = {
   },
   drive: {
     name: 'drive',
-    path: 'modules/drive-file-manager/drive-file/manager.html',
+    path: 'modules/drive-file-manager/drive-file-manager.html',
     type: DriveFileManager,
+  },
+  github: {
+    name: 'github',
+    path: 'modules/github-file-manager/github-file-manager.html',
+    type: GithubFileManager,
   },
   jupyter: {
     name: 'jupyter',
@@ -36,6 +41,7 @@ const FILE_MANAGER_ELEMENT = {
 enum FileManagerType {
   BIG_QUERY,
   DRIVE,
+  GITHUB,
   JUPYTER,
 }
 
@@ -57,6 +63,7 @@ class FileManagerFactory {
     switch (name) {
       case 'bigquery': return FileManagerType.BIG_QUERY;
       case 'drive': return FileManagerType.DRIVE;
+      case 'github': return FileManagerType.GITHUB;
       case 'jupyter': return FileManagerType.JUPYTER;
       default: throw new Error('Unknown FileManagerType name ' + name);
     }
@@ -67,6 +74,7 @@ class FileManagerFactory {
     switch (type) {
       case FileManagerType.BIG_QUERY: return 'bigquery';
       case FileManagerType.DRIVE: return 'drive';
+      case FileManagerType.GITHUB: return 'github';
       case FileManagerType.JUPYTER: return 'jupyter';
       default: throw new Error('Unknown FileManager type: ' + type);
     }
@@ -86,6 +94,7 @@ class FileManagerFactory {
     switch (fileManagerType) {
       case FileManagerType.BIG_QUERY: return FILE_MANAGER_ELEMENT.bigquery;
       case FileManagerType.DRIVE: return FILE_MANAGER_ELEMENT.drive;
+      case FileManagerType.GITHUB: return FILE_MANAGER_ELEMENT.github;
       case FileManagerType.JUPYTER: return FILE_MANAGER_ELEMENT.jupyter;
       default: throw new Error('Unknown FileManagerType');
     }

--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.html
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.html
@@ -12,9 +12,9 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 -->
 
-<link rel="import" href="../bigquery-file-manager/bigquery-file-manager.html">
-<link rel="import" href="../drive-file-manager/drive-file-manager.html">
-<link rel="import" href="../github-file-manager/github-file-manager.html">
-<link rel="import" href="../jupyter-file-manager/jupyter-file-manager.html">
+<link rel="import" href="../../components/datalab-icons/datalab-icons.html">
+<link rel="import" href="../../modules/base-api-manager/base-api-manager.html">
+<link rel="import" href="../../modules/file-manager/file-manager.html">
+<link rel="import" href="../../modules/utils/utils.html">
 
-<script src="file-manager-factory.js"></script>
+<script src="github-file-manager.js"></script>

--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * This file manager connects to api.github.com and uses the github REST API
+ * as documented at developer.github.com/v3.
+ */
+
+// TODO(jimmc) - handle paged results
+
+class GithubFile extends DatalabFile {}
+
+interface GhRepoResponse {
+  id: string;
+  name: string;   // just the repo name
+  full_name: string;  // user/repo
+  description: string;
+  // There are a ton of other fields, including a bunch of URLs,
+  // creation time, forks, watchers, etc.
+}
+
+interface GhDirEntryResponse {
+  name: string; // filename only
+  path: string; // relative to the repo base
+  sha: string;
+  size: number; // size of file in bytes
+  type: string; // 'file' or 'dir'
+  url: string;  // the url to access this file via the api
+  // There are a bunch of other fields, mostly URLs
+}
+
+interface GhFileResponse {
+  type: string;
+  size: number;
+  name: string;
+  path: string;
+  encoding: string;
+  content: string;
+  url: string;  // the url to access this file via the api
+}
+
+/**
+ * A file manager that wraps the Github API so that we can browse github
+ * repositories.
+ */
+class GithubFileManager implements FileManager {
+
+  private _githubApiManager: GithubApiManager;
+
+  public get(fileId: DatalabFileId): Promise<DatalabFile> {
+    const pathParts = fileId.path.split('/').filter((part) => !!part);
+    if (pathParts.length === 0) {
+      return Promise.resolve(this._ghRootDatalabFile());
+    }
+    const githubPath = '/repos/' + pathParts.slice(0,2).join('/') +
+        '/contents/' + pathParts.slice(2).join('/');
+    return this._githubApiPathRequest(githubPath)
+        .then((response: GhFileResponse) => {
+          return this._ghFileToDatalabFile(response);
+        });
+  }
+
+  public getStringContent(fileId: DatalabFileId, _asText?: boolean):
+      Promise<string> {
+    const pathParts = fileId.path.split('/').filter((part) => !!part);
+    const githubPath = '/repos/' + pathParts.slice(0,2).join('/') +
+        '/contents/' + pathParts.slice(2).join('/');
+    return this._githubApiPathRequest(githubPath)
+        .then((response: GhFileResponse) => {
+          return this._ghFileToContentString(response);
+        });
+  }
+
+  public async getRootFile() {
+    return this.get(new DatalabFileId('/', FileManagerType.GITHUB));
+  }
+
+  public saveText(_file: DatalabFile, _content: string): Promise<DatalabFile> {
+    throw new UnsupportedMethod('saveText', this);
+  }
+
+  public list(fileId: DatalabFileId): Promise<DatalabFile[]> {
+    const pathParts = fileId.path.split('/').filter((part) => !!part);
+    if (pathParts.length === 0) {
+      // No org/user specified. This would mean we should list all of them,
+      // but we know that's too many, so we return an empty list.
+      return Promise.resolve([]);
+    } else if (pathParts.length === 1) {
+      // Only the username or org was specified, list their repos
+      const githubPath = '/users/' + pathParts[0] + '/repos';
+      return this._githubApiPathRequest(githubPath)
+          .then((response: GhRepoResponse[]) => {
+            return this._ghReposResponseToDatalabFiles(response);
+          });
+    } else {
+      // If at least two path components were specified, then we have
+      // a username and a project. Everything after that, if specified,
+      // are folders or files under that.
+      const githubPath = '/repos/' + pathParts.slice(0,2).join('/') +
+        '/contents/' + pathParts.slice(2).join('/');
+      return this._githubApiPathRequest(githubPath)
+          .then((response: GhDirEntryResponse[]) => {
+            return this._ghDirEntriesResponseToDatalabFiles(response);
+          });
+    }
+  }
+
+  public create(_fileType: DatalabFileType, _containerId: DatalabFileId, _name: string):
+      Promise<DatalabFile> {
+    throw new UnsupportedMethod('create', this);
+  }
+
+  public rename(_oldFileId: DatalabFileId, _name: string, _newContainerId?: DatalabFileId):
+      Promise<DatalabFile> {
+    throw new UnsupportedMethod('rename', this);
+  }
+
+  public delete(_fileId: DatalabFileId): Promise<boolean> {
+    throw new UnsupportedMethod('delete', this);
+  }
+
+  public copy(_fileId: DatalabFileId, _destinationDirectoryId: DatalabFileId): Promise<DatalabFile> {
+    throw new UnsupportedMethod('copy', this);
+  }
+
+  public async getEditorUrl(fileId: DatalabFileId) {
+    return Utils.getHostRoot() + '/editor?file=' + fileId.toQueryString();
+  }
+
+  public async getNotebookUrl(fileId: DatalabFileId): Promise<string> {
+    return location.protocol + '//' + location.host +
+        '/notebook?file=' + fileId.toQueryString();
+  }
+
+  public pathToPathHistory(path: string): DatalabFile[] {
+    const pathParts = path.split('/').filter((part) => !!part);
+    const files: DatalabFile[] = [];
+    for (let p = 0; p < pathParts.length; p++) {
+      files[p] = this._ghPathPartsToDatalabFile(pathParts.slice(0, p + 1));
+    }
+    return files;
+  }
+
+  // We don't know if the tyep of the item is actually a directory without
+  // querying the github API, so we assume every component is a dir.
+  private _ghPathPartsToDatalabFile(parts: string[]): DatalabFile {
+    const path = parts.join('/');
+    return new GithubFile({
+      icon: '',
+      id: new DatalabFileId(path, FileManagerType.GITHUB),
+      name: parts[parts.length - 1],
+      status: DatalabFileStatus.IDLE,
+      type: DatalabFileType.DIRECTORY,
+    } as DatalabFile);
+  }
+
+  private _githubApiPathRequest(githubPath: string): Promise<any> {
+    const githubBaseUrl = 'https://api.github.com';
+    const restUrl = githubBaseUrl + githubPath;
+    const options: XhrOptions = {
+      headers: {
+        'Accept': 'application/vnd.github.v3+json',
+        'User-Agent': 'googledatalab-datalab-app',
+      },
+    };
+    return this._getGithubApiManager().sendRequestAsync(restUrl, options, false);
+  }
+
+  private _getGithubApiManager(): GithubApiManager {
+    if (!this._githubApiManager) {
+      this._githubApiManager = new GithubApiManager();
+    }
+    return this._githubApiManager;
+  }
+
+  private _ghRootDatalabFile(): DatalabFile {
+    const path = '/';
+    return new GithubFile({
+      icon: '',
+      id: new DatalabFileId(path, FileManagerType.GITHUB),
+      name: '/',
+      status: DatalabFileStatus.IDLE,
+      type: DatalabFileType.FILE,
+    } as DatalabFile);
+  }
+
+  private _ghReposResponseToDatalabFiles(response: GhRepoResponse[]):
+      DatalabFile[] {
+    return response.map(repo => this._ghRepoToDatalabFile(repo));
+  }
+
+  private _ghDirEntriesResponseToDatalabFiles(response: GhDirEntryResponse[]):
+      DatalabFile[] {
+    return response.map(file => this._ghDirEntryToDatalabFile(file));
+  }
+
+  private _ghRepoToDatalabFile(repo: GhRepoResponse): DatalabFile {
+    const type = DatalabFileType.DIRECTORY;
+    const icon = Utils.getItemIconString(type);
+    return new GithubFile({
+      icon,
+      id: new DatalabFileId(repo.full_name, FileManagerType.GITHUB),
+      name: repo.name,
+      status: DatalabFileStatus.IDLE,
+      type,
+    } as DatalabFile);
+  }
+
+  private _ghDirEntryToDatalabFile(file: GhDirEntryResponse): DatalabFile {
+    const type =
+        file.name.endsWith('.ipynb') ? DatalabFileType.NOTEBOOK :
+        file.type === 'dir' ? DatalabFileType.DIRECTORY :
+        DatalabFileType.FILE;
+    const icon = Utils.getItemIconString(type);
+    const pathParts = file.url.split('/');
+    const prefix = pathParts.slice(4, 6).join('/'); // user and project
+    const path = prefix + '/' + file.path;
+    return new GithubFile({
+      icon,
+      id: new DatalabFileId(path, FileManagerType.GITHUB),
+      name: file.name,
+      status: DatalabFileStatus.IDLE,
+      type,
+    } as DatalabFile);
+  }
+
+  private _ghFileToDatalabFile(file: GhFileResponse): DatalabFile {
+    const type = file.type === 'dir' ?
+        DatalabFileType.DIRECTORY : DatalabFileType.FILE;
+    const icon = Utils.getItemIconString(type);
+    const pathParts = file.url.split('/');
+    const prefix = pathParts.slice(4, 6).join('/'); // user and project
+    const path = prefix + '/' + file.path;
+    return new GithubFile({
+      icon,
+      id: new DatalabFileId(path, FileManagerType.GITHUB),
+      name: file.name,
+      status: DatalabFileStatus.IDLE,
+      type,
+    } as DatalabFile);
+  }
+
+  private _ghFileToContentString(file: GhFileResponse): string {
+    if (file.encoding != 'base64') {
+      throw new Error('github file encoding "' + file.encoding +
+        '" is not supported');
+    }
+    return atob(file.content);
+  }
+}
+
+// We just want the sendRequestAsync method of BaseApimanager.
+class GithubApiManager extends BaseApiManager {
+  getBasePath() {
+    return Promise.resolve('');
+  }
+}

--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
@@ -17,7 +17,11 @@
  * as documented at developer.github.com/v3.
  */
 
-// TODO(jimmc) - handle paged results
+// TODO(jimmc): Need to deal with the following
+// paged results (default page size is 30, can request up to 100)
+// error conditions
+// rate limiting (default is 60 per hour)
+// size and dates for display in file browser (once it can do that)
 
 class GithubFile extends DatalabFile {}
 
@@ -277,6 +281,8 @@ class GithubFileManager implements FileManager {
   }
 }
 
+// TODO(jimmc): See if we can drop this class as part of moving
+// back towards having just one ApiManager.
 // We just want the sendRequestAsync method of BaseApimanager.
 class GithubApiManager extends BaseApiManager {
   // We don't care about this method, but it is abstract in the base class.


### PR DESCRIPTION
This just implements the happy path for browsing github projects and reading files. It doesn't check for errors and it doesn't attempt to deal with paging. The default page size is 30 items, which can be bumped up to 100 with a query parameter. But as is, it can be used with the file browser to browse github projects and repositories and to open text files and notebooks.