### PR TITLE
Fix height problem on file picker dialog.

### DIFF
--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -22,7 +22,6 @@ the License.
         --divider-half-width: 5px;
       }
       #container {
-        height: 100%;
         width: 100%;
         display: flex;
         position: relative;


### PR DESCRIPTION
This fixes a bug where the file list overlaps with the filename field when the dialog is not very tall.

Before:
![dialog-height-before](https://user-images.githubusercontent.com/116825/30622260-43fa7b46-9d65-11e7-9df1-ecbfe73e2e8b.png)

After:
![dialog-height-after](https://user-images.githubusercontent.com/116825/30622258-414c0874-9d65-11e7-8a87-666050e1d169.png)
