### PR TITLE
Add a Docs page

### DIFF
--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -98,7 +98,7 @@ if [[ $LIVE_MODE == 1 ]]; then
 fi
 
 docker run -it --entrypoint=$ENTRYPOINT \
-  -p 127.0.0.1:8081:8080 \
+  -p 127.0.0.1:8080:8080 \
   -v "$CONTENT/datalab:/content/datalab" \
   $PYDATALAB_MOUNT_OPT \
   ${DEVROOT_DOCKER_OPTION} \

--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -98,7 +98,7 @@ if [[ $LIVE_MODE == 1 ]]; then
 fi
 
 docker run -it --entrypoint=$ENTRYPOINT \
-  -p 127.0.0.1:8080:8080 \
+  -p 127.0.0.1:8081:8080 \
   -v "$CONTENT/datalab:/content/datalab" \
   $PYDATALAB_MOUNT_OPT \
   ${DEVROOT_DOCKER_OPTION} \

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -79,6 +79,7 @@ the License.
             <file-browser class="page" name="files" file-id="{{fileId}}"></file-browser>
             <datalab-sessions class="page" name="sessions"></datalab-sessions>
             <datalab-terminal class="page" name="terminal"></datalab-terminal>
+            <datalab-docs class="page" name="docs"></datalab-docs>
           </iron-pages>
         </div>
       </div>

--- a/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.html
+++ b/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.html
@@ -28,8 +28,9 @@ the License.
       }
     </style>
 
-    <file-browser id="fileBrowser" file-manager-type='drive'
-        file-id="drive:0BwjcD5486XPzQWk3MzQ2SzZCa2c" hide-toolbar></file-browser>
+    <!-- TODO: Trim the first two breadcrumbs so they don't appear in the nav bar -->
+    <file-browser id="fileBrowser" file-manager-type='github'
+        file-id="github:googledatalab/notebooks" hide-toolbar></file-browser>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.html
+++ b/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.html
@@ -1,0 +1,37 @@
+<!--
+Copyright 2017 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+in compliance with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License
+is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+or implied. See the License for the specific language governing permissions and limitations under
+the License.
+-->
+
+<link rel="import" href="../../components/datalab-page/datalab-page.html">
+<link rel="import" href="../../components/file-browser/file-browser.html">
+<link rel="import" href="../../components/shared-styles/shared-styles.html">
+
+<dom-module id="datalab-docs">
+  <template>
+    <style include="datalab-shared-styles">
+      :host {
+        display: flex;
+        flex-direction: column;
+      }
+      file-browser {
+        height: 100%;
+      }
+    </style>
+
+    <file-browser id="fileBrowser" file-manager-type='drive'
+        file-id="drive:0BwjcD5486XPzQWk3MzQ2SzZCa2c" hide-toolbar></file-browser>
+
+  </template>
+</dom-module>
+
+<script src="datalab-docs.js"></script>

--- a/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.ts
+++ b/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.ts
@@ -16,7 +16,7 @@
 /// <reference path="../item-list/item-list.ts" />
 
 /**
- * Data Browser element for Datalab.
+ * Docs element for Datalab.
  */
 class DatalabDocsElement extends Polymer.Element implements DatalabPageElement {
 

--- a/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.ts
+++ b/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/// <reference path="../input-dialog/input-dialog.ts" />
+/// <reference path="../item-list/item-list.ts" />
+
+/**
+ * Data Browser element for Datalab.
+ */
+class DatalabDocsElement extends Polymer.Element implements DatalabPageElement {
+
+  static get is() { return 'datalab-docs'; }
+
+  static get properties() {
+    return {
+      fileId: {
+        notify: true,
+        type: String,
+      },
+    };
+  }
+
+  /**
+   * Pass through requests to our file-browser element.
+   */
+  focusHandler() {
+    this.$.fileBrowser.focusHandler();
+  }
+  blurHandler() {
+    this.$.fileBrowser.blurHandler();
+  }
+  resizeHandler() {
+    this.$.fileBrowser.resizeHandler();
+  }
+}
+
+customElements.define(DatalabDocsElement.is, DatalabDocsElement);

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
@@ -120,6 +120,17 @@ the License.
             </div>
           </paper-button>
         </a>
+        <br>
+        <hr>
+        <br>
+        <a href="{{_uiroot}}/docs" id="docs">
+          <paper-button class="sidebar-button">
+            <div class="sidebar-button-container">
+              <iron-icon class="sidebar-button-icon" icon="help"></iron-icon>
+              <div class="sidebar-button-title">Docs</div>
+            </div>
+          </paper-button>
+        </a>
       </iron-selector>
     </div>
     

--- a/sources/web/datalab/polymer/polymer.json
+++ b/sources/web/datalab/polymer/polymer.json
@@ -3,6 +3,7 @@
   "shell": "components/datalab-app/datalab-app.html",
   "fragments": [
     "components/data-browser/data-browser.html",
+    "components/datalab-docs/datalab-docs.html",
     "components/datalab-editor/datalab-editor.html",
     "components/datalab-sessions/datalab-sessions.html",
     "components/datalab-sidebar/datalab-sidebar.html",

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -180,6 +180,7 @@ export function isExperimentalResource(pathname: string) {
       // TODO: use a different API to download files when we have a content service.
       pathname.indexOf('/sessions') === 0 ||
       pathname.indexOf('/terminal') === 0 ||
+      pathname.indexOf('/docs') === 0 ||
       pathname.indexOf('/editor') === 0 ||
       pathname.indexOf('/bower_components') === 0 ||
       pathname.indexOf('/components') === 0 ||
@@ -213,6 +214,7 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
       return;
     } else if (pathname === '/data' ||
         pathname === '/files' ||
+        pathname === '/docs' ||
         pathname === '/sessions' ||
         pathname === '/terminal') {
       pathname = '/index.html';


### PR DESCRIPTION
The Docs page appears in the sidebar and loads the docs from Github.

![image](https://user-images.githubusercontent.com/1424661/30497148-a60dd182-9a06-11e7-9361-2a90b72b9330.png)
