### PR TITLE
Allow setting the CLOUDSDK_CONFIG variable

### DIFF
--- a/containers/datalab/content/setup-env.sh
+++ b/containers/datalab/content/setup-env.sh
@@ -21,7 +21,7 @@ export DATALAB_ENV="local"
 
 # Ensure that gcloud has been told to use a config directory under the
 # mounted volume (so that the results of 'gcloud auth login' are persisted).
-export CLOUDSDK_CONFIG=/content/datalab/.config
+export CLOUDSDK_CONFIG=${CLOUDSDK_CONFIG:-"/content/datalab/.config"}
 
 # Lookup the project and zone, which may be in the mapped gcloud config.
 export PROJECT_ID=${PROJECT_ID:-`gcloud config list -q --format 'value(core.project)' 2> /dev/null`}


### PR DESCRIPTION
This change modifies the container startup process to reuse the "CLOUDSDK_CONFIG" environment variable if it has already been set.

This allows the user launching the container to change that value to something else, and we will then honor that specified value.