### PR TITLE
Use locally installed tsc/tslint to avoid build environment differences

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -46,11 +46,6 @@ function install_typescript() {
   npm install -g typescript
 }
 
-function install_tslint() {
-  echo "Installing tslint"
-  npm install -g tslint
-}
-
 function install_git() {
   echo "Updating apt repository"
   apt-get update -y -qq

--- a/sources/web/datalab/package.json
+++ b/sources/web/datalab/package.json
@@ -18,8 +18,5 @@
   },
   "scripts": {
     "start": "node app.js"
-  },
-  "devDependencies": {
-    "tslint": "^5.5.0"
   }
 }

--- a/sources/web/datalab/polymer/package.json
+++ b/sources/web/datalab/polymer/package.json
@@ -16,6 +16,8 @@
     "@types/codemirror": "0.0.42",
     "@types/gapi.auth2": "0.0.42",
     "@types/mocha": "^2.2.41",
-    "@types/socket.io-client": "^1.4.30"
+    "@types/socket.io-client": "^1.4.30",
+    "tslint": "^5.7.0",
+    "typescript": "^2.5.3"
   }
 }


### PR DESCRIPTION
This reduces the number of global dependencies that build environments need to have, also unifying the build errors contributors will get.
We can't yet take out `typescript` since it's needed for the node.js app, but we should at some point.