### PR TITLE
Move open-in-notebook button to new Data toolbar.

### DIFF
--- a/sources/web/datalab/polymer/components/data-browser/data-browser.html
+++ b/sources/web/datalab/polymer/components/data-browser/data-browser.html
@@ -29,7 +29,7 @@ the License.
     </style>
 
     <file-browser id="fileBrowser" file-manager-type='bigquery'
-        file-id="{{fileId}}" hide-toolbar></file-browser>
+        file-id="{{fileId}}" toolbar-mode="data"></file-browser>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.html
+++ b/sources/web/datalab/polymer/components/datalab-docs/datalab-docs.html
@@ -29,8 +29,7 @@ the License.
     </style>
 
     <file-browser id="fileBrowser" file-manager-type='github' n-leading-breadcrumbs-to-trim="2"
-        file-id="github/googledatalab/notebooks" hide-toolbar></file-browser>
-
+        file-id="github/googledatalab/notebooks" toolbar-mode="none"></file-browser>
   </template>
 </dom-module>
 

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -131,86 +131,100 @@ the License.
       }
     </style>
 
-    <div id="toolbar" hidden$={{_isToolbarHidden}}>
+    <div id="toolbar" hidden$="{{_isToolbarHidden}}">
 
-      <!--Default Add toolbar, contains Add buttons for notebook, file, and folder-->
-      <span id="addToolbar">
-        <paper-button class="toolbar-button" on-click="_createNewNotebook">
+      <div id="fileToolbar" hidden$="[[!_isToolbarMode('files')]]">
+
+        <!--Default Add toolbar, contains Add buttons for notebook, file, and folder-->
+        <span id="addToolbar">
+          <paper-button class="toolbar-button" on-click="_createNewNotebook">
+            <iron-icon icon="add-box"></iron-icon>
+            <span>Notebook</span>
+          </paper-button>
+          <paper-button class="toolbar-button" on-click="_createNewFile">
+            <iron-icon icon="add-box"></iron-icon>
+            <span>File</span>
+          </paper-button>
+          <paper-button class="toolbar-button" on-click="_createNewDirectory">
+            <iron-icon icon="add-box"></iron-icon>
+            <span>Folder</span>
+          </paper-button>
+        </span>
+
+        <!--Alternative Add toolbar, shows up when toolbar is too small-->
+        <span id="altAddToolbarContainer" class="dropdown-menu-container">
+          <paper-button id="altAddToolbarToggle" class="toolbar-button"
+                        on-click="_toggleAltAddToolbar">
+            <iron-icon icon="add-box"></iron-icon>
+            <span>New</span>
+            <iron-icon icon="hardware:keyboard-arrow-down"></iron-icon>
+          </paper-button>
+          <paper-dialog id="altAddToolbar" class="dropdown-menu" on-blur="_closeDropdown">
+          </paper-dialog>
+        </span>
+
+        <!--Default Update toolbar, contains buttons to modify files/folders-->
+        <span id="updateToolbar">
+          <paper-button class="toolbar-button" on-click="_altUpload">
+            <iron-icon icon="file-upload"></iron-icon>
+            <span>Upload</span>
+          </paper-button>
+          <!--This is hidden but its functionality is used by the alt upload button above-->
+          <input type="file" id="altFileUpload" multiple style="display: none"
+                 on-change="_upload">
+          <paper-button class="toolbar-button" on-click="_openSelectedInEditor"
+                        disabled$={{!selectedFile}}>
+            <iron-icon icon="editor:short-text"></iron-icon>
+            <span>Edit as Text</span>
+          </paper-button>
+          <paper-button class="toolbar-button" on-click="_copySelectedItem"
+                        disabled$={{!selectedFile}}>
+            <iron-icon icon="content-copy"></iron-icon>
+            <span>Copy</span>
+          </paper-button>
+          <paper-button class="toolbar-button" on-click="_moveSelectedItem"
+                        disabled$={{!selectedFile}}>
+            <iron-icon icon="redo"></iron-icon>
+            <span>Move</span>
+          </paper-button>
+          <paper-button class="toolbar-button" on-click="_renameSelectedItem"
+                        disabled$={{!selectedFile}}>
+            <iron-icon icon="editor:border-color"></iron-icon>
+            <span>Rename</span>
+          </paper-button>
+          <!--TODO: Delete operation supports deleting multiple files, but we'll
+          only enable the button when one file is selected for now, until we get
+          the group moving/copying functionality too-->
+          <paper-button class="toolbar-button" on-click="_deleteSelectedItems"
+                        disabled$={{!selectedFile}}>
+            <iron-icon icon="delete"></iron-icon>
+            <span>Delete</span>
+          </paper-button>
+        </span>
+
+        <!--Alternative Update toolbar, shows up when toolbar is too small-->
+        <span id="altUpdateToolbarContainer" class="dropdown-menu-container">
+          <paper-button id="altUpdateToolbarToggle" class="toolbar-button"
+                        on-click="_toggleAltUpdateToolbar">
+            <iron-icon icon="more-horiz"></iron-icon>
+          </paper-button>
+          <paper-dialog id="altUpdateToolbar" class="dropdown-menu" on-blur="_closeDropdown">
+          </paper-dialog>
+        </span>
+
+      </div> <!-- fileToolbar -->
+
+      <div id="dataToolbar" hidden$=[[!_isToolbarMode('data')]]>
+
+        <paper-button class="toolbar-button" on-click="_openInNotebook"
+                        disabled$={{!_canOpenInNotebook}}>
           <iron-icon icon="add-box"></iron-icon>
-          <span>Notebook</span>
+          <span>Open in Notebook</span>
         </paper-button>
-        <paper-button class="toolbar-button" on-click="_createNewFile">
-          <iron-icon icon="add-box"></iron-icon>
-          <span>File</span>
-        </paper-button>
-        <paper-button class="toolbar-button" on-click="_createNewDirectory">
-          <iron-icon icon="add-box"></iron-icon>
-          <span>Folder</span>
-        </paper-button>
-      </span>
 
-      <!--Alternative Add toolbar, shows up when toolbar is too small-->
-      <span id="altAddToolbarContainer" class="dropdown-menu-container">
-        <paper-button id="altAddToolbarToggle" class="toolbar-button"
-                      on-click="_toggleAltAddToolbar">
-          <iron-icon icon="add-box"></iron-icon>
-          <span>New</span>
-          <iron-icon icon="hardware:keyboard-arrow-down"></iron-icon>
-        </paper-button>
-        <paper-dialog id="altAddToolbar" class="dropdown-menu" on-blur="_closeDropdown">
-        </paper-dialog>
-      </span>
+      </div> <!-- dataToolbar -->
 
-      <!--Default Update toolbar, contains buttons to modify files/folders-->
-      <span id="updateToolbar">
-        <paper-button class="toolbar-button" on-click="_altUpload">
-          <iron-icon icon="file-upload"></iron-icon>
-          <span>Upload</span>
-        </paper-button>
-        <!--This is hidden but its functionality is used by the alt upload button above-->
-        <input type="file" id="altFileUpload" multiple style="display: none"
-               on-change="_upload">
-      <paper-button class="toolbar-button" on-click="_openSelectedInEditor"
-                    disabled$={{!selectedFile}}>
-        <iron-icon icon="editor:short-text"></iron-icon>
-        <span>Edit as Text</span>
-      </paper-button>
-        <paper-button class="toolbar-button" on-click="_copySelectedItem"
-                      disabled$={{!selectedFile}}>
-          <iron-icon icon="content-copy"></iron-icon>
-          <span>Copy</span>
-        </paper-button>
-        <paper-button class="toolbar-button" on-click="_moveSelectedItem"
-                      disabled$={{!selectedFile}}>
-          <iron-icon icon="redo"></iron-icon>
-          <span>Move</span>
-        </paper-button>
-        <paper-button class="toolbar-button" on-click="_renameSelectedItem"
-                      disabled$={{!selectedFile}}>
-          <iron-icon icon="editor:border-color"></iron-icon>
-          <span>Rename</span>
-        </paper-button>
-        <!--TODO: Delete operation supports deleting multiple files, but we'll
-        only enable the button when one file is selected for now, until we get
-        the group moving/copying functionality too-->
-        <paper-button class="toolbar-button" on-click="_deleteSelectedItems"
-                      disabled$={{!selectedFile}}>
-          <iron-icon icon="delete"></iron-icon>
-          <span>Delete</span>
-        </paper-button>
-      </span>
-
-      <!--Alternative Update toolbar, shows up when toolbar is too small-->
-      <span id="altUpdateToolbarContainer" class="dropdown-menu-container">
-        <paper-button id="altUpdateToolbarToggle" class="toolbar-button"
-                      on-click="_toggleAltUpdateToolbar">
-          <iron-icon icon="more-horiz"></iron-icon>
-        </paper-button>
-        <paper-dialog id="altUpdateToolbar" class="dropdown-menu" on-blur="_closeDropdown">
-        </paper-dialog>
-      </span>
-
-    </div>
+    </div> <!-- toolbar -->
 
     <div id="file-picker">
       <!--Navigation bar with back/forward buttons, refresh, and breadcrumbs-->

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -63,6 +63,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
   /**
    * Toolbar display mode.
+   * Possible values: 'none', 'data', 'files'.
    */
   public toolbarMode: string;
 
@@ -522,7 +523,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
   _handleSelectionChanged() {
     const selectedIndices = (this.$.files as ItemListElement).selectedIndices;
     const newSelectedFile = (selectedIndices.length === 1) ?
-      this._fileList[selectedIndices[0]] : null;
+        this._fileList[selectedIndices[0]] : null;
     if (newSelectedFile !== this.selectedFile) {
       this._canOpenInNotebook = false;
       this.selectedFile = newSelectedFile;
@@ -535,7 +536,6 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * Called when the inline details are done loading for an item in our list.
    */
   _handleInlineDetailsLoaded(e: CustomEvent) {
-    Utils.log.verbose('Got inline-details-loaded event:', e);
     const eventFields = e.detail as any;
     const file = eventFields.file as DatalabFile;
     if (file === this.selectedFile) {

--- a/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.html
+++ b/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.html
@@ -29,7 +29,8 @@ the License.
     </style>
     <div id="container" hidden$="{{!file}}">
       <iron-pages id="inline-details" selected="{{details}}" attr-for-selected="name">
-        <table-inline-details class="inline-details" name="table" file="{{file}}" active="{{active}}"></table-inline-details>
+        <table-inline-details id="table-inline-details" class="inline-details"
+            name="table" file="{{file}}" active="{{active}}"></table-inline-details>
       </iron-pages>
     </div>
   </template>

--- a/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.ts
+++ b/sources/web/datalab/polymer/components/inline-details-pane/inline-details-pane.ts
@@ -72,6 +72,16 @@ class InlineDetailsPaneElement extends Polymer.Element {
       Polymer.importHref(pageUrl, undefined, undefined, true);
     }
   }
+
+  show() {
+    if (this.details) {
+      const elementId = this.details + '-inline-details';
+      const element = this.$[elementId];
+      if (element && element.show) {
+        element.show();
+      }
+    }
+  }
 }
 
 customElements.define(InlineDetailsPaneElement.is, InlineDetailsPaneElement);

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -74,6 +74,7 @@ class ItemListRow {
   _updateInlineDetails(
       inlineDetailsMode: InlineDetailsDisplayMode,
       multiSelect: boolean, rowDetailsElement: HTMLElement) {
+    const oldShowInlineDetails = this.showInlineDetails;
     if (!this.canShowDetails) {
       // If we don't know how to dislay details element, then we never do
       this.showInlineDetails = false;
@@ -91,8 +92,15 @@ class ItemListRow {
       // Assume SINGLE_SELECT, but we know multiple items are selected
       this.showInlineDetails = false;
     }
-    if (this.showInlineDetails && !this._detailsElement) {
-      this._addDetailsElement(rowDetailsElement);
+    if (this.showInlineDetails) {
+      if (!this._detailsElement) {
+        this._addDetailsElement(rowDetailsElement);
+      } else if (!oldShowInlineDetails) {
+        const detailsElementAsAny = this._detailsElement as any;
+        if (detailsElementAsAny.show) {
+          detailsElementAsAny.show();
+        }
+      }
     }
   }
 

--- a/sources/web/datalab/polymer/components/preview-pane/preview-pane.html
+++ b/sources/web/datalab/polymer/components/preview-pane/preview-pane.html
@@ -35,7 +35,7 @@ the License.
     <div id="container">
       <iron-pages id="preview" selected="{{preview}}" attr-for-selected="name" hidden$="{{!file}}">
         <notebook-preview class="preview" name="notebook" file="{{file}}" active="{{active}}"></notebook-preview>
-        <table-preview class="preview" name="table" file="{{file}}" active="{{active}}"></table-preview>
+        <table-preview id="tablePreview" class="preview" name="table" file="{{file}}" active="{{active}}"></table-preview>
         <text-preview class="preview" name="text" file="{{file}}" active="{{active}}"></text-preview>
       </iron-pages>
       <div class="placeholder" hidden$="{{file}}">

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.html
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.html
@@ -62,11 +62,6 @@ the License.
       }
     </style>
     <div id="container" hidden$={{!_table}}>
-      <br>
-      <paper-button id="openInNotebookButton" raised on-click="_openInNotebook">
-        Open in Notebook
-      </paper-button>
-      <br>
       <h3>Table Details: <span id="tableId">{{_table.tableReference.tableId}}</span></h3>
       <span class="strong">Project: </span>
       <span id="projectId">{{_table.tableReference.projectId}}</span>

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.ts
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.ts
@@ -175,35 +175,6 @@ class TablePreviewElement extends Polymer.Element {
   _formatMode(mode: string) {
     return mode || this.DEFAULT_MODE;
   }
-
-  /**
-   * Opens the current table in the table schema template notebook.
-   */
-  async _openInNotebook() {
-
-    if (this._table) {
-      const dict = {
-        BIGQUERY_DATASET_ID: this._table.tableReference.datasetId,
-        BIGQUERY_FULL_ID: this._table.id.replace(':', '.'),
-        BIGQUERY_PROJECT_ID: this._table.tableReference.projectId,
-        BIGQUERY_TABLE_DESCRIPTION: this._table.description,
-        BIGQUERY_TABLE_ID: this._table.tableReference.tableId,
-      };
-      const template = new BigQueryTableOverviewTemplate(dict, this);
-
-      try {
-        const notebook = await TemplateManager.newNotebookFromTemplate(template);
-
-        if (notebook) {
-          FileManagerFactory.getInstanceForType(notebook.id.source).getNotebookUrl(notebook.id)
-            .then((url) => window.open(url, '_blank'));
-        }
-      } catch (e) {
-        Utils.showErrorDialog('Error', e.message);
-      }
-    }
-  }
-
 }
 
 customElements.define(TablePreviewElement.is, TablePreviewElement);


### PR DESCRIPTION
The button in the toolbar is only enabled when there is exactly one selected item displayed, and it is a BigQuery table.

Before:
![data-bar-before](https://user-images.githubusercontent.com/116825/31301482-113b0b9c-aaaf-11e7-8ad9-1d2d1fb427be.png)

After:
![data-bar-after](https://user-images.githubusercontent.com/116825/31301486-17c86194-aaaf-11e7-91ce-bdec207d28e3.png)
