### PR TITLE
Take datalab-app as a dependency for all entrypoints

### DIFF
--- a/sources/web/datalab/polymer/editor.html
+++ b/sources/web/datalab/polymer/editor.html
@@ -22,6 +22,7 @@ the License.
     <title>Google Cloud Datalab</title>
     <link rel="shortcut icon" href="images/favicon.ico">
 
+    <link rel="import" href="components/datalab-app/datalab-app.html">
     <link rel="import" href="components/datalab-editor/datalab-editor.html">
     <link rel="import" href="modules/utils/utils.html">
     <link id="themeStylesheet" rel="stylesheet" href="index.css">

--- a/sources/web/datalab/polymer/notebook.html
+++ b/sources/web/datalab/polymer/notebook.html
@@ -9,10 +9,7 @@
     <link rel="shortcut icon" href="images/favicon.ico">
 
     <link id="themeStylesheet" rel="stylesheet" href="index.light.css">
-    <link rel="import" href="modules/api-manager/api-manager.html">
-    <link rel="import" href="modules/file-manager/file-manager.html">
-    <link rel="import" href="modules/file-manager-factory/file-manager-factory.html">
-    <link rel="import" href="modules/utils/utils.html">
+    <link rel="import" href="components/datalab-app/datalab-app.html">
   </head>
   <body>
     <style>


### PR DESCRIPTION
After bundling resources, datalab-app is the only shell, and all its dependencies get inlined into it. In order to get the shared dependencies, other entrypoints, e.g. editor and notebook, need to take datalab-app as a dependency.