### PR TITLE
Fix breadcrumbs height css issue

### DIFF
--- a/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
+++ b/sources/web/datalab/polymer/components/bread-crumbs/bread-crumbs.html
@@ -62,7 +62,7 @@ the License.
         content: "";
         position: absolute;
         border: 0 solid var(--primary-bg-color);
-        border-width: 24px 12px;
+        border-width: 22px 12px;
       }
       #breadcrumb div.crumb a:before {
         left: -24px;


### PR DESCRIPTION
This only shows on the copy/move dialog, since it uses default z-index.