### PR TITLE
Do not block on listing sessions when listing files

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -399,7 +399,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       .then((sessions) => {
         const listElement = this.$.files as ItemListElement;
         this._fileList.forEach((file, i) => {
-          if (sessions.indexOf(file.id.path) > -1) {
+          // The v1 notebook editor creates sessions with just the file path,
+          // while v2 editor uses the full id string.
+          if (sessions.indexOf(file.id.path) > -1 ||
+              sessions.indexOf(file.id.toQueryString()) > -1) {
             listElement.set('rows.' + i + '.columns.1', Utils.getFileStatusString(DatalabFileStatus.RUNNING));
           }
         });

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -68,25 +68,8 @@ class DriveFileManager implements FileManager {
       'name',
     ];
 
-    // TODO: Put this code in a common place, instead of doing this for every
-    // file manager. Perhaps a base file manager should get the list of files
-    // and sessions and build the resulting DatalabFile list.
-    const [upstreamFiles, sessions] = await Promise.all([
-      GapiManager.drive.listFiles(fileFields, queryPredicates, orderModifiers),
-      SessionManager.listSessionPaths()
-        .catch((e) => {
-          Utils.log.error('Could not load sessions: ' + e.message);
-          return [];
-        }),
-    ]);
-    // Combine the return values of the two requests to supplement the files
-    // array with the status value.
-    return upstreamFiles.map((file) => {
-      const driveFile = this._fromUpstreamFile(file);
-      driveFile.status = (sessions as string[]).indexOf(driveFile.id.path) > -1 ?
-          DatalabFileStatus.RUNNING : DatalabFileStatus.IDLE;
-      return driveFile;
-    });
+    const upstreamFiles = await GapiManager.drive.listFiles(fileFields, queryPredicates, orderModifiers);
+    return upstreamFiles.map((file) => this._fromUpstreamFile(file));
   }
 
   public async create(fileType: DatalabFileType, containerId?: DatalabFileId, name?: string)

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
@@ -179,10 +179,7 @@ class JupyterFileManager implements FileManager {
   }
 
   public async list(containerId: DatalabFileId): Promise<DatalabFile[]> {
-    const [container, sessions] = await Promise.all([
-      this._getFileWithContent(containerId.path),
-      SessionManager.listSessionPaths(),
-    ]);
+    const container = await this._getFileWithContent(containerId.path);
     if (container.type !== 'directory') {
       throw new Error('Can only list files in a directory. Found type: ' +
           typeof(container.type));
@@ -191,12 +188,7 @@ class JupyterFileManager implements FileManager {
     // Combine the return values of the two requests to supplement the files
     // array with the status value.
     const files = container.content;
-    return files.map((file: any) => {
-      const jupyterFile = JupyterFileManager._upstreamFileToJupyterFile(file);
-      jupyterFile.status = sessions.indexOf(jupyterFile.path) > -1 ?
-          DatalabFileStatus.RUNNING : DatalabFileStatus.IDLE;
-      return jupyterFile;
-    });
+    return files.map((file: any) => JupyterFileManager._upstreamFileToJupyterFile(file));
   }
 
   public create(fileType: DatalabFileType, containerId?: DatalabFileId, name?: string) {

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -92,6 +92,9 @@ describe('<file-browser>', () => {
     ApiManagerFactory.getInstance().getBasePath = () => {
       return Promise.resolve('');
     };
+    SessionManager.listSessionsAsync = () => {
+      return Promise.resolve([]);
+    };
     const mockFileManager = new MockFileManager();
     mockFileManager.list = () => {
       return Promise.resolve(mockFiles);


### PR DESCRIPTION
This PR solves the following:
- Listing files used to block on listing sessions, so that file status can be populated. This PR separates these too, loading files first, then adding their status.
- Removes code duplication around listing files/sessions.
- Fixes a bug where Drive files status weren't showing because the session ids changed to include the full `DatalabFileId` strings.