### PR TITLE
Fix alternating row colors

### DIFF
--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -54,7 +54,7 @@ the License.
         line-height: 35px;
         cursor: default;
       }
-      .row:nth-child(even) {
+      .row:nth-of-type(even) {
         background-color: var(--secondary-bg-color);
       }
       .row:hover {


### PR DESCRIPTION
These stopped working after adding an extra div for each row, making all actual `.row` elements even.