### PR TITLE
Get session file names from their file managers

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.html
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.html
@@ -16,6 +16,7 @@ the License.
 <link rel="import" href="../../components/item-list/item-list.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 <link rel="import" href="../../modules/session-manager/session-manager.html">
+<link rel="import" href="../../modules/file-manager-factory/file-manager-factory.html">
 
 <link rel="import" href="../../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">


### PR DESCRIPTION
This change tries to get the file manager from the session path if it's a valid DatalabFileId, and get the file's name and icon from that, otherwise defaults to the old behavior.