### PR TITLE
Revert "Move clean-up to the bottom of base/Dockerfile"

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -192,7 +192,18 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         tcp-port-used@0.1.2 \
         node-cache@3.2.0 && \
     cd / && \
-    /tools/node/bin/npm install -g forever
+    /tools/node/bin/npm install -g forever && \
+
+# Clean up
+    apt-get purge -y build-essential bzip2 cpp pkg-config libfreetype6-dev && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/lib/dpkg/info/* && \
+    rm -rf /tmp/* && \
+    rm -rf /root/.cache/* && \
+    rm -rf /usr/share/locale/* && \
+    rm -rf /usr/share/i18n/locales/* && \
+    cd /
 
 
 ENV LANG en_US.UTF-8
@@ -236,15 +247,3 @@ RUN cd /datalab/lib/pydatalab && \
     ln -s /usr/local/lib/python2.7/dist-packages/notebook/static/custom/custom.css /datalab/nbconvert/custom.css && \
     cd /
 
-
-# Clean up
-RUN cd / && \
-    apt-get purge -y build-essential bzip2 cpp pkg-config libfreetype6-dev && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/lib/dpkg/info/* && \
-    rm -rf /tmp/* && \
-    rm -rf /root/.cache/* && \
-    rm -rf /usr/share/locale/* && \
-    rm -rf /usr/share/i18n/locales/* && \
-    cd /

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -195,7 +195,6 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     /tools/node/bin/npm install -g forever && \
 
 # Clean up
-    apt-get purge -y build-essential bzip2 cpp pkg-config libfreetype6-dev && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /var/lib/dpkg/info/* && \


### PR DESCRIPTION
The cleanup step needs to be performed in the same Docker `RUN` command in order to actually remove the files from the Docker image (otherwise, they just wind up hidden in a subsequent layer).

We'll move the cleanup code back to where it was, and then take out the offending line which was causing the build issues.