### PR TITLE
Update to using ws@1.1.4 to avoid websockets/ws:778

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -183,9 +183,8 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
 # Add some unchanging bits - specifically node modules (that need to be kept in sync
 # with packages.json manually, but help save build time, by preincluding them in an
 # earlier layer).
-# Note: ws is now over 1.0 but using that gives issues so leaving at 0.4.2 for now.
     /tools/node/bin/npm install \
-        ws@0.4.32 \
+        ws@1.1.4 \
         http-proxy@1.13.2 \
         mkdirp@0.5.1 \
         node-uuid@1.4.7 \

--- a/containers/base/Dockerfile.py2
+++ b/containers/base/Dockerfile.py2
@@ -110,9 +110,8 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
 # Add some unchanging bits - specifically node modules (that need to be kept in sync
 # with packages.json manually, but help save build time, by preincluding them in an
 # earlier layer).
-# Note: ws is now over 1.0 but using that gives issues so leaving at 0.4.2 for now.
     /tools/node/bin/npm install \
-        ws@0.4.32 \
+        ws@1.1.4 \
         http-proxy@1.13.2 \
         mkdirp@0.5.1 \
         node-uuid@1.4.7 \

--- a/sources/web/datalab/package.json
+++ b/sources/web/datalab/package.json
@@ -10,7 +10,7 @@
     "request": "^2.71.0",
     "socket.io": "^1.3.6",
     "tcp-port-used": "^0.1.2",
-    "ws": "^0.4.32",
+    "ws": "1.1.4",
     "node-cache": "~3.0.0"
   },
   "engines": {


### PR DESCRIPTION
https://github.com/websockets/ws/issues/778 can cause ws to raise, terminating the python runtime.  Upgrading ws avoids this.

b/66429362