### PR TITLE
Show drive files with the default file icon

### DIFF
--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -30,7 +30,8 @@ class DriveFileManager implements FileManager {
 
   private static _upstreamToDriveFile(file: gapi.client.drive.File) {
     const datalabFile: DriveFile = new DriveFile({
-      icon: file.iconLink,
+      icon: file.mimeType === DriveFileManager._directoryMimeType ?
+                              file.iconLink : 'editor:insert-drive-file',
       id: new DatalabFileId(file.id, FileManagerType.DRIVE),
       name: file.name,
       status: DatalabFileStatus.IDLE,


### PR DESCRIPTION
Directories will still get their icon from drive to keep using the shared icon, but all files now show with the default file icon.