### PR TITLE
Make the fake metadata address configurable.

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -174,6 +174,11 @@ declare module common {
      * Possible options are: jupyter, drive, sharedDrive, docs, and bigquery
      */
     supportedFileBrowserSources: string[];
+
+    /**
+     * The host/port on which to serve the fake metadata service, if active.
+     */
+    fakeMetadataAddress: {host: "metadata.google.internal"|"metadata"|null, port: number};
   }
 
   interface TimeoutInfo {

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -46,5 +46,6 @@
     "--MultiKernelManager.default_kernel_name=\"python2\"",
     "--ip=\"127.0.0.1\""
   ],
-  "supportedFileBrowserSources": ["jupyter"]
+  "supportedFileBrowserSources": ["jupyter"],
+  "fakeMetadataAddress": {"host": "metadata.google.internal", "port": 80}
 }

--- a/sources/web/datalab/metadata.ts
+++ b/sources/web/datalab/metadata.ts
@@ -46,9 +46,9 @@ const metadata: FakeMetadata = {
   },
 };
 
-function launchFakeServer(metadata: FakeMetadata): void {
-  const port = 80;
-  const host = 'metadata.google.internal';
+function launchFakeServer(metadata: FakeMetadata, settings: common.AppSettings): void {
+  const port = settings.fakeMetadataAddress.port;
+  const host = settings.fakeMetadataAddress.host;
   logging.getLogger().info('Starting fake metadata server at http://%s:%d with %s',
                            host, port, JSON.stringify(metadata));
 
@@ -111,19 +111,19 @@ function launchFakeServer(metadata: FakeMetadata): void {
     // earlier invocation of `gcloud` could have written that file. To account
     // for this, we overwrite the file with the value that indicates the tool
     // should read from the metadata server.
-    const gceFile = '/content/datalab/.config/gce'
+    const gceFile = settings.contentDir + '/datalab/.config/gce';
     fs.writeFileSync(gceFile, "True");
   });
 }
 
 /**
- * Initializes the Jupyter server manager.
+ * Initializes the GCE metadata service fake.
  */
 export function init(settings: common.AppSettings): void {
   if (process.env.DATALAB_FAKE_METADATA_SERVER != 'true') {
     return;
   }
-  launchFakeServer(metadata);
+  launchFakeServer(metadata, settings);
 }
 
 function parseCreds(request: http.ServerRequest, callback: Function): void {


### PR DESCRIPTION
This makes it possible to configure the GCE metadata fake to serve on a
different host/port combination; the primary goal is to make it possible to
use the metadata service locally without the related Docker network
configs. (Without this, server startup will fail attempting to bind to
`metadata.google.internal`.)

PTAL @ojarjur 