### PR TITLE
Proper array -> string conversation for cell source

### DIFF
--- a/sources/web/datalab/polymer/components/notebook-preview/notebook-preview.ts
+++ b/sources/web/datalab/polymer/components/notebook-preview/notebook-preview.ts
@@ -100,7 +100,8 @@ class NotebookPreviewElement extends Polymer.Element {
           let markdownHtml = '';
           firstTwoCells.forEach((cell) => {
             if (cell.cell_type === 'markdown') {
-              markdownHtml += marked(cell.source.toString());
+              const cellSource = Array.isArray(cell.source) ? cell.source.join('\n') : cell.source;
+              markdownHtml += marked(cellSource);
             }
           });
           this.$.previewHtml.innerHTML = markdownHtml;


### PR DESCRIPTION
Depending on the notebook editor, cell source might be a string or an array of strings.