### PR TITLE
Set default Data tab start location to bigquery-public-data project.

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -239,7 +239,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       this._pathHistoryIndex = 0 + this.nLeadingBreadcrumbsToTrim;
     });
 
-    let fileId = this._getFileIdFromProperty();
+    const fileId = this._getFileIdFromProperty();
     if (fileId) {
       this.fileManagerType = FileManagerFactory.fileManagerTypetoString(fileId.source);
     }
@@ -258,12 +258,6 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       } else {
         this.fileManagerType = 'drive';
       }
-    }
-
-    if (!fileId && this.fileManagerType === 'bigquery') {
-      // Set the default starting location for bigquery browsing to be
-      // the bigquery-public-data project.
-      fileId = DatalabFileId.fromString('bigquery/bigquery-public-data');
     }
 
     this._fileManager = FileManagerFactory.getInstanceForType(
@@ -1171,7 +1165,13 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       if (startuppath) {
         this._pathHistory = this._fileManager.pathToPathHistory(startuppath);
       }
+    } else if (this.fileManagerType === 'bigquery') {
+      // Set the default starting location for bigquery browsing to be
+      // the bigquery-public-data project.
+      this._pathHistory =
+          this._fileManager.pathToPathHistory('bigquery-public-data');
     }
+
     // Always add the root file to the beginning.
     const root = await this._fileManager.getRootFile();
     this._pathHistory.unshift(root);

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -239,7 +239,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       this._pathHistoryIndex = 0 + this.nLeadingBreadcrumbsToTrim;
     });
 
-    const fileId = this._getFileIdFromProperty();
+    let fileId = this._getFileIdFromProperty();
     if (fileId) {
       this.fileManagerType = FileManagerFactory.fileManagerTypetoString(fileId.source);
     }
@@ -258,6 +258,12 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       } else {
         this.fileManagerType = 'drive';
       }
+    }
+
+    if (!fileId && this.fileManagerType === 'bigquery') {
+      // Set the default starting location for bigquery browsing to be
+      // the bigquery-public-data project.
+      fileId = DatalabFileId.fromString('bigquery/bigquery-public-data');
     }
 
     this._fileManager = FileManagerFactory.getInstanceForType(


### PR DESCRIPTION
This PR changes the default starting location of the Data tab to be the bigquery-public-data project. This is what it will display when the user first clicks the Data tab (or enters the /data URL).
![start-bigquery-public-data](https://user-images.githubusercontent.com/116825/31404340-a01d44b6-adb0-11e7-89ba-2a0b6ce13b9e.png)
