### PR TITLE
Use URL paths for file id, enable relative file paths

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -21,6 +21,7 @@ the License.
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
 <link rel="import" href="../../components/resizable-divider/resizable-divider.html">
 <link rel="import" href="../../modules/api-manager/api-manager.html">
+<link rel="import" href="../../modules/file-manager-factory/file-manager-factory.html">
 <link rel="import" href="../../modules/settings-manager/settings-manager.html">
 
 <dom-module id="datalab-app">
@@ -66,11 +67,12 @@ the License.
     </style>
 
     <!--Router-->
-    <app-location route="{{route}}" query-params={{queryParams}}></app-location>
+    <app-location route="{{route}}"></app-location>
     <app-route
         route="{{route}}"
-        pattern="{{rootPattern}}:page"
-        data="{{routeData}}"></app-route>
+        pattern="/:page"
+        data="{{routeData}}"
+        tail="{{routeTail}}"></app-route>
 
     <div id="container">
       <datalab-toolbar></datalab-toolbar>

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -69,7 +69,7 @@ the License.
     <app-location route="{{route}}" query-params={{queryParams}}></app-location>
     <app-route
         route="{{route}}"
-        pattern="/:page"
+        pattern="{{rootPattern}}:page"
         data="{{routeData}}"></app-route>
 
     <div id="container">

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -69,7 +69,7 @@ the License.
     <app-location route="{{route}}" query-params={{queryParams}}></app-location>
     <app-route
         route="{{route}}"
-        pattern="{{rootPattern}}:page"
+        pattern="/:page"
         data="{{routeData}}"></app-route>
 
     <div id="container">

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -43,7 +43,9 @@ class DatalabAppElement extends Polymer.Element {
    */
   public routeData: object;
 
-  // TODO: doc
+  /**
+   * Tail of the parsed route, which contains the file id in its path property.
+   */
   public routeTail: object;
 
   private _boundResizeHandler: EventListenerObject;
@@ -93,8 +95,9 @@ class DatalabAppElement extends Polymer.Element {
 
   static get observers() {
     return [
-      // We need a complex observer for changes to the routeData
-      // object's page property.
+      // We need a complex observer for changes to the routeData object's page
+      // property, and the path property of routeTail, which contains the file
+      // id.
       '_routePageChanged(routeData.page)',
       '_routeTailPathChanged(routeTail.path)',
     ];

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -42,15 +42,9 @@ class DatalabAppElement extends Polymer.Element {
   public page: string;
 
   /**
-   * Pattern for extracting current pathname component. This is matched
-   * against current location to extract the page name.
-   */
-  public rootPattern: string;
-
-  /**
-   * Current matching result from the window.location against the
-   * root pattern. This gets re-evaluated every time the current page
-   * changes, and can be used to get the current active page's name.
+   * Current matching result from the window.location. This gets re-evaluated
+   * every time the current page changes, and can be used to get the current
+   * active page's name.
    */
   public routeData: object;
 
@@ -59,19 +53,6 @@ class DatalabAppElement extends Polymer.Element {
 
   constructor() {
     super();
-
-    // Fix the root path (see https://github.com/Polymer/polymer/issues/4822)
-    const rootUrl = new URL(this.rootPath);
-    rootUrl.hash = '';
-    rootUrl.search = '';
-    const strippedRoot = rootUrl.toString();
-    const rootPath =
-        strippedRoot.substring(0, strippedRoot.lastIndexOf('/') + 1);
-    // TODO - once polymer #4822 is fixed, remove the above code that
-    // creates rootPath and use this.rootPath in the following line.
-
-    // Set the pattern once to be the current document pathname.
-    this.rootPattern = (new URL(rootPath)).pathname;
 
     this._boundResizeHandler = this.resizeHandler.bind(this);
     window.addEventListener('resize', this._boundResizeHandler, true);
@@ -109,7 +90,6 @@ class DatalabAppElement extends Polymer.Element {
         observer: '_queryParamsChanged',
         type: Object,
       },
-      rootPattern: String,
       routeData: Object,
     };
   }

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -42,9 +42,15 @@ class DatalabAppElement extends Polymer.Element {
   public page: string;
 
   /**
-   * Current matching result from the window.location. This gets re-evaluated
-   * every time the current page changes, and can be used to get the current
-   * active page's name.
+   * Pattern for extracting current pathname component. This is matched
+   * against current location to extract the page name.
+   */
+  public rootPattern: string;
+
+  /**
+   * Current matching result from the window.location against the
+   * root pattern. This gets re-evaluated every time the current page
+   * changes, and can be used to get the current active page's name.
    */
   public routeData: object;
 
@@ -53,6 +59,19 @@ class DatalabAppElement extends Polymer.Element {
 
   constructor() {
     super();
+
+    // Fix the root path (see https://github.com/Polymer/polymer/issues/4822)
+    const rootUrl = new URL(this.rootPath);
+    rootUrl.hash = '';
+    rootUrl.search = '';
+    const strippedRoot = rootUrl.toString();
+    const rootPath =
+        strippedRoot.substring(0, strippedRoot.lastIndexOf('/') + 1);
+    // TODO - once polymer #4822 is fixed, remove the above code that
+    // creates rootPath and use this.rootPath in the following line.
+
+    // Set the pattern once to be the current document pathname.
+    this.rootPattern = (new URL(rootPath)).pathname;
 
     this._boundResizeHandler = this.resizeHandler.bind(this);
     window.addEventListener('resize', this._boundResizeHandler, true);
@@ -90,6 +109,7 @@ class DatalabAppElement extends Polymer.Element {
         observer: '_queryParamsChanged',
         type: Object,
       },
+      rootPattern: String,
       routeData: Object,
     };
   }

--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.ts
@@ -27,11 +27,6 @@
 class DatalabAppElement extends Polymer.Element {
 
   /**
-   * The query parameters (from app-location).
-   */
-  public queryParams: {};
-
-  /**
    * The fileId being propagated to and from our pages.
    */
   public fileId: string;
@@ -42,36 +37,20 @@ class DatalabAppElement extends Polymer.Element {
   public page: string;
 
   /**
-   * Pattern for extracting current pathname component. This is matched
-   * against current location to extract the page name.
-   */
-  public rootPattern: string;
-
-  /**
-   * Current matching result from the window.location against the
-   * root pattern. This gets re-evaluated every time the current page
-   * changes, and can be used to get the current active page's name.
+   * Current matching result from the window.location. This gets re-evaluated
+   * every time the current page changes, and can be used to get the current
+   * active page's name.
    */
   public routeData: object;
+
+  // TODO: doc
+  public routeTail: object;
 
   private _boundResizeHandler: EventListenerObject;
   private _fileBrowserSources: string[];
 
   constructor() {
     super();
-
-    // Fix the root path (see https://github.com/Polymer/polymer/issues/4822)
-    const rootUrl = new URL(this.rootPath);
-    rootUrl.hash = '';
-    rootUrl.search = '';
-    const strippedRoot = rootUrl.toString();
-    const rootPath =
-        strippedRoot.substring(0, strippedRoot.lastIndexOf('/') + 1);
-    // TODO - once polymer #4822 is fixed, remove the above code that
-    // creates rootPath and use this.rootPath in the following line.
-
-    // Set the pattern once to be the current document pathname.
-    this.rootPattern = (new URL(rootPath)).pathname;
 
     this._boundResizeHandler = this.resizeHandler.bind(this);
     window.addEventListener('resize', this._boundResizeHandler, true);
@@ -104,13 +83,11 @@ class DatalabAppElement extends Polymer.Element {
         type: String,
         value: '',
       },
-      queryParams: {
+      routeData: Object,
+      routeTail: {
         notify: true,
-        observer: '_queryParamsChanged',
         type: Object,
       },
-      rootPattern: String,
-      routeData: Object,
     };
   }
 
@@ -119,6 +96,7 @@ class DatalabAppElement extends Polymer.Element {
       // We need a complex observer for changes to the routeData
       // object's page property.
       '_routePageChanged(routeData.page)',
+      '_routeTailPathChanged(routeTail.path)',
     ];
   }
 
@@ -140,17 +118,8 @@ class DatalabAppElement extends Polymer.Element {
     }
   }
 
-  _queryParamsChanged() {
-    const queryParams = (this.queryParams || {}) as {[key: string]: string};
-    const fileParamName = 'file';
-    const fileParam = queryParams[fileParamName] || '';
-    if (fileParam !== this.fileId) {
-      this.fileId = fileParam;
-    }
-  }
-
   _fileIdChanged() {
-    this.set('queryParams.file', this.fileId);
+    this.set('routeTail.path', this.fileId);
   }
 
   /**
@@ -159,6 +128,14 @@ class DatalabAppElement extends Polymer.Element {
    */
   _routePageChanged(page: string) {
     this.page = page;
+  }
+
+  _routeTailPathChanged() {
+    let path = (this.routeTail as any).path as string;
+    if (path.startsWith('/')) {
+      path = path.substr(1);
+    }
+    this.fileId = path;
   }
 
   /**

--- a/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.html
+++ b/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.html
@@ -29,7 +29,7 @@ the License.
     </style>
 
     <file-browser id="fileBrowser" file-manager-type='github' n-leading-breadcrumbs-to-trim="2"
-        file-id="github:googledatalab/notebooks" hide-toolbar></file-browser>
+        file-id="github/googledatalab/notebooks" hide-toolbar></file-browser>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
+++ b/sources/web/datalab/polymer/components/datalab-sessions/datalab-sessions.ts
@@ -111,7 +111,7 @@ class SessionsElement extends Polymer.Element implements DatalabPageElement {
     } else {
       let id: DatalabFileId;
       try {
-        id = DatalabFileId.fromQueryString(session.notebook.path);
+        id = DatalabFileId.fromString(session.notebook.path);
       } catch (e) {
         // If we fail to parse the path as a file id, default to using Jupyter,
         // since the V1 Jupyter notebook editor does not pass a full file id.

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
@@ -90,7 +90,7 @@ the License.
       <div class="button-placeholder"></div>
       <iron-selector class="container" attr-for-selected="id" selected={{page}}
                      class="drawer-list" role="navigation">
-        <a href="{{_uiroot}}/data" id="data" hidden$="{{!_showDataTab}}">
+        <a href="/data" id="data" hidden$="{{!_showDataTab}}">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="av:library-books"></iron-icon>
@@ -98,7 +98,7 @@ the License.
             </div>
           </paper-button>
         </a>
-        <a href="{{_uiroot}}/files" id="files">
+        <a href="/files" id="files">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="editor:insert-drive-file"></iron-icon>
@@ -106,7 +106,7 @@ the License.
             </div>
           </paper-button>
         </a>
-        <a href="{{_uiroot}}/sessions" id="sessions">
+        <a href="/sessions" id="sessions">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="list"></iron-icon>
@@ -114,7 +114,7 @@ the License.
             </div>
           </paper-button>
         </a>
-        <a href="{{_uiroot}}/terminal" id="terminal">
+        <a href="/terminal" id="terminal">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="av:featured-play-list"></iron-icon>
@@ -126,7 +126,7 @@ the License.
         <br>
         <hr>
         <br>
-        <a href="{{_uiroot}}/docs" id="docs">
+        <a href="/docs" id="docs">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="help"></iron-icon>

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
@@ -26,7 +26,6 @@ class SidebarElement extends Polymer.Element {
 
   // TODO - remove _showDataTab once the Data tab is ready to be visible
   private _showDataTab = false;
-  private _uiroot: string;
 
   static get is() { return 'datalab-sidebar'; }
 
@@ -35,10 +34,6 @@ class SidebarElement extends Polymer.Element {
       _showDataTab: {
         type: Boolean,
         value: false,
-      },
-      _uiroot: {
-        type: String,
-        value: '',
       },
       page: {
         type: String,
@@ -49,12 +44,7 @@ class SidebarElement extends Polymer.Element {
 
   public ready() {
     super.ready();
-    if (location.pathname.startsWith('/exp/')) {
-      this._uiroot = '/exp';
-      Utils.uiroot = this._uiroot;
-    }
-    if (location.pathname.startsWith('/exp/data') ||
-        location.pathname.startsWith('/data')) {
+    if (location.pathname.startsWith('/data')) {
       this._showDataTab = true;
     }
   }

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -284,9 +284,9 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
         return null;
       }
       try {
-        fileId = DatalabFileId.fromQueryString(this.fileId);
+        fileId = DatalabFileId.fromString(this.fileId);
       } catch (e) {
-        Utils.showErrorDialog('Invalid file query parameter', e.message);
+        Utils.showErrorDialog('Invalid file path', e.message);
         // Fall through with fileId unset
       }
     }
@@ -424,13 +424,13 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
           // The v1 notebook editor creates sessions with just the file path,
           // while v2 editor uses the full id string.
           if (sessions.indexOf(file.id.path) > -1 ||
-              sessions.indexOf(file.id.toQueryString()) > -1) {
+              sessions.indexOf(file.id.toString()) > -1) {
             listElement.set('rows.' + i + '.columns.1', Utils.getFileStatusString(DatalabFileStatus.RUNNING));
           }
         });
       })
       .catch((e: Error) => {
-        const fileSpec = this.currentFile.id.toQueryString();
+        const fileSpec = this.currentFile.id.toString();
         const msgPrefix = 'Error getting list of files from ' + fileSpec + ':';
         if (throwOnError === true) {
           throw new Error(msgPrefix + ' ' + e.message);
@@ -558,7 +558,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
         return;
       }
       this._ignoreFileIdChange = true;
-      this.fileId = this.currentFile.id.toQueryString();
+      this.fileId = this.currentFile.id.toString();
       this._ignoreFileIdChange = false;
     }
   }
@@ -1101,7 +1101,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     // This method is called when we are switching tabs, and when that is
     // happening, iron-location sets an internal dontUpdateUrl flag that
     // prevents our update of the fileIdProperty from happening. In order to
-    // get our file param in place, we delay execution until after
+    // get our file path in place, we delay execution until after
     // _urlChanged() in iron-location.html has completed.
     window.setTimeout(() => this._setFileIdPropertyToCurrentFile(), 0);
   }

--- a/sources/web/datalab/polymer/editor.html
+++ b/sources/web/datalab/polymer/editor.html
@@ -20,6 +20,7 @@ the License.
           content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
     <title>Google Cloud Datalab</title>
+    <base href="{base_url}">
     <link rel="shortcut icon" href="images/favicon.ico">
 
     <link rel="import" href="components/datalab-app/datalab-app.html">

--- a/sources/web/datalab/polymer/editor.html
+++ b/sources/web/datalab/polymer/editor.html
@@ -20,13 +20,12 @@ the License.
           content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
     <title>Google Cloud Datalab</title>
-    <base href="{base_url}">
-    <link rel="shortcut icon" href="images/favicon.ico">
+    <link rel="shortcut icon" href="{base_url}images/favicon.ico">
 
-    <link rel="import" href="components/datalab-app/datalab-app.html">
-    <link rel="import" href="components/datalab-editor/datalab-editor.html">
-    <link rel="import" href="modules/utils/utils.html">
-    <link id="themeStylesheet" rel="stylesheet" href="index.css">
+    <link rel="import" href="{base_url}components/datalab-app/datalab-app.html">
+    <link rel="import" href="{base_url}components/datalab-editor/datalab-editor.html">
+    <link rel="import" href="{base_url}modules/utils/utils.html">
+    <link id="themeStylesheet" rel="stylesheet" href="{base_url}index.css">
   </head>
   <body>
     <style>

--- a/sources/web/datalab/polymer/editor.ts
+++ b/sources/web/datalab/polymer/editor.ts
@@ -38,13 +38,14 @@ if (editorElement) {
   // the url querystring
   editorElement.addEventListener('file-id-changed', (e: CustomEvent) => {
     const newId = e.detail.value as DatalabFileId;
-    const url = location.protocol + '//' + location.host + '/editor/' + (newId || '');
+    const url = location.protocol + '//' + location.host +
+        Utils.constants.editorUrlComponent + (newId || '');
     window.history.replaceState({}, '', url);
   });
 
   // Pass the file's path if it's specified in the location.
-  if (location.pathname.startsWith('/editor/')) {
-    const path = location.pathname.substr('/editor/'.length);
+  if (location.pathname.startsWith(Utils.constants.editorUrlComponent)) {
+    const path = location.pathname.substr(Utils.constants.editorUrlComponent.length);
     try {
       editorElement.fileId = DatalabFileId.fromString(path);
     } catch (e) {

--- a/sources/web/datalab/polymer/editor.ts
+++ b/sources/web/datalab/polymer/editor.ts
@@ -38,21 +38,15 @@ if (editorElement) {
   // the url querystring
   editorElement.addEventListener('file-id-changed', (e: CustomEvent) => {
     const newId = e.detail.value as DatalabFileId;
-    if (newId) {
-      params.set('file', newId ? newId.toQueryString() : '');
-    } else {
-      params.delete('file');
-    }
-    const url = location.protocol + '//' + location.host + location.pathname +
-                '?' + decodeURIComponent(params.toString());
+    const url = location.protocol + '//' + location.host + '/editor/' + (newId || '');
     window.history.replaceState({}, '', url);
   });
 
   // Pass the file's path if it's specified in the location.
-  const params = new URLSearchParams(window.location.search);
-  if (params.has('file')) {
+  if (location.pathname.startsWith('/editor/')) {
+    const path = location.pathname.substr('/editor/'.length);
     try {
-      editorElement.fileId = DatalabFileId.fromQueryString(params.get('file') as string);
+      editorElement.fileId = DatalabFileId.fromString(path);
     } catch (e) {
       Utils.showErrorDialog('Error loading file', e.message);
       editorElement.fileId = null;

--- a/sources/web/datalab/polymer/index.html
+++ b/sources/web/datalab/polymer/index.html
@@ -20,12 +20,11 @@ the License.
           content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
     <title>Google Cloud Datalab</title>
-    <base href="{base_url}">
-    <link rel="shortcut icon" href="images/favicon.ico">
+    <link rel="shortcut icon" href="{base_url}images/favicon.ico">
 
-    <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script>
-    <link rel="import" href="components/datalab-app/datalab-app.html">
-    <link id="themeStylesheet" rel="stylesheet" href="index.css">
+    <script src="{base_url}bower_components/webcomponentsjs/webcomponents-loader.js"></script>
+    <link rel="import" href="{base_url}components/datalab-app/datalab-app.html">
+    <link id="themeStylesheet" rel="stylesheet" href="{base_url}index.css">
   </head>
   <body>
     <style is="custom-style">

--- a/sources/web/datalab/polymer/index.html
+++ b/sources/web/datalab/polymer/index.html
@@ -20,6 +20,7 @@ the License.
           content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
     <title>Google Cloud Datalab</title>
+    <base href="{base_url}">
     <link rel="shortcut icon" href="images/favicon.ico">
 
     <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script>

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -36,7 +36,7 @@ class DriveFileManager implements FileManager {
   public async getStringContent(fileId: DatalabFileId, _asText?: boolean): Promise<string> {
     const [, content] = await GapiManager.drive.getFileWithContent(fileId.path);
     if (content === null) {
-      throw new Error('Could not download file: ' + fileId.toQueryString());
+      throw new Error('Could not download file: ' + fileId.toString());
     }
     return content;
   }
@@ -110,12 +110,12 @@ class DriveFileManager implements FileManager {
   }
 
   public async getEditorUrl(fileId: DatalabFileId) {
-    return Utils.getHostRoot() + '/editor?file=' + fileId.toQueryString();
+    return Utils.getHostRoot() + '/editor/' + fileId.toString();
   }
 
   public async getNotebookUrl(fileId: DatalabFileId): Promise<string> {
     return location.protocol + '//' + location.host +
-        '/notebook?file=' + fileId.toQueryString();
+        '/notebook/' + fileId.toString();
   }
 
   public pathToPathHistory(path: string): DatalabFile[] {

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -110,12 +110,12 @@ class DriveFileManager implements FileManager {
   }
 
   public async getEditorUrl(fileId: DatalabFileId) {
-    return Utils.getHostRoot() + '/editor/' + fileId.toString();
+    return Utils.getHostRoot() + Utils.constants.editorUrlComponent + fileId.toString();
   }
 
   public async getNotebookUrl(fileId: DatalabFileId): Promise<string> {
     return location.protocol + '//' + location.host +
-        '/notebook/' + fileId.toString();
+        Utils.constants.notebookUrlComponent + fileId.toString();
   }
 
   public pathToPathHistory(path: string): DatalabFile[] {

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -46,7 +46,7 @@ enum DatalabFileStatus {
  * Unique identifier for a file object.
  */
 class DatalabFileId {
-  private static _delim = ':';
+  private static _delim = '/';
 
   path: string;
   source: FileManagerType;
@@ -56,19 +56,21 @@ class DatalabFileId {
     this.source = source;
   }
 
-  public static fromQueryString(querystring: string) {
-    const tokens = querystring.split(DatalabFileId._delim);
-    if (tokens.length !== 2) {
-      throw new Error('Invalid format for file id: ' + querystring);
+  public static fromString(path: string) {
+    const tokens = path.split(this._delim);
+    // Allow an empty path token
+    if (tokens.length === 1) {
+      tokens.push('');
     }
-    return new DatalabFileId(tokens[1], FileManagerFactory.fileManagerNameToType(tokens[0]));
+    const source = tokens.shift() as string;
+    return new DatalabFileId(tokens.join(this._delim),
+        FileManagerFactory.fileManagerNameToType(source));
   }
 
-  public toQueryString() {
-    return FileManagerFactory.fileManagerTypetoString(this.source) + DatalabFileId._delim +
-        this.path;
+  public toString() {
+    return FileManagerFactory.fileManagerTypetoString(this.source) +
+        DatalabFileId._delim + this.path;
   }
-
 }
 
 class NotebookContent {

--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
@@ -135,12 +135,12 @@ class GithubFileManager implements FileManager {
   }
 
   public async getEditorUrl(fileId: DatalabFileId) {
-    return Utils.getHostRoot() + '/editor/' + fileId.toString();
+    return Utils.getHostRoot() + Utils.constants.editorUrlComponent + fileId.toString();
   }
 
   public async getNotebookUrl(fileId: DatalabFileId): Promise<string> {
     return location.protocol + '//' + location.host +
-        '/notebook/' + fileId.toString();
+        Utils.constants.notebookUrlComponent + fileId.toString();
   }
 
   public pathToPathHistory(path: string): DatalabFile[] {

--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
@@ -135,12 +135,12 @@ class GithubFileManager implements FileManager {
   }
 
   public async getEditorUrl(fileId: DatalabFileId) {
-    return Utils.getHostRoot() + '/editor?file=' + fileId.toQueryString();
+    return Utils.getHostRoot() + '/editor/' + fileId.toString();
   }
 
   public async getNotebookUrl(fileId: DatalabFileId): Promise<string> {
     return location.protocol + '//' + location.host +
-        '/notebook?file=' + fileId.toQueryString();
+        '/notebook/' + fileId.toString();
   }
 
   public pathToPathHistory(path: string): DatalabFile[] {

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
@@ -282,7 +282,7 @@ class JupyterFileManager implements FileManager {
   public async getEditorUrl(fileId: DatalabFileId) {
     // TODO: We will need to get the base path when loading notebooks
     // from a VM running Datalab with Jupyter.
-    return Utils.getHostRoot() + '/editor?file=' + fileId.toQueryString();
+    return Utils.getHostRoot() + '/editor/' + fileId.toString();
   }
 
   public pathToPathHistory(path: string): DatalabFile[] {

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
@@ -282,7 +282,7 @@ class JupyterFileManager implements FileManager {
   public async getEditorUrl(fileId: DatalabFileId) {
     // TODO: We will need to get the base path when loading notebooks
     // from a VM running Datalab with Jupyter.
-    return Utils.getHostRoot() + '/editor/' + fileId.toString();
+    return Utils.getHostRoot() + Utils.constants.editorUrlComponent + fileId.toString();
   }
 
   public pathToPathHistory(path: string): DatalabFile[] {

--- a/sources/web/datalab/polymer/modules/template-manager/template-manager.ts
+++ b/sources/web/datalab/polymer/modules/template-manager/template-manager.ts
@@ -119,7 +119,7 @@ class BigQueryTableOverviewTemplate extends NotebookTemplate {
     }
 
     // Specify the default location of the template.
-    const defaultTemplateLocation = 'static:/templates/BigQueryTableOverview.ipynb';
+    const defaultTemplateLocation = 'static/templates/BigQueryTableOverview.ipynb';
 
     // TODO(jimmc); Until we have a user setting, allow specifying an alternate
     // location for the template file, for debugging, such as
@@ -127,7 +127,7 @@ class BigQueryTableOverviewTemplate extends NotebookTemplate {
     const windowDatalab = window.datalab || {}
     const templateLocation =
         windowDatalab.tableSchemaTemplateFileId || defaultTemplateLocation;
-    const templateId = DatalabFileId.fromQueryString(templateLocation);
+    const templateId = DatalabFileId.fromString(templateLocation);
     super(templateId, parameters, resolver);
   }
 }
@@ -149,7 +149,7 @@ class TemplateManager extends Polymer.Element {
 
     // TODO(jimmc): Look for a user preference for baseDir
     const baseType = (appSettings.defaultFileManager || 'drive');
-    const baseDir = baseType + ':';
+    const baseDir = baseType + '/';
     // TODO(jimmc): Allow specifying a path with baseDir. For now, we are
     // just using the root of the filesystem as the default location.
     const baseName = 'temp';

--- a/sources/web/datalab/polymer/modules/template-manager/template-manager.ts
+++ b/sources/web/datalab/polymer/modules/template-manager/template-manager.ts
@@ -212,7 +212,7 @@ class TemplateManager extends Polymer.Element {
   public static async getTemplateStringContent(fileId: DatalabFileId,
       resolver: Polymer.Element) {
     if (fileId.source === FileManagerType.STATIC) {
-      const resolvedUrl = resolver.resolveUrl('../..' + fileId.path);
+      const resolvedUrl = resolver.resolveUrl('../../' + fileId.path);
       const templateStringContent =
           await ApiManager.sendTextRequestAsync(resolvedUrl, {}, false);
       return templateStringContent;

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -17,8 +17,6 @@
  */
 class Utils {
 
-  static uiroot = '';   // Gets set to "/exp"
-
   public static log = class {
     public static verbose(...args: any[]) {
       // tslint:disable-next-line:no-console
@@ -175,7 +173,7 @@ class Utils {
    * Returns the current root URI.
    */
   public static getHostRoot() {
-    return location.protocol + '//' + location.host + Utils.uiroot;
+    return location.protocol + '//' + location.host;
   }
 
   /**

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -17,6 +17,8 @@
  */
 class Utils {
 
+  static uiroot = '';   // Gets set to "/exp"
+
   public static log = class {
     public static verbose(...args: any[]) {
       // tslint:disable-next-line:no-console
@@ -26,6 +28,11 @@ class Utils {
       // tslint:disable-next-line:no-console
       console.error(...args);
     }
+  };
+
+  public static constants = {
+    editorUrlComponent:   '/editor/',
+    notebookUrlComponent: '/notebook/',
   };
 
   /**
@@ -170,7 +177,6 @@ class Utils {
   public static getHostRoot() {
     return location.protocol + '//' + location.host + Utils.uiroot;
   }
-  static uiroot = '';   // Gets set to "/exp"
 
   /**
    * Flattens a BigQuery table schema

--- a/sources/web/datalab/polymer/notebook.html
+++ b/sources/web/datalab/polymer/notebook.html
@@ -6,11 +6,10 @@
           content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
     <title>Google Cloud Datalab</title>
-    <base href="{base_url}">
-    <link rel="shortcut icon" href="images/favicon.ico">
+    <link rel="shortcut icon" href="{base_url}images/favicon.ico">
 
-    <link id="themeStylesheet" rel="stylesheet" href="index.light.css">
-    <link rel="import" href="components/datalab-app/datalab-app.html">
+    <link id="themeStylesheet" rel="stylesheet" href="{base_url}index.light.css">
+    <link rel="import" href="{base_url}components/datalab-app/datalab-app.html">
   </head>
   <body>
     <style>

--- a/sources/web/datalab/polymer/notebook.html
+++ b/sources/web/datalab/polymer/notebook.html
@@ -6,6 +6,7 @@
           content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
     <title>Google Cloud Datalab</title>
+    <base href="{base_url}">
     <link rel="shortcut icon" href="images/favicon.ico">
 
     <link id="themeStylesheet" rel="stylesheet" href="index.light.css">

--- a/sources/web/datalab/polymer/notebook.ts
+++ b/sources/web/datalab/polymer/notebook.ts
@@ -88,12 +88,21 @@ function sendMessageToNotebookEditor(message: IframeMessage) {
 }
 
 if (location.pathname.startsWith('/notebook/')) {
-  const path = location.pathname.substr('/notebook/'.length);
-  // Currently this is one-directional, iframe wrapper querystring -> iframe hash param.
-  // We will need to change this if the editor is allowed to change the id of the
-  // open file, for example in the case of Jupyter files where the id is the file path.
   if (iframe) {
     window.top.addEventListener('message', processMessageEvent);
-    iframe.src = '/notebookeditor/' + path + '#fileId=' + path;
+
+    const path = location.pathname.substr('/notebook/'.length);
+
+    // Set the iframe source to load the notebook editor resources.
+    // TODO: Currently this is one-directional, iframe wrapper url -> iframe
+    // hash param. We will need to change this if the editor is allowed to
+    // change the id of the open file, for example in the case of the editor
+    // renaming the file.
+
+    // Adding the 'inIframe' query parameter signals to the server that we want
+    // to load the notebook editor resources as opposed to the notebook shell
+    // (this file). Both resources are loaded at /notebook in order to make any
+    // links in the editor relative to /notebook as well.
+    iframe.src = '/notebook/' + path + '?inIframe#fileId=' + path;
   }
 }

--- a/sources/web/datalab/polymer/notebook.ts
+++ b/sources/web/datalab/polymer/notebook.ts
@@ -87,11 +87,11 @@ function sendMessageToNotebookEditor(message: IframeMessage) {
   }
 }
 
-if (location.pathname.startsWith('/notebook/')) {
+if (location.pathname.startsWith(Utils.constants.notebookUrlComponent)) {
   if (iframe) {
     window.top.addEventListener('message', processMessageEvent);
 
-    const path = location.pathname.substr('/notebook/'.length);
+    const path = location.pathname.substr(Utils.constants.notebookUrlComponent.length);
 
     // Set the iframe source to load the notebook editor resources.
     // TODO: Currently this is one-directional, iframe wrapper url -> iframe
@@ -103,6 +103,7 @@ if (location.pathname.startsWith('/notebook/')) {
     // to load the notebook editor resources as opposed to the notebook shell
     // (this file). Both resources are loaded at /notebook in order to make any
     // links in the editor relative to /notebook as well.
-    iframe.src = '/notebook/' + path + '?inIframe#fileId=' + path;
+    iframe.src = Utils.constants.notebookUrlComponent + path +
+        '?inIframe#fileId=' + path;
   }
 }

--- a/sources/web/datalab/polymer/notebook.ts
+++ b/sources/web/datalab/polymer/notebook.ts
@@ -94,6 +94,6 @@ if (location.pathname.startsWith('/notebook/')) {
   // open file, for example in the case of Jupyter files where the id is the file path.
   if (iframe) {
     window.top.addEventListener('message', processMessageEvent);
-    iframe.src = 'notebookeditor#fileId=' + path;
+    iframe.src = '/notebookeditor/' + path + '#fileId=' + path;
   }
 }

--- a/sources/web/datalab/polymer/notebook.ts
+++ b/sources/web/datalab/polymer/notebook.ts
@@ -57,7 +57,7 @@ async function processMessageEvent(e: MessageEvent) {
   } else if (message.command === CommandId.LOAD_NOTEBOOK) {
     let outgoingMessage: IframeMessage;
     try {
-      const id = DatalabFileId.fromQueryString(message.arguments);
+      const id = DatalabFileId.fromString(message.arguments);
       const fileManager = FileManagerFactory.getInstanceForType(id.source);
       const [file, doc] = await Promise.all([
         fileManager.get(id),
@@ -87,13 +87,13 @@ function sendMessageToNotebookEditor(message: IframeMessage) {
   }
 }
 
-const params = new URLSearchParams(window.location.search);
-if (params.has('file')) {
+if (location.pathname.startsWith('/notebook/')) {
+  const path = location.pathname.substr('/notebook/'.length);
   // Currently this is one-directional, iframe wrapper querystring -> iframe hash param.
   // We will need to change this if the editor is allowed to change the id of the
   // open file, for example in the case of Jupyter files where the id is the file path.
   if (iframe) {
     window.top.addEventListener('message', processMessageEvent);
-    iframe.src = '/notebookeditor#fileId=' + params.get('file');
+    iframe.src = 'notebookeditor#fileId=' + path;
   }
 }

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -198,6 +198,10 @@ export function isExperimentalResource(pathname: string) {
   );
 }
 
+function firstComponent(pathname: string) {
+  return pathname.split('/')[1];
+}
+
 /**
  * Implements static file handling.
  * @param request the incoming file request.
@@ -208,6 +212,8 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
 
   // -------------------------------- start of experimental UI resources
   let replaceBasepath = false;
+  // List of page names that resolve to index.html
+  const indexPageNames = ['data', 'files', 'docs', 'sessions', 'terminal'];
   if (isExperimentalResource(pathname)) {
     logging.getLogger().debug('Serving experimental UI resource: ' + pathname);
     let rootRedirect = 'files';
@@ -220,14 +226,10 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
       response.setHeader('Location', path.join(appSettings.datalabBasePath, rootRedirect));
       response.end();
       return;
-    } else if (pathname.indexOf('/data') === 0 ||
-        pathname.indexOf('/files') === 0||
-        pathname.indexOf('/docs') === 0 ||
-        pathname.indexOf('/sessions') === 0 ||
-        pathname.indexOf('/terminal') === 0) {
+    } else if (indexPageNames.indexOf(firstComponent(pathname)) > -1) {
       pathname = '/index.html';
       replaceBasepath = true;
-    } else if (pathname === '/editor') {
+    } else if (firstComponent(pathname) === 'editor') {
       pathname = '/editor.html';
       replaceBasepath = true;
     } else if (pathname === '/index.css') {

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -105,7 +105,8 @@ function sendFile(filePath: string, response: http.ServerResponse,
         response.setHeader('Cache-Control', 'no-cache');
       }
       response.writeHead(200, { 'Content-Type': contentType });
-      response.end(content);
+      const contentWithBase = content.toString().replace(/\{base_url}/g, '/');
+      response.end(contentWithBase);
     }
   }, isDynamic);
 }
@@ -175,7 +176,7 @@ export function isExperimentalResource(pathname: string) {
   const experimentalUiEnabled = process.env.DATALAB_EXPERIMENTAL_UI;
   return experimentalUiEnabled === 'true' && (
       pathname.indexOf('/data') === 0 ||
-      pathname === '/files' ||
+      pathname.indexOf('/files') === 0 ||
       // /files/path?download=true is used to download files from Jupyter
       // TODO: use a different API to download files when we have a content service.
       pathname.indexOf('/sessions') === 0 ||
@@ -213,11 +214,11 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
       response.setHeader('Location', path.join(appSettings.datalabBasePath, rootRedirect));
       response.end();
       return;
-    } else if (pathname === '/data' ||
-        pathname === '/files' ||
-        pathname === '/docs' ||
-        pathname === '/sessions' ||
-        pathname === '/terminal') {
+    } else if (pathname.indexOf('/data') === 0 ||
+        pathname.indexOf('/files') === 0||
+        pathname.indexOf('/docs') === 0 ||
+        pathname.indexOf('/sessions') === 0 ||
+        pathname.indexOf('/terminal') === 0) {
       pathname = '/index.html';
     } else if (pathname === '/editor') {
       pathname = '/editor.html';
@@ -226,7 +227,7 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
       pathname = '/index.' + (userSettings.theme || 'light') + '.css';
     }
     pathname = 'experimental' + pathname;
-    console.log('sending experimental file: ' + pathname);
+    logging.getLogger().debug('sending experimental file: ' + pathname);
     sendDataLabFile(pathname, response);
     return;
   }

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -105,8 +105,9 @@ function sendFile(filePath: string, response: http.ServerResponse,
         response.setHeader('Cache-Control', 'no-cache');
       }
       response.writeHead(200, { 'Content-Type': contentType });
-      const contentWithBase = content.toString().replace(/\{base_url}/g, '/');
-      response.end(contentWithBase);
+      const contentStr = content.toString().replace(
+          /\{base_url}/g, appSettings.datalabBasePath);
+      response.end(contentStr);
     }
   }, isDynamic);
 }

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -198,6 +198,9 @@ export function isExperimentalResource(pathname: string) {
   );
 }
 
+/**
+ * Parses the given url path and returns the first component.
+ */
 function firstComponent(pathname: string) {
   return pathname.split('/')[1];
 }

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -106,11 +106,13 @@ function sendFile(filePath: string, response: http.ServerResponse,
         response.setHeader('Cache-Control', 'no-cache');
       }
       response.writeHead(200, { 'Content-Type': contentType });
-      let contentStr = content.toString();
       if (replaceBasepath) {
-        contentStr = contentStr.replace(/\{base_url}/g, appSettings.datalabBasePath);
+        const contentStr = content.toString().replace(
+            /\{base_url}/g, appSettings.datalabBasePath);
+        response.end(contentStr);
+      } else {
+        response.end(content);
       }
-      response.end(contentStr);
     }
   }, isDynamic);
 }


### PR DESCRIPTION
This PR changes the way the new UI handles file paths in navigation and in the notebook editor, by making the file path part of the page URL, which allows relative links to work resolve properly.