### PR TITLE
Add file source dropdown to file browser

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -168,6 +168,12 @@ declare module common {
      * The shutdown command to use after an idle timeout.
      */
     idleTimeoutShutdownCommand: string;
+
+    /**
+     * List of supported sources for the file browser.
+     * Possible options are: jupyter, drive, sharedDrive, docs, and bigquery
+     */
+    supportedFileBrowserSources: string[];
   }
 
   interface TimeoutInfo {

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -45,5 +45,6 @@
     "--KernelManager.autorestart=True",
     "--MultiKernelManager.default_kernel_name=\"python2\"",
     "--ip=\"127.0.0.1\""
-  ]
+  ],
+  "supportedFileBrowserSources": ["jupyter"]
 }

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -21,6 +21,7 @@ the License.
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
 <link rel="import" href="../../components/resizable-divider/resizable-divider.html">
 <link rel="import" href="../../modules/api-manager-factory/api-manager-factory.html">
+<link rel="import" href="../../modules/settings-manager/settings-manager.html">
 
 <dom-module id="datalab-app">
   <template>
@@ -78,7 +79,8 @@ the License.
           <iron-pages id="pages" selected="{{page}}" attr-for-selected="name">
             <!-- Elements here must implement the DatalabPageElement interface -->
             <data-browser class="page" name="data" file-id="{{fileId}}"></data-browser>
-            <file-browser class="page" name="files" file-id="{{fileId}}"></file-browser>
+            <file-browser class="page" name="files" file-id="{{fileId}}"
+                          file-manager-type-list="{{_fileBrowserSources}}"></file-browser>
             <datalab-sessions class="page" name="sessions"></datalab-sessions>
             <datalab-terminal class="page" name="terminal"></datalab-terminal>
             <datalab-docs class="page" name="docs"></datalab-docs>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -55,6 +55,7 @@ class DatalabAppElement extends Polymer.Element {
   public routeData: object;
 
   private _boundResizeHandler: EventListenerObject;
+  private _fileBrowserSources: string[];
 
   constructor() {
     super();
@@ -92,6 +93,10 @@ class DatalabAppElement extends Polymer.Element {
 
   static get properties() {
     return {
+      _fileBrowserSources: {
+        type: Array,
+        value: () => [],
+      },
       fileId: {
         observer: '_fileIdChanged',
         type: String,
@@ -119,10 +124,13 @@ class DatalabAppElement extends Polymer.Element {
     ];
   }
 
-  ready() {
+  async ready() {
     super.ready();
 
     window.addEventListener('focus', () => this._focusHandler());
+
+    const settings = await SettingsManager.getAppSettingsAsync();
+    this._fileBrowserSources = settings.supportedFileBrowserSources;
   }
 
   /**

--- a/sources/web/datalab/polymer/components/datalab-icons/datalab-icons.html
+++ b/sources/web/datalab/polymer/components/datalab-icons/datalab-icons.html
@@ -32,6 +32,41 @@ the License.
             8h2v2H4v-2zm4-4h2v2H8V8zm4 0h2v2h-2V8zm-4 4h2v2H8v-2zm4
             0h2v2h-2v-2z" fill-rule="evenodd"/>
       </g>
+      <g id="drive-logo" transform="scale(.1146)">
+          <defs>
+            <path id="SVGID_1_" d="M126.02,16H65.98L4,124l29.3,52H158.7l29.3-52L126.02,16z M63.43,124L96,67.8l32.57,56.2H63.43z"/>
+          </defs>
+          <clipPath id="SVGID_2_">
+            <use xlink:href="#SVGID_1_"  overflow="visible"/>
+          </clipPath>
+          <g clip-path="url(#SVGID_2_)">
+            <polygon fill="#4285F4" points="33.3,124 33.3,176 158.7,176 188,124"/>
+            <linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="48.5546" y1="150.1036" x2="93.974" y2="174.7461">
+              <stop offset="0" style="stop-color:#1A237E;stop-opacity:0.2"/>
+              <stop offset="1" style="stop-color:#1A237E;stop-opacity:0.02"/>
+            </linearGradient>
+            <polygon fill="url(#SVGID_3_)" points="63.43,124 93.57,176 33.3,176"/>
+            <g>
+              <polygon fill="#FFFFFF" fill-opacity="0.2" points="62.85,125 186.29,125 186.29,125 188,124 63.43,124 63.43,124"/>
+              <polygon fill="#1A237E" fill-opacity="0.2" points="186.29,125 158.12,175 33.88,175 33.3,176 158.7,176 188,124"/>
+              <polygon fill="#1A237E" fill-opacity="0.05" points="64.01,125 63.43,124 33.3,176 34.45,176"/>
+            </g>
+          </g>
+          <g clip-path="url(#SVGID_2_)">
+            <polygon fill="#0F9D58" points="65.98,16 4,124 33.3,176 103.99,54.01"/>
+            <g>
+              <polygon fill="#263238" fill-opacity="0.1" points="65.98,16 66.53,18.95 94.84,67.8 33.31,173.98 5.15,124 4,124 33.3,176 96,67.8"/>
+              <polygon fill="#FFFFFF" fill-opacity="0.2" points="5.15,124 66.56,17 65.98,16 65.98,16 4,124 5.15,124"/>
+            </g>
+          </g>
+          <g clip-path="url(#SVGID_2_)">
+            <polygon fill="#FFCD40" points="126.02,16 65.98,16 128.57,124 188,124"/>
+            <g>
+              <polygon fill="#FFFFFF" fill-opacity="0.2" points="126.02,16 65.98,16 67.71,17 125.44,17 186.85,124 188,124"/>
+              <polygon fill="#BF360C" fill-opacity="0.1" points="129.14,123 67.71,17 67.71,17 65.98,16 128.57,124 129.14,123"/>
+            </g>
+          </g>
+        </g>
     </defs>
   </svg>
 </iron-iconset-svg>

--- a/sources/web/datalab/polymer/components/datalab-icons/datalab-icons.html
+++ b/sources/web/datalab/polymer/components/datalab-icons/datalab-icons.html
@@ -33,40 +33,61 @@ the License.
             0h2v2h-2v-2z" fill-rule="evenodd"/>
       </g>
       <g id="drive-logo" transform="scale(.1146)">
-          <defs>
-            <path id="SVGID_1_" d="M126.02,16H65.98L4,124l29.3,52H158.7l29.3-52L126.02,16z M63.43,124L96,67.8l32.57,56.2H63.43z"/>
-          </defs>
-          <clipPath id="SVGID_2_">
-            <use xlink:href="#SVGID_1_"  overflow="visible"/>
-          </clipPath>
-          <g clip-path="url(#SVGID_2_)">
-            <polygon fill="#4285F4" points="33.3,124 33.3,176 158.7,176 188,124"/>
-            <linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="48.5546" y1="150.1036" x2="93.974" y2="174.7461">
-              <stop offset="0" style="stop-color:#1A237E;stop-opacity:0.2"/>
-              <stop offset="1" style="stop-color:#1A237E;stop-opacity:0.02"/>
-            </linearGradient>
-            <polygon fill="url(#SVGID_3_)" points="63.43,124 93.57,176 33.3,176"/>
-            <g>
-              <polygon fill="#FFFFFF" fill-opacity="0.2" points="62.85,125 186.29,125 186.29,125 188,124 63.43,124 63.43,124"/>
-              <polygon fill="#1A237E" fill-opacity="0.2" points="186.29,125 158.12,175 33.88,175 33.3,176 158.7,176 188,124"/>
-              <polygon fill="#1A237E" fill-opacity="0.05" points="64.01,125 63.43,124 33.3,176 34.45,176"/>
-            </g>
-          </g>
-          <g clip-path="url(#SVGID_2_)">
-            <polygon fill="#0F9D58" points="65.98,16 4,124 33.3,176 103.99,54.01"/>
-            <g>
-              <polygon fill="#263238" fill-opacity="0.1" points="65.98,16 66.53,18.95 94.84,67.8 33.31,173.98 5.15,124 4,124 33.3,176 96,67.8"/>
-              <polygon fill="#FFFFFF" fill-opacity="0.2" points="5.15,124 66.56,17 65.98,16 65.98,16 4,124 5.15,124"/>
-            </g>
-          </g>
-          <g clip-path="url(#SVGID_2_)">
-            <polygon fill="#FFCD40" points="126.02,16 65.98,16 128.57,124 188,124"/>
-            <g>
-              <polygon fill="#FFFFFF" fill-opacity="0.2" points="126.02,16 65.98,16 67.71,17 125.44,17 186.85,124 188,124"/>
-              <polygon fill="#BF360C" fill-opacity="0.1" points="129.14,123 67.71,17 67.71,17 65.98,16 128.57,124 129.14,123"/>
-            </g>
+        <defs>
+          <path id="SVGID_1_" d="M126.02,16H65.98L4,124l29.3,52H158.7l29.3-52L126.02,16z M63.43,124L96,67.8l32.57,56.2H63.43z"/>
+        </defs>
+        <clipPath id="SVGID_2_">
+          <use xlink:href="#SVGID_1_"  overflow="visible"/>
+        </clipPath>
+        <g clip-path="url(#SVGID_2_)">
+          <polygon fill="#4285F4" points="33.3,124 33.3,176 158.7,176 188,124"/>
+          <linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="48.5546" y1="150.1036" x2="93.974" y2="174.7461">
+            <stop offset="0" style="stop-color:#1A237E;stop-opacity:0.2"/>
+            <stop offset="1" style="stop-color:#1A237E;stop-opacity:0.02"/>
+          </linearGradient>
+          <polygon fill="url(#SVGID_3_)" points="63.43,124 93.57,176 33.3,176"/>
+          <g>
+            <polygon fill="#FFFFFF" fill-opacity="0.2" points="62.85,125 186.29,125 186.29,125 188,124 63.43,124 63.43,124"/>
+            <polygon fill="#1A237E" fill-opacity="0.2" points="186.29,125 158.12,175 33.88,175 33.3,176 158.7,176 188,124"/>
+            <polygon fill="#1A237E" fill-opacity="0.05" points="64.01,125 63.43,124 33.3,176 34.45,176"/>
           </g>
         </g>
+        <g clip-path="url(#SVGID_2_)">
+          <polygon fill="#0F9D58" points="65.98,16 4,124 33.3,176 103.99,54.01"/>
+          <g>
+            <polygon fill="#263238" fill-opacity="0.1" points="65.98,16 66.53,18.95 94.84,67.8 33.31,173.98 5.15,124 4,124 33.3,176 96,67.8"/>
+            <polygon fill="#FFFFFF" fill-opacity="0.2" points="5.15,124 66.56,17 65.98,16 65.98,16 4,124 5.15,124"/>
+          </g>
+        </g>
+        <g clip-path="url(#SVGID_2_)">
+          <polygon fill="#FFCD40" points="126.02,16 65.98,16 128.57,124 188,124"/>
+          <g>
+            <polygon fill="#FFFFFF" fill-opacity="0.2" points="126.02,16 65.98,16 67.71,17 125.44,17 186.85,124 188,124"/>
+            <polygon fill="#BF360C" fill-opacity="0.1" points="129.14,123 67.71,17 67.71,17 65.98,16 128.57,124 129.14,123"/>
+          </g>
+        </g>
+      </g>
+      <g id="github-logo">
+        <svg aria-hidden="true" class="octicon octicon-mark-github" version="1.1" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path></svg>
+      </g>
+      <g id="local-disk">
+        <path fill="#6F6F6F" ng-attr-d="{{icon.data}}" d="M6,2H18A2,2 0 0,1 20,4V20A2,2 0 0,1 18,22H6A2,2 0 0,1 4,20V4A2,2 0 0,1 6,2M12,4A6,6 0 0,0 6,10C6,13.31 8.69,16 12.1,16L11.22,13.77C10.95,13.29 11.11,12.68 11.59,12.4L12.45,11.9C12.93,11.63 13.54,11.79 13.82,12.27L15.74,14.69C17.12,13.59 18,11.9 18,10A6,6 0 0,0 12,4M12,9A1,1 0 0,1 13,10A1,1 0 0,1 12,11A1,1 0 0,1 11,10A1,1 0 0,1 12,9M7,18A1,1 0 0,0 6,19A1,1 0 0,0 7,20A1,1 0 0,0 8,19A1,1 0 0,0 7,18M12.09,13.27L14.58,19.58L17.17,18.08L12.95,12.77L12.09,13.27Z"></path>
+      </g>
+      <svg id="bigquery-logo" viewBox="0 0 128 128">
+        <defs>
+          <linearGradient id="a" x1="63.9997" y1="122.9664" x2="63.9997" y2="9.2106" gradientTransform="matrix(1, 0, 0, -1, 0, 130)" gradientUnits="userSpaceOnUse">
+            <stop offset="0" stop-color="#4387fd"/><stop offset="1" stop-color="#4683ea"/>
+          </linearGradient>
+        </defs>
+        <title>Artboard 1-crop</title>
+        <path d="M27.7906,115.2166,1.54,69.7493a11.499,11.499,0,0,1,0-11.499L27.7906,12.7831a11.4991,11.4991,0,0,1,9.9585-5.7495H90.25a11.4991,11.4991,0,0,1,9.9585,5.7495L126.4594,58.25a11.499,11.499,0,0,1,0,11.499l-26.2506,45.4672A11.4991,11.4991,0,0,1,90.25,120.966H37.7491A11.4989,11.4989,0,0,1,27.7906,115.2166Z" fill="url(#a)"/>
+        <path d="M80.6247,47.8749,64,43.4256,49.0668,48.9745,43.3,64,47.9372,80.729l40.237,40.237H90.25a11.499,11.499,0,0,0,9.9585-5.75l17.48-30.277Z" opacity="0.07" style="isolation:isolate"/>
+        <path d="M64,40.804A23.1953,23.1953,0,1,0,87.1944,64,23.1954,23.1954,0,0,0,64,40.804m0,40.7948A17.6,17.6,0,1,1,81.6,64,17.5986,17.5986,0,0,1,64,81.5988" fill="#fff"/>
+        <path d="M52.99,63.1041v7.2091a12.7943,12.7943,0,0,0,4.381,4.4754V63.1041Z" fill="#fff"/>
+        <path d="M61.6754,57.0263V76.4372a11.86,11.86,0,0,0,4.3822.0309V57.0263Z" fill="#fff"/>
+        <path d="M70.7656,66.1008v8.5614a12.7857,12.7857,0,0,0,4.3822-4.7V66.1008Z" fill="#fff"/>
+        <path d="M80.6914,78.2867l-2.403,2.4049a1.0879,1.0879,0,0,0,0,1.5371l9.1143,9.112a1.0881,1.0881,0,0,0,1.5371,0l2.403-2.4013a1.0917,1.0917,0,0,0,0-1.5365l-9.1156-9.1162a1.09,1.09,0,0,0-1.5358,0" fill="#fff"/>
+      </svg>
     </defs>
   </svg>
 </iron-iconset-svg>

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -65,7 +65,7 @@ the License.
       }
       #fileSourceToggle {
         color: var(--primary-fg-color);
-        padding-right: 15px;
+        padding: 0px 15px;
       }
       .dropdown-menu-container {
         position: relative;
@@ -98,6 +98,7 @@ the License.
         display: flex;
         flex: 0 0 calc(var(--toolbar-height) - 1px);
         background-color: var(--primary-bg-color);
+        padding-left: 10px;
       }
       .files-container {
         display: flex;
@@ -215,16 +216,6 @@ the License.
     <div id="file-picker">
       <!--Navigation bar with back/forward buttons, refresh, and breadcrumbs-->
       <div id="navbar">
-        <paper-button id="backNav" class="toolbar-button" on-click="_navBackward">
-          <iron-icon icon="chevron-left"></iron-icon>
-        </paper-button>
-        <paper-button id="forwardNav" class="toolbar-button" on-click="_navForward">
-          <iron-icon icon="chevron-right"></iron-icon>
-        </paper-button>
-        <paper-button class="toolbar-button" hidden$="{{small}}" on-click="_fetchFileList">
-          <iron-icon icon="refresh"></iron-icon>
-        </paper-button>
-
         <span id="fileSourcesContainer" class="dropdown-menu-container">
           <paper-button id="fileSourceToggle" class="toolbar-button"
                         on-click="_toggleFileSourceDropdown"
@@ -237,6 +228,16 @@ the License.
           <paper-dialog id="fileSourcesDropdown" class="dropdown-menu" on-blur="_closeDropdown">
           </paper-dialog>
         </span>
+
+        <paper-button id="backNav" class="toolbar-button" on-click="_navBackward">
+          <iron-icon icon="chevron-left"></iron-icon>
+        </paper-button>
+        <paper-button id="forwardNav" class="toolbar-button" on-click="_navForward">
+          <iron-icon icon="chevron-right"></iron-icon>
+        </paper-button>
+        <paper-button class="toolbar-button" hidden$="{{small}}" on-click="_fetchFileList">
+          <iron-icon icon="refresh"></iron-icon>
+        </paper-button>
 
         <div class="vseparator"></div>
         <bread-crumbs id="breadCrumbs"></bread-crumbs>

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -14,9 +14,10 @@ the License.
 
 <link rel="import" href="../../components/base-dialog/base-dialog.html">
 <link rel="import" href="../../components/bread-crumbs/bread-crumbs.html">
+<link rel="import" href="../../components/datalab-icons/datalab-icons.html">
 <link rel="import" href="../../components/datalab-page/datalab-page.html">
-<link rel="import" href="../../components/input-dialog/input-dialog.html">
 <link rel="import" href="../../components/inline-details-pane/inline-details-pane.html">
+<link rel="import" href="../../components/input-dialog/input-dialog.html">
 <link rel="import" href="../../components/item-list/item-list.html">
 <link rel="import" href="../../components/preview-pane/preview-pane.html">
 <link rel="import" href="../../components/resizable-divider/resizable-divider.html">
@@ -62,10 +63,10 @@ the License.
       #altAddToolbarToggle, #altUpdateToolbarToggle {
         display: none;
       }
-      #altAddToolbarContainer, #altUpdateToolbarContainer {
+      .dropdown-menu-container {
         position: relative;
       }
-      #altAddToolbar, #altUpdateToolbar {
+      .dropdown-menu {
         display: flex;
         flex-direction: column;
         align-items: flex-start;
@@ -74,13 +75,13 @@ the License.
         position: absolute;
         left: 0px;
         margin: 0px;
-        padding: 10px;
+        padding: 3px 0px;
         min-width: 200px;
         box-shadow: 0px 0px 10px 1px var(--box-shadow-color);
         border: 1px solid var(--outline-color);
       }
-      #altAddToolbar > *, #altUpdateToolbar > * {
-        padding: 5px;
+      .dropdown-menu > * {
+        padding: 10px;
         margin: 0px;
         width: 100%;
       }
@@ -145,14 +146,14 @@ the License.
       </span>
 
       <!--Alternative Add toolbar, shows up when toolbar is too small-->
-      <span id="altAddToolbarContainer">
+      <span id="altAddToolbarContainer" class="dropdown-menu-container">
         <paper-button id="altAddToolbarToggle" class="toolbar-button"
                       on-click="_toggleAltAddToolbar">
           <iron-icon icon="add-box"></iron-icon>
           <span>New</span>
           <iron-icon icon="hardware:keyboard-arrow-down"></iron-icon>
         </paper-button>
-        <paper-dialog id="altAddToolbar">
+        <paper-dialog id="altAddToolbar" class="dropdown-menu" on-blur="_closeDropdown">
         </paper-dialog>
       </span>
 
@@ -196,12 +197,12 @@ the License.
       </span>
 
       <!--Alternative Update toolbar, shows up when toolbar is too small-->
-      <span id="altUpdateToolbarContainer">
+      <span id="altUpdateToolbarContainer" class="dropdown-menu-container">
         <paper-button id="altUpdateToolbarToggle" class="toolbar-button"
                       on-click="_toggleAltUpdateToolbar">
           <iron-icon icon="more-horiz"></iron-icon>
         </paper-button>
-        <paper-dialog id="altUpdateToolbar">
+        <paper-dialog id="altUpdateToolbar" class="dropdown-menu" on-blur="_closeDropdown">
         </paper-dialog>
       </span>
 
@@ -219,6 +220,26 @@ the License.
         <paper-button class="toolbar-button" hidden$="{{small}}" on-click="_fetchFileList">
           <iron-icon icon="refresh"></iron-icon>
         </paper-button>
+
+        <span id="fileSourcesContainer" class="dropdown-menu-container">
+          <paper-button id="fileSourceToggle" class="toolbar-button"
+                        on-click="_toggleFileSourceDropdown">
+            <iron-icon icon="datalab-icons:drive-logo"></iron-icon>
+            <span>My Drive</span>
+            <iron-icon icon="hardware:keyboard-arrow-down"></iron-icon>
+          </paper-button>
+          <paper-dialog id="fileSourcesDropdown" class="dropdown-menu" on-blur="_closeDropdown">
+            <paper-button class="toolbar-button" on-click="_sourceDrive">
+              <iron-icon icon="datalab-icons:drive-logo"></iron-icon>
+              <span>My Drive</span>
+            </paper-button>
+            <paper-button class="toolbar-button" on-click="_sourceDriveShared">
+              <iron-icon icon="folder-shared"></iron-icon>
+              <span>Shared on Drive</span>
+            </paper-button>
+          </paper-dialog>
+        </span>
+
         <div class="vseparator"></div>
         <bread-crumbs id="breadCrumbs"></bread-crumbs>
         <paper-button id="togglePreview" class="toolbar-button" on-click="_togglePreviewPane"

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -63,6 +63,10 @@ the License.
       #altAddToolbarToggle, #altUpdateToolbarToggle {
         display: none;
       }
+      #fileSourceToggle {
+        color: var(--primary-fg-color);
+        padding-right: 15px;
+      }
       .dropdown-menu-container {
         position: relative;
       }
@@ -223,20 +227,14 @@ the License.
 
         <span id="fileSourcesContainer" class="dropdown-menu-container">
           <paper-button id="fileSourceToggle" class="toolbar-button"
-                        on-click="_toggleFileSourceDropdown">
-            <iron-icon icon="datalab-icons:drive-logo"></iron-icon>
-            <span>My Drive</span>
-            <iron-icon icon="hardware:keyboard-arrow-down"></iron-icon>
+                        on-click="_toggleFileSourceDropdown"
+                        disabled$="{{!_hasMultipleFileSources}}">
+            <iron-icon icon="{{_fileManagerDisplayIcon}}"></iron-icon>
+            <span>{{_fileManagerDisplayName}}</span>
+            <iron-icon icon="hardware:keyboard-arrow-down" hidden$="{{!_hasMultipleFileSources}}">
+            </iron-icon>
           </paper-button>
           <paper-dialog id="fileSourcesDropdown" class="dropdown-menu" on-blur="_closeDropdown">
-            <paper-button class="toolbar-button" on-click="_sourceDrive">
-              <iron-icon icon="datalab-icons:drive-logo"></iron-icon>
-              <span>My Drive</span>
-            </paper-button>
-            <paper-button class="toolbar-button" on-click="_sourceDriveShared">
-              <iron-icon icon="folder-shared"></iron-icon>
-              <span>Shared on Drive</span>
-            </paper-button>
           </paper-dialog>
         </span>
 

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -302,7 +302,9 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
   async _fileManagerTypeListChanged() {
     if (!this.fileManagerTypeList) {
       const settings = await SettingsManager.getAppSettingsAsync();
-      this.fileManagerTypeList = settings.supportedFileBrowserSources.map((source) =>
+      // Fall back to Jupyter if settings are somehow outdated.
+      const types = settings.supportedFileBrowserSources || ['jupyter'];
+      this.fileManagerTypeList = types.map((source) =>
           FileManagerFactory.fileManagerNameToType(source));
     }
 
@@ -927,7 +929,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
   }
 
   _toggleFileSourceDropdown() {
-    if (this._hasMultipleFileSources) {
+    // Only toggle the dropdown open if there are multiple file sources. We do
+    // this so that it looks like a static div instead of a dropdown if only
+    // once source is supported.
+    if (this._hasMultipleFileSources || this.$.fileSourcesDropdown.opened) {
       this.$.fileSourcesDropdown.toggle();
     }
   }

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -313,15 +313,13 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     Utils.deleteAllChildren(menu);
 
     this.fileManagerTypeList.forEach((type) => {
-      const config = FILE_MANAGER_CONFIG.get(type);
-      if (!config) {
-        throw new Error('Unknown FileManagerType: ' + type.toString());
-      }
+      const config = FileManagerFactory.getFileManagerConfig(type);
+      const strType = FileManagerFactory.fileManagerTypetoString(type);
       const btn = document.createElement('paper-button');
       btn.classList.add('toolbar-button');
       btn.addEventListener('click', () => {
-        if (this.fileManagerType !== type) {
-          this.fileManagerType = type;
+        if (this.fileManagerType !== strType) {
+          this.fileManagerType = strType;
           this._fileManager = FileManagerFactory.getInstanceForType(type);
           this.fileId = '';
 
@@ -1043,10 +1041,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       this._pathHistoryIndex = this._pathHistory.length - 1;
     }
     const type = FileManagerFactory.fileManagerNameToType(this.fileManagerType);
-    const config = FILE_MANAGER_CONFIG.get(type);
-    if (!config) {
-      throw new Error('Unknown FileManagerType: ' + this.fileManagerType);
-    }
+    const config = FileManagerFactory.getFileManagerConfig(type);
     this._fileManagerDisplayIcon = config.displayIcon;
     this._fileManagerDisplayName = config.displayName;
   }

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -320,11 +320,13 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       const btn = document.createElement('paper-button');
       btn.classList.add('toolbar-button');
       btn.addEventListener('click', () => {
-        this.fileManagerType = type;
-        this._fileManager = FileManagerFactory.getInstanceForType(type);
-        this.fileId = '';
+        if (this.fileManagerType !== type) {
+          this.fileManagerType = type;
+          this._fileManager = FileManagerFactory.getInstanceForType(type);
+          this.fileId = '';
 
-        this._loadStartupPath(null);
+          this._loadStartupPath(null);
+        }
       });
 
       const icon = document.createElement('iron-icon');

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -873,6 +873,20 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     this.$.altUpdateToolbar.toggle();
   }
 
+  _toggleFileSourceDropdown() {
+    this.$.fileSourcesDropdown.toggle();
+  }
+
+  _closeDropdown(e: MouseEvent) {
+    const element = e.target as HTMLDivElement;
+    if (element.classList.contains('dropdown-menu')) {
+      // Brief pause for ripple animation
+      setTimeout(() => {
+        (element as any).close();
+      }, 150);
+    }
+  }
+
   /**
    * Called on window.resize, collapses elements to keep the element usable
    * on small screens.

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -122,6 +122,7 @@ the License.
       }
       .toolbar-button > span {
         width: 70%;
+        pointer-events: none;
       }
       .toolbar-button[disabled] {
         color: var(--disabled-fg-color);
@@ -132,6 +133,7 @@ the License.
         min-width: 20px;
         height: 20px;
         padding-right: 3px;
+        pointer-events: none;
       }
     </style>
   </template>

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -199,6 +199,12 @@ class SharedDriveFileManager extends DriveFileManager {
     return driveFile;
   }
 
+  /**
+   * For shared files, the query should include the 'sharedWithMe' predicate
+   * without any parents, but if the user wants to dig in on a specific
+   * directory, it should be included as the parent, and `sharedWithMe` should
+   * be removed.
+   */
   protected async _getQueryPredicates(fileId: DatalabFileId) {
     const root = await this.getRootFile();
     if (root.id.path === fileId.path) {

--- a/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
@@ -22,7 +22,7 @@ enum FileManagerType {
 }
 
 interface FileManagerConfig {
-  className: any;
+  className: new () => FileManager;
   displayIcon: string;
   displayName: string;
   name: string;
@@ -30,58 +30,56 @@ interface FileManagerConfig {
 }
 
 /**
- * Dependency custom element for ApiManager
- */
-const FILE_MANAGER_CONFIG = new Map<FileManagerType, FileManagerConfig> ([
-  [
-    FileManagerType.BIG_QUERY, {
-      className: BigQueryFileManager,
-      displayIcon: 'datalab-icons:bigquery-logo',
-      displayName: 'BigQuery',
-      name: 'bigquery',
-      path: 'modules/bigquery-file-manager/bigquery-file-manager.html',
-    }
-  ], [
-    FileManagerType.DRIVE, {
-      className: DriveFileManager,
-      displayIcon: 'datalab-icons:drive-logo',
-      displayName: 'My Drive',
-      name: 'drive',
-      path: 'modules/drive-file-manager/drive-file-manager.html',
-    }
-  ], [
-    FileManagerType.GITHUB, {
-      className: GithubFileManager,
-      displayIcon: 'datalab-icons:github-logo',
-      displayName: 'Github',
-      name: 'github',
-      path: 'modules/github-file-manager/github-file-manager.html',
-    }
-  ], [
-    FileManagerType.JUPYTER, {
-      className: JupyterFileManager,
-      displayIcon: 'datalab-icons:local-disk',
-      displayName: 'Local Disk',
-      name: 'jupyter',
-      path: 'modules/jupyter-file-manager/jupyter-file-manager.html',
-    }
-  ], [
-    FileManagerType.SHARED_DRIVE, {
-      className: SharedDriveFileManager,
-      displayIcon: 'folder-shared',
-      displayName: 'Shared on Drive',
-      name: 'sharedDrive',
-      path: 'modules/drive-file-manager/drive-file-manager.html',
-    }
-  ]
-]);
-
-/**
  * Maintains and gets the static FileManager singleton.
  */
-// TODO: Find a better way to switch the FileManager instance based on the
-// environment
 class FileManagerFactory {
+
+  /**
+   * Dependency custom element for ApiManager
+   */
+  private static _fileManagerConfig = new Map<FileManagerType, FileManagerConfig> ([
+    [
+      FileManagerType.BIG_QUERY, {
+        className: BigQueryFileManager,
+        displayIcon: 'datalab-icons:bigquery-logo',
+        displayName: 'BigQuery',
+        name: 'bigquery',
+        path: 'modules/bigquery-file-manager/bigquery-file-manager.html',
+      }
+    ], [
+      FileManagerType.DRIVE, {
+        className: DriveFileManager,
+        displayIcon: 'datalab-icons:drive-logo',
+        displayName: 'My Drive',
+        name: 'drive',
+        path: 'modules/drive-file-manager/drive-file-manager.html',
+      }
+    ], [
+      FileManagerType.GITHUB, {
+        className: GithubFileManager,
+        displayIcon: 'datalab-icons:github-logo',
+        displayName: 'Github',
+        name: 'github',
+        path: 'modules/github-file-manager/github-file-manager.html',
+      }
+    ], [
+      FileManagerType.JUPYTER, {
+        className: JupyterFileManager,
+        displayIcon: 'datalab-icons:local-disk',
+        displayName: 'Local Disk',
+        name: 'jupyter',
+        path: 'modules/jupyter-file-manager/jupyter-file-manager.html',
+      }
+    ], [
+      FileManagerType.SHARED_DRIVE, {
+        className: SharedDriveFileManager,
+        displayIcon: 'folder-shared',
+        displayName: 'Shared on Drive',
+        name: 'sharedDrive',
+        path: 'modules/drive-file-manager/drive-file-manager.html',
+      }
+    ]
+  ]);
 
   private static _fileManagers: { [fileManagerType: string]: FileManager } = {};
 
@@ -107,16 +105,21 @@ class FileManagerFactory {
   }
 
   public static getInstanceForType(fileManagerType: FileManagerType) {
-    const config = FILE_MANAGER_CONFIG.get(fileManagerType);
-    if (!config) {
-      throw new Error('Unknown FileManagerType: ' + fileManagerType.toString());
-    }
+    const config = this.getFileManagerConfig(fileManagerType);
     if (!FileManagerFactory._fileManagers[config.name]) {
 
       FileManagerFactory._fileManagers[fileManagerType] = new config.className();
     }
 
     return FileManagerFactory._fileManagers[fileManagerType];
+  }
+
+  public static getFileManagerConfig(type: FileManagerType) {
+    const config = this._fileManagerConfig.get(type);
+    if (!config) {
+      throw new Error('Unknown FileManagerType: ' + type.toString());
+    }
+    return config;
   }
 
 }

--- a/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
@@ -22,7 +22,7 @@ enum FileManagerType {
 }
 
 interface FileManagerConfig {
-  class: new () => FileManager;
+  typeClass: new () => FileManager;
   displayIcon: string;
   displayName: string;
   name: string;
@@ -40,43 +40,43 @@ class FileManagerFactory {
   private static _fileManagerConfig = new Map<FileManagerType, FileManagerConfig> ([
     [
       FileManagerType.BIG_QUERY, {
-        class: BigQueryFileManager,
         displayIcon: 'datalab-icons:bigquery-logo',
         displayName: 'BigQuery',
         name: 'bigquery',
         path: 'modules/bigquery-file-manager/bigquery-file-manager.html',
+        typeClass: BigQueryFileManager,
       }
     ], [
       FileManagerType.DRIVE, {
-        class: DriveFileManager,
         displayIcon: 'datalab-icons:drive-logo',
         displayName: 'My Drive',
         name: 'drive',
         path: 'modules/drive-file-manager/drive-file-manager.html',
+        typeClass: DriveFileManager,
       }
     ], [
       FileManagerType.GITHUB, {
-        class: GithubFileManager,
         displayIcon: 'datalab-icons:github-logo',
         displayName: 'Github',
         name: 'github',
         path: 'modules/github-file-manager/github-file-manager.html',
+        typeClass: GithubFileManager,
       }
     ], [
       FileManagerType.JUPYTER, {
-        class: JupyterFileManager,
         displayIcon: 'datalab-icons:local-disk',
         displayName: 'Local Disk',
         name: 'jupyter',
         path: 'modules/jupyter-file-manager/jupyter-file-manager.html',
+        typeClass: JupyterFileManager,
       }
     ], [
       FileManagerType.SHARED_DRIVE, {
-        class: SharedDriveFileManager,
         displayIcon: 'folder-shared',
         displayName: 'Shared on Drive',
         name: 'sharedDrive',
         path: 'modules/drive-file-manager/drive-file-manager.html',
+        typeClass: SharedDriveFileManager,
       }
     ]
   ]);
@@ -108,7 +108,7 @@ class FileManagerFactory {
     const config = this.getFileManagerConfig(fileManagerType);
     if (!FileManagerFactory._fileManagers[config.name]) {
 
-      FileManagerFactory._fileManagers[fileManagerType] = new config.class();
+      FileManagerFactory._fileManagers[fileManagerType] = new config.typeClass();
     }
 
     return FileManagerFactory._fileManagers[fileManagerType];

--- a/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
@@ -22,7 +22,7 @@ enum FileManagerType {
 }
 
 interface FileManagerConfig {
-  className: new () => FileManager;
+  class: new () => FileManager;
   displayIcon: string;
   displayName: string;
   name: string;
@@ -40,7 +40,7 @@ class FileManagerFactory {
   private static _fileManagerConfig = new Map<FileManagerType, FileManagerConfig> ([
     [
       FileManagerType.BIG_QUERY, {
-        className: BigQueryFileManager,
+        class: BigQueryFileManager,
         displayIcon: 'datalab-icons:bigquery-logo',
         displayName: 'BigQuery',
         name: 'bigquery',
@@ -48,7 +48,7 @@ class FileManagerFactory {
       }
     ], [
       FileManagerType.DRIVE, {
-        className: DriveFileManager,
+        class: DriveFileManager,
         displayIcon: 'datalab-icons:drive-logo',
         displayName: 'My Drive',
         name: 'drive',
@@ -56,7 +56,7 @@ class FileManagerFactory {
       }
     ], [
       FileManagerType.GITHUB, {
-        className: GithubFileManager,
+        class: GithubFileManager,
         displayIcon: 'datalab-icons:github-logo',
         displayName: 'Github',
         name: 'github',
@@ -64,7 +64,7 @@ class FileManagerFactory {
       }
     ], [
       FileManagerType.JUPYTER, {
-        className: JupyterFileManager,
+        class: JupyterFileManager,
         displayIcon: 'datalab-icons:local-disk',
         displayName: 'Local Disk',
         name: 'jupyter',
@@ -72,7 +72,7 @@ class FileManagerFactory {
       }
     ], [
       FileManagerType.SHARED_DRIVE, {
-        className: SharedDriveFileManager,
+        class: SharedDriveFileManager,
         displayIcon: 'folder-shared',
         displayName: 'Shared on Drive',
         name: 'sharedDrive',
@@ -108,7 +108,7 @@ class FileManagerFactory {
     const config = this.getFileManagerConfig(fileManagerType);
     if (!FileManagerFactory._fileManagers[config.name]) {
 
-      FileManagerFactory._fileManagers[fileManagerType] = new config.className();
+      FileManagerFactory._fileManagers[fileManagerType] = new config.class();
     }
 
     return FileManagerFactory._fileManagers[fileManagerType];

--- a/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
@@ -12,38 +12,69 @@
  * the License.
  */
 
+enum FileManagerType {
+  BIG_QUERY = 'bigquery',
+  DRIVE = 'drive',
+  GITHUB = 'github',
+  JUPYTER = 'jupyter',
+  MOCK = 'mock',
+  SHARED_DRIVE = 'sharedDrive',
+}
+
+interface FileManagerConfig {
+  className: any;
+  displayIcon: string;
+  displayName: string;
+  name: string;
+  path: string;
+}
+
 /**
  * Dependency custom element for ApiManager
  */
-const FILE_MANAGER_ELEMENT = {
-  bigquery: {
-    name: 'bigquery',
-    path: 'modules/bigquery-file-manager/bigquery-file-manager.html',
-    type: BigQueryFileManager,
-  },
-  drive: {
-    name: 'drive',
-    path: 'modules/drive-file-manager/drive-file-manager.html',
-    type: DriveFileManager,
-  },
-  github: {
-    name: 'github',
-    path: 'modules/github-file-manager/github-file-manager.html',
-    type: GithubFileManager,
-  },
-  jupyter: {
-    name: 'jupyter',
-    path: 'modules/jupyter-file-manager/jupyter-file-manager.html',
-    type: JupyterFileManager,
-  },
-};
-
-enum FileManagerType {
-  BIG_QUERY,
-  DRIVE,
-  GITHUB,
-  JUPYTER,
-}
+const FILE_MANAGER_CONFIG = new Map<FileManagerType, FileManagerConfig> ([
+  [
+    FileManagerType.BIG_QUERY, {
+      className: BigQueryFileManager,
+      displayIcon: 'datalab-icons:bigquery-logo',
+      displayName: 'BigQuery',
+      name: 'bigquery',
+      path: 'modules/bigquery-file-manager/bigquery-file-manager.html',
+    }
+  ], [
+    FileManagerType.DRIVE, {
+      className: DriveFileManager,
+      displayIcon: 'datalab-icons:drive-logo',
+      displayName: 'My Drive',
+      name: 'drive',
+      path: 'modules/drive-file-manager/drive-file-manager.html',
+    }
+  ], [
+    FileManagerType.GITHUB, {
+      className: GithubFileManager,
+      displayIcon: 'datalab-icons:github-logo',
+      displayName: 'Github',
+      name: 'github',
+      path: 'modules/github-file-manager/github-file-manager.html',
+    }
+  ], [
+    FileManagerType.JUPYTER, {
+      className: JupyterFileManager,
+      displayIcon: 'datalab-icons:local-disk',
+      displayName: 'Local Disk',
+      name: 'jupyter',
+      path: 'modules/jupyter-file-manager/jupyter-file-manager.html',
+    }
+  ], [
+    FileManagerType.SHARED_DRIVE, {
+      className: SharedDriveFileManager,
+      displayIcon: 'folder-shared',
+      displayName: 'Shared on Drive',
+      name: 'sharedDrive',
+      path: 'modules/drive-file-manager/drive-file-manager.html',
+    }
+  ]
+]);
 
 /**
  * Maintains and gets the static FileManager singleton.
@@ -65,38 +96,27 @@ class FileManagerFactory {
       case 'drive': return FileManagerType.DRIVE;
       case 'github': return FileManagerType.GITHUB;
       case 'jupyter': return FileManagerType.JUPYTER;
+      case 'sharedDrive': return FileManagerType.SHARED_DRIVE;
       default: throw new Error('Unknown FileManagerType name ' + name);
     }
   }
 
   // Consider moving this to a strings module
   public static fileManagerTypetoString(type: FileManagerType) {
-    switch (type) {
-      case FileManagerType.BIG_QUERY: return 'bigquery';
-      case FileManagerType.DRIVE: return 'drive';
-      case FileManagerType.GITHUB: return 'github';
-      case FileManagerType.JUPYTER: return 'jupyter';
-      default: throw new Error('Unknown FileManager type: ' + type);
-    }
+    return type.toString();
   }
 
   public static getInstanceForType(fileManagerType: FileManagerType) {
-    const backendType = FileManagerFactory._getBackendType(fileManagerType);
-    if (!FileManagerFactory._fileManagers[backendType.name]) {
+    const config = FILE_MANAGER_CONFIG.get(fileManagerType);
+    if (!config) {
+      throw new Error('Unknown FileManagerType: ' + fileManagerType.toString());
+    }
+    if (!FileManagerFactory._fileManagers[config.name]) {
 
-      FileManagerFactory._fileManagers[fileManagerType] = new backendType.type();
+      FileManagerFactory._fileManagers[fileManagerType] = new config.className();
     }
 
     return FileManagerFactory._fileManagers[fileManagerType];
   }
 
-  private static _getBackendType(fileManagerType: FileManagerType) {
-    switch (fileManagerType) {
-      case FileManagerType.BIG_QUERY: return FILE_MANAGER_ELEMENT.bigquery;
-      case FileManagerType.DRIVE: return FILE_MANAGER_ELEMENT.drive;
-      case FileManagerType.GITHUB: return FILE_MANAGER_ELEMENT.github;
-      case FileManagerType.JUPYTER: return FILE_MANAGER_ELEMENT.jupyter;
-      default: throw new Error('Unknown FileManagerType');
-    }
-  }
 }

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -12,9 +12,29 @@
  * the License.
  */
 
-class MockDatalabFile extends DatalabFile {}
+class MockFile extends DatalabFile {
+  constructor(name: string) {
+    super({
+      getInlineDetailsName: () => '',
+      getPreviewName: () => '',
+      icon: '',
+      id: new DatalabFileId('', FileManagerType.MOCK),
+      name,
+      status: DatalabFileStatus.IDLE,
+      type: DatalabFileType.DIRECTORY,
+    });
+  }
+}
 
 class MockFileManager implements FileManager {
+  public getDisplayName() {
+    return 'Mock';
+  }
+
+  public getDisplayIcon() {
+    return 'mock-icon';
+  }
+
   public get(_fileId: DatalabFileId): Promise<DatalabFile> {
     throw new UnsupportedMethod('get', this);
   }
@@ -22,13 +42,7 @@ class MockFileManager implements FileManager {
     throw new UnsupportedMethod('getContent', this);
   }
   public async getRootFile() {
-    const file: DatalabFile = new MockDatalabFile({
-      icon: '/',
-      id: new DatalabFileId('/', FileManagerType.JUPYTER),
-      name: 'root',
-      type: DatalabFileType.DIRECTORY,
-    } as DatalabFile);
-    return file;
+    return new MockFile('root');
   }
   public saveText(_file: DatalabFile, _content: string): Promise<DatalabFile> {
     throw new UnsupportedMethod('saveText', this);
@@ -56,11 +70,8 @@ class MockFileManager implements FileManager {
   public getEditorUrl(_fileId: DatalabFileId): Promise<string> {
     throw new UnsupportedMethod('getEditorUrl', this);
   }
-  public pathToPathHistory(path: string): DatalabFile[] {
-    const datalabFile = new MockDatalabFile({
-      id: new DatalabFileId(path, FileManagerType.JUPYTER),
-    } as DatalabFile);
-    return [datalabFile];
+  public pathToPathHistory(_path: string): DatalabFile[] {
+    throw new UnsupportedMethod('getEditorUrl', this);
   }
 }
 
@@ -68,28 +79,10 @@ describe('<file-browser>', () => {
   let testFixture: FileBrowserElement;
   const startuppath = new DatalabFileId('testpath', FileManagerType.JUPYTER);
 
-  const mockFiles: DatalabFile[] = [
-    new MockDatalabFile({
-      icon: '',
-      id: new DatalabFileId('', FileManagerType.JUPYTER),
-      name: 'file1',
-      status: DatalabFileStatus.IDLE,
-      type: DatalabFileType.DIRECTORY,
-    } as DatalabFile),
-    new MockDatalabFile({
-      icon: '',
-      id: new DatalabFileId('', FileManagerType.JUPYTER),
-      name: 'file2',
-      status: DatalabFileStatus.IDLE,
-      type: DatalabFileType.DIRECTORY,
-    } as DatalabFile),
-    new MockDatalabFile({
-      icon: '',
-      id: new DatalabFileId('', FileManagerType.JUPYTER),
-      name: 'file3',
-      status: DatalabFileStatus.RUNNING,
-      type: DatalabFileType.DIRECTORY,
-    } as DatalabFile),
+  const mockFiles = [
+    new MockFile('file1'),
+    new MockFile('file2'),
+    new MockFile('file3'),
   ];
 
   before(() => {

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -13,12 +13,12 @@
  */
 
 class MockFile extends DatalabFile {
-  constructor(name: string) {
+  constructor(name = '', path = '') {
     super({
       getInlineDetailsName: () => '',
       getPreviewName: () => '',
       icon: '',
-      id: new DatalabFileId('', FileManagerType.MOCK),
+      id: new DatalabFileId(path, FileManagerType.MOCK),
       name,
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
@@ -27,14 +27,6 @@ class MockFile extends DatalabFile {
 }
 
 class MockFileManager implements FileManager {
-  public getDisplayName() {
-    return 'Mock';
-  }
-
-  public getDisplayIcon() {
-    return 'mock-icon';
-  }
-
   public get(_fileId: DatalabFileId): Promise<DatalabFile> {
     throw new UnsupportedMethod('get', this);
   }
@@ -70,14 +62,14 @@ class MockFileManager implements FileManager {
   public getEditorUrl(_fileId: DatalabFileId): Promise<string> {
     throw new UnsupportedMethod('getEditorUrl', this);
   }
-  public pathToPathHistory(_path: string): DatalabFile[] {
-    throw new UnsupportedMethod('getEditorUrl', this);
+  public pathToPathHistory(path: string): DatalabFile[] {
+    return [new MockFile('', path)];
   }
 }
 
 describe('<file-browser>', () => {
   let testFixture: FileBrowserElement;
-  const startuppath = new DatalabFileId('testpath', FileManagerType.JUPYTER);
+  const startuppath = new DatalabFileId('testpath', FileManagerType.MOCK);
 
   const mockFiles = [
     new MockFile('file1'),


### PR DESCRIPTION
This PR adds the ability to switch the file browser's source using a dropdown. In order to achieve this, it does the following:
- Adds an app setting for the list of supported file sources, which gets read on startup.
- Adds icons for: local disk (jupyter), drive, bigquery, and github.
- Adds a dropdown, similar to the file browser's toolbar dropdowns that appear when the window is too narrow. In this it also fixes an issue where the dropdown doesn't dismiss after clicking a button, by listening on the blur event.
- Adds a `SharedDriveFileManager` that extends `DriveFileManager` and changes the gapi query appropriately.
- Cleans up the `FileManagerFactory`'s methods for getting and converting file manager types.

![image](https://user-images.githubusercontent.com/1424661/30622847-200f41b8-9d69-11e7-9eb1-60c8d8c1e347.png)

The dropdown appears as a single unselectable div when there's only one source:
![image](https://user-images.githubusercontent.com/1424661/30622858-32bbb580-9d69-11e7-9405-27a13616dfc6.png)
