### PR TITLE
Fix showing preview placeholder when no items selected

### DIFF
--- a/sources/web/datalab/polymer/components/preview-pane/preview-pane.html
+++ b/sources/web/datalab/polymer/components/preview-pane/preview-pane.html
@@ -32,8 +32,8 @@ the License.
         color: var(--neutral-fg-color);
       }
     </style>
-    <div id="container" hidden$="{{!file}}">
-      <iron-pages id="preview" selected="{{preview}}" attr-for-selected="name">
+    <div id="container">
+      <iron-pages id="preview" selected="{{preview}}" attr-for-selected="name" hidden$="{{!file}}">
         <notebook-preview class="preview" name="notebook" file="{{file}}" active="{{active}}"></notebook-preview>
         <table-preview class="preview" name="table" file="{{file}}" active="{{active}}"></table-preview>
         <text-preview class="preview" name="text" file="{{file}}" active="{{active}}"></text-preview>

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.html
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.html
@@ -22,12 +22,6 @@ the License.
 <dom-module id="table-preview">
   <template>
     <style include="datalab-shared-styles">
-      #placeholder {
-        height: 100%;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-      }
       #openInNotebookButton {
         background-color: var(--paper-blue-600);
         color: white;
@@ -67,9 +61,6 @@ the License.
         margin: 20px 0px;
       }
     </style>
-    <div id="placeholder" hidden$={{_table}}>
-      <paper-spinner active hidden$={{!_busy}}></paper-spinner>
-    </div>
     <div id="container" hidden$={{!_table}}>
       <br>
       <paper-button id="openInNotebookButton" raised on-click="_openInNotebook">

--- a/sources/web/datalab/polymer/test/table-preview-test.ts
+++ b/sources/web/datalab/polymer/test/table-preview-test.ts
@@ -74,13 +74,6 @@ describe('<table-preview>', () => {
     Polymer.dom.flush();
   });
 
-  it('displays an empty element if no table is provided', () => {
-    assert(!testFixture.$.placeholder.hidden, 'placeholder should be shown');
-    assert(testFixture.$.container.hidden, 'container should be hidden');
-    assert(testFixture.$.placeholder.querySelector('paper-spinner'),
-        'spinner should be hidden if no table is loading');
-  });
-
   it('loads the table given its id and gets its details', (done: () => null) => {
     testFixture.addEventListener('_table-changed', () => {
       Polymer.dom.flush();


### PR DESCRIPTION
The placeholder element is common to all preview elements, so the container div containing both the elements and the placeholder shouldn't be hidden.