### PR TITLE
File browser busy loading fixes

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -202,9 +202,17 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
   }
 
   async _init() {
-    // Must set this to true before calling super.ready(), because the latter will cause
-    // property updates that will cause _fetchFileList to be called first, we don't want
-    // that. We want ready() to be the entry point so it gets the user's last saved path.
+    // TODO(yelsayed): We use this flag to prevent multiple async operations to
+    // step on each other. It basically acts as a semaphore; when an operation
+    // is called, it first checks if this flag is raised, and it stops if it is.
+    // Otherwise it raises it first. This result in operations stopping if
+    // others are executing, instead of queueing, which is not obviously a
+    // better experience. We might want to revisit this later.
+
+    // Additionally, we must set this to true before calling super.ready(),
+    // because the latter will cause property updates that will cause
+    // _fetchFileList to be called first, we don't want that. We want ready() to
+    // be the entry point so it gets the user's last saved path.
     this._fetching = true;
 
     // Likewise, we set the flag to prevent _fileIdChanged from taking action.

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -250,7 +250,20 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
         FileManagerFactory.fileManagerNameToType(this.fileManagerType));
 
     await this._loadStartupPath(fileId);
-    await this._finishLoadingFiles();
+
+    this.resizeHandler();
+    this.focusHandler();
+
+    filesElement.addEventListener('itemDoubleClick',
+                                  this._handleDoubleClicked.bind(this));
+    filesElement.addEventListener('selected-indices-changed',
+                                  this._handleSelectionChanged.bind(this));
+
+    // For a small file/directory picker, we don't need to show the status.
+    filesElement.columns = this.small ? ['Name'] : ['Name', 'Status'];
+
+    this._fetching = false;
+    await this._fetchFileList();
 
     this._ignoreFileIdChange = false;
   }
@@ -323,6 +336,9 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       const btn = document.createElement('paper-button');
       btn.classList.add('toolbar-button');
       btn.addEventListener('click', () => {
+        if (this._fetching) {
+          return;
+        }
         if (this.fileManagerType !== strType) {
           this.fileManagerType = strType;
           this._fileManager = FileManagerFactory.getInstanceForType(type);
@@ -449,6 +465,9 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * an effect, a directory will still navigate.
    */
   async _handleDoubleClicked(e: ItemClickEvent) {
+    if (this._fetching) {
+      return;
+    }
     const clickedItem = this._fileList[e.detail.index];
     if (this.small && clickedItem.type !== DatalabFileType.DIRECTORY) {
       return;
@@ -561,6 +580,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * uses the FileManager to save it on the backend.
    */
   async _upload() {
+    if (this._fetching) {
+      return;
+    }
+
     const inputElement = this.$.altFileUpload as HTMLInputElement;
     const files = [...inputElement.files as any];
     const uploadPromises: Array<Promise<any>> = [];
@@ -595,6 +618,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       }
     }
 
+    this._fetching = true;
     files.forEach((file: File) => {
 
       // First, load the file data into memory.
@@ -646,6 +670,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     // Wait on all upload requests before declaring success or failure.
     try {
       await Promise.all(uploadPromises);
+      this._fetching = false;
       if (uploadPromises.length) {
         // Dispatch a success notification, and refresh the file list
         const message = files.length > 1 ? files.length + ' files' : files[0].name;
@@ -656,6 +681,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       // Reset the input element.
       inputElement.value = '';
     } catch (e) {
+      this._fetching = false;
       Utils.showErrorDialog('Error uploading file', e.message);
     }
   }
@@ -672,6 +698,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * of files to redraw.
    */
   _createNewItem(itemType: DatalabFileType) {
+
+    if (this._fetching) {
+      return;
+    }
 
     // First, open a dialog to let the user specify a name for the notebook.
     const inputOptions: InputDialogOptions = {
@@ -691,13 +721,18 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
             newName += '.ipynb';
           }
 
+          this._fetching = true;
           return this._fileManager.create(itemType, this.currentFile.id, newName)
             .then(() => {
               // Dispatch a success notification, and refresh the file list
               this.dispatchEvent(new NotificationEvent('Created ' + newName + '.'));
+              this._fetching = false;
               this._fetchFileList();
             })
-            .catch((e: Error) => Utils.showErrorDialog('Error creating item', e.message));
+            .catch((e: Error) => {
+              this._fetching = false;
+              Utils.showErrorDialog('Error creating item', e.message);
+            });
         } else {
           return Promise.resolve(null);
         }
@@ -725,6 +760,9 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * selected.
    */
   _renameSelectedItem() {
+    if (this._fetching) {
+      return;
+    }
 
     const selectedIndices = (this.$.files as ItemListElement).selectedIndices;
     if (selectedIndices.length === 1) {
@@ -744,15 +782,20 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       return Utils.showDialog(InputDialogElement, inputOptions)
         .then((closeResult: InputDialogCloseResult) => {
           if (closeResult.confirmed && closeResult.userInput) {
+            this._fetching = true;
             return this._fileManager.rename(selectedObject.id, closeResult.userInput)
               .then(() => {
                 // Dispatch a success notification, and refresh the file list
                 const message = 'Renamed ' + selectedObject.name +
                     ' to ' + closeResult.userInput + '.';
                 this.dispatchEvent(new NotificationEvent(message));
+                this._fetching = false;
                 this._fetchFileList();
               })
-              .catch((e: Error) => Utils.showErrorDialog('Error renaming item', e.message));
+              .catch((e: Error) => {
+                this._fetching = false;
+                Utils.showErrorDialog('Error renaming item', e.message);
+              });
           } else {
             return Promise.resolve(null);
           }
@@ -768,6 +811,9 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * then refreshes the file list.
    */
   _deleteSelectedItems() {
+    if (this._fetching) {
+      return;
+    }
 
     const selectedIndices = (this.$.files as ItemListElement).selectedIndices;
     if (selectedIndices.length) {
@@ -813,6 +859,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
             const deletePromises = selectedIndices.map((i: number) => {
               return this._fileManager.delete(this._fileList[i].id);
             });
+            this._fetching = true;
             // TODO: [yebrahim] If at least one delete fails, _fetchFileList will never be called,
             // even if some other deletes completed.
             return Promise.all(deletePromises)
@@ -820,9 +867,13 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
                 // Dispatch a success notification, and refresh the file list
                 const message = 'Deleted ' + num + (num === 1 ? ' file.' : 'files.');
                 this.dispatchEvent(new NotificationEvent(message));
+                this._fetching = false;
                 this._fetchFileList();
               })
-              .catch((e: Error) => Utils.showErrorDialog('Error deleting item', e.message));
+              .catch((e: Error) => {
+                this._fetching = false;
+                Utils.showErrorDialog('Error deleting item', e.message);
+              });
           } else {
             return Promise.resolve(null);
           }
@@ -867,6 +918,9 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * TODO: Consider allowing multiple items to be copied.
    */
   _copySelectedItem() {
+    if (this._fetching) {
+      return;
+    }
 
     const selectedIndices = (this.$.files as ItemListElement).selectedIndices;
 
@@ -883,14 +937,19 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       return Utils.showDialog(DirectoryPickerDialogElement, options)
         .then((closeResult: DirectoryPickerDialogCloseResult) => {
           if (closeResult.confirmed) {
+            this._fetching = true;
             return this._fileManager.copy(selectedObject.id, closeResult.selectedDirectory.id)
               .then(() => {
                 // Dispatch a success notification, and refresh the file list
                 const message = 'Copied item.';
                 this.dispatchEvent(new NotificationEvent(message));
+                this._fetching = false;
                 this._fetchFileList();
               })
-              .catch((e: Error) => Utils.showErrorDialog('Error copying item', e.message));
+              .catch((e: Error) => {
+                this._fetching = false;
+                Utils.showErrorDialog('Error copying item', e.message);
+              });
           } else {
             return Promise.resolve(null);
           }
@@ -907,6 +966,9 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * TODO: Consider allowing multiple items to be moved.
    */
   _moveSelectedItem() {
+    if (this._fetching) {
+      return;
+    }
 
     const selectedIndices = (this.$.files as ItemListElement).selectedIndices;
 
@@ -923,6 +985,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       return Utils.showDialog(DirectoryPickerDialogElement, options)
         .then((closeResult: DirectoryPickerDialogCloseResult) => {
           if (closeResult.confirmed) {
+            this._fetching = true;
             // Moving is renaming.
             return this._fileManager.rename(selectedObject.id, selectedObject.name,
                                             closeResult.selectedDirectory.id)
@@ -930,9 +993,13 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
                 // Dispatch a success notification, and refresh the file list
                 const message = 'Moved item.';
                 this.dispatchEvent(new NotificationEvent(message));
+                this._fetching = false;
                 this._fetchFileList();
               })
-              .catch((e: Error) => Utils.showErrorDialog('Error moving item', e.message));
+              .catch((e: Error) => {
+                this._fetching = false;
+                Utils.showErrorDialog('Error moving item', e.message);
+              });
           } else {
             return Promise.resolve(null);
           }
@@ -1066,25 +1133,6 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     const config = FileManagerFactory.getFileManagerConfig(type);
     this._fileManagerDisplayIcon = config.displayIcon;
     this._fileManagerDisplayName = config.displayName;
-  }
-
-  private _finishLoadingFiles() {
-    this.resizeHandler();
-    this.focusHandler();
-
-    const filesElement = this.shadowRoot.querySelector('#files');
-    if (filesElement) {
-      filesElement.addEventListener('itemDoubleClick',
-                                    this._handleDoubleClicked.bind(this));
-      filesElement.addEventListener('selected-indices-changed',
-                                    this._handleSelectionChanged.bind(this));
-    }
-
-    // For a small file/directory picker, we don't need to show the status.
-    (this.$.files as ItemListElement).columns = this.small ? ['Name'] : ['Name', 'Status'];
-
-    this._fetching = false;
-    return this._fetchFileList();
   }
 
 }

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -403,7 +403,8 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       })
       // Now load the sessions and update the running status of each file
       // whose id is in the session list.
-      .then(() => SessionManager.listSessionPaths())
+      // We do not need to load sessions when in small mode.
+      .then(() => this.small ? Promise.resolve([]) : SessionManager.listSessionPaths())
       .catch((e) => {
         // Do not block loading files if sessions don't load for some reason.
         Utils.log.error('Could not load sessions: ' + e.message);


### PR DESCRIPTION
This PR checks and sets the fetching busy status of the file browser on all async operations.
It also removes loading sessions when in the small mode for the copy/move dialog.