### PR TITLE
Add another path to the metadata fake.

### DIFF
--- a/sources/web/datalab/metadata.ts
+++ b/sources/web/datalab/metadata.ts
@@ -68,7 +68,8 @@ function launchFakeServer(metadata: FakeMetadata): void {
       res.writeHead(200, { 'Metadata-Flavor': 'Google', 'Content-Type': 'application/text' });
       res.write('default/\n');
       res.write(metadata.creds.account + '/\n');
-    } else if (urlpath == '/computeMetadata/v1/instance/service-accounts/default/' &&
+    } else if ((urlpath == '/computeMetadata/v1/instance/service-accounts/default/' ||
+                urlpath == '/computeMetadata/v1/instance/service-accounts/' + metadata.creds.account + '/') &&
                (parsed_url.query['recursive'] || '').toLowerCase() == "true") {
       const accountJSON: any = {
         aliases: ["default"],


### PR DESCRIPTION
Before this change, google-auth-library-python can refresh a GCE metadata
token against the fake at most once:
* on the first attempt, it uses the name `default`
* once that response is received, it updates its service account name in the
  credentials object
* a second attempt uses the updated name in the URL.

The fix is trivial (just check for the second path).

PTAL @ojarjur 