### PR TITLE
Allow datalab and jupyter to start up when missing a home dir.

### DIFF
--- a/containers/datalab/run.sh
+++ b/containers/datalab/run.sh
@@ -36,6 +36,7 @@ LIVE_MODE=1
 PYDATALAB=''
 MORE_ENV=''
 CONSOLE_LOG_LEVEL='debug'
+DATALAB_PORT="${DATALAB_PORT:-8081}"
 
 function realpath() {
   perl -MCwd -e 'print Cwd::realpath($ARGV[0]),qq<\n>' $1
@@ -72,6 +73,11 @@ while [ $# -gt 0 ]; do
       LIVE_MODE=0
       shift
       ;;
+    -p | --port)
+      DATALAB_PORT="$2"
+      shift
+      shift
+      ;;
     --pydatalab)
       if [ $# -lt 2 ]; then
         echo "--pydatalab requires an argument"
@@ -98,7 +104,7 @@ if [[ $LIVE_MODE == 1 ]]; then
 fi
 
 docker run -it --entrypoint=$ENTRYPOINT \
-  -p 127.0.0.1:8081:8080 \
+  -p 127.0.0.1:${DATALAB_PORT}:8080 \
   -v "$CONTENT/datalab:/content/datalab" \
   $PYDATALAB_MOUNT_OPT \
   ${DEVROOT_DOCKER_OPTION} \

--- a/sources/web/datalab/jupyter.ts
+++ b/sources/web/datalab/jupyter.ts
@@ -186,9 +186,17 @@ function createJupyterServerAtPort(port: number, userId: string, userDir: string
 function createJupyterServer(userId: string, remainingAttempts: number) {
   logging.getLogger().info('Checking user dir for %s exists', userId);
   var userDir = userManager.getUserDir(userId);
+  logging.getLogger().info('Checking dir %s exists', userDir);
   if (!fs.existsSync(userDir)) {
     logging.getLogger().info('Creating user dir %s', userDir);
-    fs.mkdirSync(userDir, parseInt('0755', 8));
+    try {
+      fs.mkdirSync(userDir, parseInt('0755', 8));
+    } catch (e) {
+      // This likely means the disk is not yet ready.
+      // We'll fall back to /content for now.
+      logging.getLogger().info('User dir %s does not exist', userDir);
+      userDir = '/content'
+    }
   }
 
   nextJupyterPort = appSettings.nextJupyterPort;

--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -243,8 +243,8 @@ export function updateUserSettingAsync(userId: string, key: string, value: strin
         copyDefaultUserSettings(userId);
       }
       catch (e) {
-        _log('Failed to copy default settings, using from existing location.', e);
-        return <common.UserSettings>JSON.parse(getDefaultUserSettings(userId));
+        _log('Failed to update settings.', e);
+        return false;
       }
     }
 

--- a/sources/web/datalab/settings.ts
+++ b/sources/web/datalab/settings.ts
@@ -239,7 +239,13 @@ export function updateUserSettingAsync(userId: string, key: string, value: strin
   const doUpdate = () => {
     if (!fs.existsSync(settingsPath)) {
       _log('User settings file %s not found, copying default settings.', settingsPath);
-      copyDefaultUserSettings(userId);
+      try {
+        copyDefaultUserSettings(userId);
+      }
+      catch (e) {
+        _log('Failed to copy default settings, using from existing location.', e);
+        return <common.UserSettings>JSON.parse(getDefaultUserSettings(userId));
+      }
     }
 
     let settings: common.UserSettings;


### PR DESCRIPTION
This will support attaching a home directory on another disk after
start.