### PR TITLE
Allow idle timeout process to be permanently disabled by env variable.

### DIFF
--- a/sources/web/datalab/idleTimeout.ts
+++ b/sources/web/datalab/idleTimeout.ts
@@ -32,9 +32,12 @@ let lastReset: number;  // The epoch, in seconds, since the last timout reset
 let shutdownCommand = '';
 
 export function initAndStart() {
-  init();
-  reset();
-  startChecker();
+  let disableIdleTimeoutProcess = process.env.DATALAB_DISABLE_IDLE_TIMEOUT_PROCESS || 'false';
+  if (disableIdleTimeoutProcess === 'false') {
+    init();
+    reset();
+    startChecker();
+  }
 }
 
 export function init() {


### PR DESCRIPTION
This allows Datalab to start up successfully without requiring that
user settings already exist, allowing the user content directory
to be specified lazily.