### PR TITLE
Move clean-up to the bottom of base/Dockerfile

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -192,18 +192,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         tcp-port-used@0.1.2 \
         node-cache@3.2.0 && \
     cd / && \
-    /tools/node/bin/npm install -g forever && \
-
-# Clean up
-    apt-get purge -y build-essential bzip2 cpp pkg-config libfreetype6-dev && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/lib/dpkg/info/* && \
-    rm -rf /tmp/* && \
-    rm -rf /root/.cache/* && \
-    rm -rf /usr/share/locale/* && \
-    rm -rf /usr/share/i18n/locales/* && \
-    cd /
+    /tools/node/bin/npm install -g forever
 
 
 ENV LANG en_US.UTF-8
@@ -247,3 +236,15 @@ RUN cd /datalab/lib/pydatalab && \
     ln -s /usr/local/lib/python2.7/dist-packages/notebook/static/custom/custom.css /datalab/nbconvert/custom.css && \
     cd /
 
+
+# Clean up
+RUN cd / && \
+    apt-get purge -y build-essential bzip2 cpp pkg-config libfreetype6-dev && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/lib/dpkg/info/* && \
+    rm -rf /tmp/* && \
+    rm -rf /root/.cache/* && \
+    rm -rf /usr/share/locale/* && \
+    rm -rf /usr/share/i18n/locales/* && \
+    cd /


### PR DESCRIPTION
Without this change ./build.sh errors out late in the game with the error below, presumably because a new transitive dependency requires compilation but the clean-up stanza has already removed gcc.

```
  Running setup.py install for setproctitle: started
    Running setup.py install for setproctitle: finished with status 'error'
    Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-E4jhlY/setproctitle/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-dXyR7P-record/install-record.txt --single-version-externally-managed --compile:
    running install
    running build
    running build_ext
    building 'setproctitle' extension
    creating build
    creating build/temp.linux-x86_64-2.7
    creating build/temp.linux-x86_64-2.7/src
    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security -fPIC -DHAVE_SYS_PRCTL_H=1 -DSPT_VERSION=1.1.10 -I/usr/include/python2.7 -c src/setproctitle.c -o build/temp.linux-x86_64-2.7/src/setproctitle.o
    unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
    
    ----------------------------------------
Command "/usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-E4jhlY/setproctitle/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-dXyR7P-record/install-record.txt --single-version-externally-managed --compile" failed with error code 1 in /tmp/pip-build-E4jhlY/setproctitle/
The command '/bin/sh -c cd /datalab/lib/pydatalab &&     pip install --upgrade-strategy only-if-needed --no-cache-dir . &&     pip install --upgrade-strategy only-if-needed /datalab/lib/pydatalab/solutionbox/image_classification/. &&     pip install --upgrade-strategy only-if-needed /datalab/lib/pydatalab/solutionbox/structured_data/. &&     pip3 install --upgrade-strategy only-if-needed --no-cache-dir . &&     pip3 install --upgrade-strategy only-if-needed /datalab/lib/pydatalab/solutionbox/image_classification/. &&     pip3 install --upgrade-strategy only-if-needed /datalab/lib/pydatalab/solutionbox/structured_data/. &&     jupyter nbextension install --py datalab.notebook &&     jupyter nbextension install --py google.datalab.notebook &&     jupyter nbextension enable --py widgetsnbextension &&     rm datalab/notebook/static/*.js google/datalab/notebook/static/*.js &&     mkdir -p /datalab/nbconvert &&     cp -R /usr/local/share/jupyter/nbextensions/gcpdatalab/* /datalab/nbconvert &&     ln -s /usr/local/lib/python2.7/dist-packages/notebook/static/custom/custom.css /datalab/nbconvert/custom.css &&     cd /' returned a non-zero code: 1
```