### PR TITLE
Increase Drive list page size from 30 to 1000

### DIFF
--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -142,7 +142,8 @@ class GapiManager {
       return gapi.client.drive.files.list({
         fields: 'nextPageToken, files(' + fileFields.join(',') + ')',
         orderBy: orderBy ? orderBy.join(',') : '',
-        pageSize: 30,
+        // TODO: Implement paging.
+        pageSize: 1000,
         q: queryPredicates.join(' and '),
       })
       .then((response: HttpResponse<gapi.client.drive.ListFilesResponse>) => {


### PR DESCRIPTION
Until we have a paging mechanism, use the maximum page size for the Drive file listing, 1000.