### PR TITLE
Fix recent bug causing cross-talk between Data and Files locations.

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -261,6 +261,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
   _getFileIdFromProperty() {
     let fileId: DatalabFileId|null = null;
     if (this.fileId) {
+      if (!this.offsetParent && !this.small) {
+        // Ignore fileId property if we are not visible, unless we are a dialog
+        return null;
+      }
       try {
         fileId = DatalabFileId.fromQueryString(this.fileId);
       } catch (e) {


### PR DESCRIPTION
In commit d59029c I removed some code in file-browser _getFileIdFromProperty, which caused the fileId from the Data tab to be copied to the Files tab and vice-versa. This PR fixes that problem.