### PR TITLE
Parallel file fetch requests, unblock file browser

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.ts
+++ b/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.ts
@@ -30,7 +30,7 @@ class DatalabEditorElement extends Polymer.Element {
   private _busy: boolean;
   private _editor: CodeMirror.Editor;
   private _file: DatalabFile | null;
-  private _fileManager: FileManager;
+  private _fileManager: BaseFileManager;
   private _theme: string;
 
   static get is() { return 'datalab-editor'; }

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -487,10 +487,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    * If this element is in "small" mode, double clicking a file does not have
    * an effect, a directory will still navigate.
    */
-  async _handleDoubleClicked(e: ItemClickEvent) {
-    if (this._fetching) {
-      return;
-    }
+  _handleDoubleClicked(e: ItemClickEvent) {
     const clickedItem = this._fileList[e.detail.index];
     if (this.small && clickedItem.type !== DatalabFileType.DIRECTORY) {
       return;
@@ -508,10 +505,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
         this._pathHistoryIndex = this._pathHistory.length - 1;
       }
     } else if (clickedItem.type === DatalabFileType.NOTEBOOK) {
-      const url = await this._fileManager.getNotebookUrl(clickedItem.id);
+      const url = this._fileManager.getNotebookUrl(clickedItem.id);
       window.open(url, '_blank');
     } else {
-      const url = await this._fileManager.getEditorUrl(clickedItem.id);
+      const url = this._fileManager.getEditorUrl(clickedItem.id);
       window.open(url, '_blank');
     }
   }

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -89,7 +89,6 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
   private _previewPaneCollapseThreshold = 600;
   private _fetching: boolean;
   private _fileList: DatalabFile[];
-  private _fileListFetchPromise: Promise<any>;
   private _fileListRefreshInterval = 60 * 1000;
   private _fileListRefreshIntervalHandle = 0;
   private _fileManager: BaseFileManager;
@@ -396,52 +395,67 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
   /**
    * Calls the FileManager to get the list of files at the current path, and
    * updates the _fileList property.
+   * This method can be called multiple times, and it will ignore the fetch
+   * result if the currentFild object has changed after the request was made.
+   * This can happen because we set up fetch from several sources:
+   * - Initialization in the ready() event handler.
+   * - Various file operations modifying the tree (new file, delete... etc)
+   * - Refresh mechanism called by the setInterval().
+   * - User clicking refresh button.
+   * - Files page gaining focus.
    * @param throwOnError whether to throw an exception if the refresh fails. This
    *                     is false by default because throwing is currently not used.
    */
   _fetchFileList(throwOnError = false): Promise<any> {
-    // Don't overlap fetch requests. This can happen because we set up fetch from several sources:
-    // - Initialization in the ready() event handler.
-    // - Refresh mechanism called by the setInterval().
-    // - User clicking refresh button.
-    // - Files page gaining focus.
-    if (this._fetching) {
-      return this._fileListFetchPromise;
-    }
     if (!this.currentFile) {
-      throw new Error('No current file to retrieve');
+      // No current file to retrieve
+      return Promise.resolve();
     }
+    const fetchFileId = this.currentFile.id;
 
     this._fetching = true;
 
-    this._fileListFetchPromise = this._fileManager.list(this.currentFile.id)
+    return this._fileManager.list(fetchFileId)
       .then((newList) => {
-        // Only refresh the UI list if there are any changes. This helps keep
-        // the item list's selections intact most of the time.
-        if (JSON.stringify(this._fileList) !== JSON.stringify(newList)) {
-          this._fileList = newList;
-          this._drawFileList();
+        // Check if the current file has changed since this fetch request was made.
+        if (fetchFileId === this.currentFile.id) {
+          // Only refresh the UI list if there are any changes. This helps keep
+          // the item list's selections intact most of the time.
+          if (JSON.stringify(this._fileList) !== JSON.stringify(newList)) {
+            this._fileList = newList;
+            this._drawFileList();
+          }
         }
       })
       // Now load the sessions and update the running status of each file
       // whose id is in the session list.
       // We do not need to load sessions when in small mode.
-      .then(() => this.small ? Promise.resolve([]) : SessionManager.listSessionPaths())
+      // Also skip this if current file id has changed since this request was made.
+      .then(() => {
+        if (fetchFileId === this.currentFile.id || this.small) {
+          return Promise.resolve([]);
+        } else {
+          return SessionManager.listSessionPaths();
+        }
+      })
       .catch((e) => {
         // Do not block loading files if sessions don't load for some reason.
         Utils.log.error('Could not load sessions: ' + e.message);
         return [] as string[];
       })
       .then((sessions) => {
-        const listElement = this.$.files as ItemListElement;
-        this._fileList.forEach((file, i) => {
-          // The v1 notebook editor creates sessions with just the file path,
-          // while v2 editor uses the full id string.
-          if (sessions.indexOf(file.id.path) > -1 ||
-              sessions.indexOf(file.id.toString()) > -1) {
-            listElement.set('rows.' + i + '.columns.1', Utils.getFileStatusString(DatalabFileStatus.RUNNING));
-          }
-        });
+        // Check if the current file has changed since this fetch request was made.
+        if (fetchFileId === this.currentFile.id) {
+          const listElement = this.$.files as ItemListElement;
+          this._fileList.forEach((file, i) => {
+            // The v1 notebook editor creates sessions with just the file path,
+            // while v2 editor uses the full id string.
+            if (sessions.indexOf(file.id.path) > -1 ||
+                sessions.indexOf(file.id.toString()) > -1) {
+              listElement.set('rows.' + i + '.columns.1', Utils.getFileStatusString(DatalabFileStatus.RUNNING));
+            }
+          });
+        }
       })
       .catch((e: Error) => {
         const fileSpec = this.currentFile.id.toString();
@@ -453,8 +467,6 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
         }
       })
       .then(() => this._fetching = false);
-
-    return this._fileListFetchPromise;
   }
 
   /**

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -417,7 +417,8 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
     return this._fileManager.list(fetchFileId)
       .then((newList) => {
-        // Check if the current file has changed since this fetch request was made.
+        // Make sure the current file hasn't changed since this fetch request was made.
+        // Skip updating the list if it has.
         if (fetchFileId === this.currentFile.id) {
           // Only refresh the UI list if there are any changes. This helps keep
           // the item list's selections intact most of the time.
@@ -438,13 +439,9 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
           return SessionManager.listSessionPaths();
         }
       })
-      .catch((e) => {
-        // Do not block loading files if sessions don't load for some reason.
-        Utils.log.error('Could not load sessions: ' + e.message);
-        return [] as string[];
-      })
       .then((sessions) => {
-        // Check if the current file has changed since this fetch request was made.
+        // Make sure the current file hasn't changed since this fetch request was made.
+        // Skip updating the list if it has.
         if (fetchFileId === this.currentFile.id) {
           const listElement = this.$.files as ItemListElement;
           this._fileList.forEach((file, i) => {
@@ -466,6 +463,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
           Utils.log.error(msgPrefix, e);
         }
       })
+      // TODO: This is not very accurate if multiple fetch requests are running
+      // in parallel. The first request will set this to false even though the
+      // others might still be running. We should look into adding some sort of
+      // operation queue to handle this.
       .then(() => this._fetching = false);
   }
 

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -92,7 +92,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
   private _fileListFetchPromise: Promise<any>;
   private _fileListRefreshInterval = 60 * 1000;
   private _fileListRefreshIntervalHandle = 0;
-  private _fileManager: FileManager;
+  private _fileManager: BaseFileManager;
   private _fileManagerDisplayName: string;
   private _fileManagerDisplayIcon: string;
   private _hasMultipleFileSources: boolean;
@@ -794,8 +794,8 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       const i = selectedIndices[0];
       const selectedObject = this._fileList[i];
 
-      this._fileManager.getEditorUrl(selectedObject.id)
-        .then((url) => window.open(url, '_blank'));
+      const url = this._fileManager.getEditorUrl(selectedObject.id);
+      window.open(url, '_blank');
     }
   }
 

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
@@ -24,7 +24,7 @@ class TableInlineDetailsElement extends Polymer.Element {
    */
   public file: BigQueryFile;
 
-  private _fileManager: FileManager;
+  private _fileManager: BaseFileManager;
   private _rows: gapi.client.bigquery.TabledataRow[];
   private _table: gapi.client.bigquery.Table | null;
   private _busy = false;
@@ -129,8 +129,9 @@ class TableInlineDetailsElement extends Polymer.Element {
         const notebook = await TemplateManager.newNotebookFromTemplate(template);
 
         if (notebook) {
-          FileManagerFactory.getInstanceForType(notebook.id.source).getNotebookUrl(notebook.id)
-            .then((url) => window.open(url, '_blank'));
+          const url = FileManagerFactory.getInstanceForType(notebook.id.source)
+              .getNotebookUrl(notebook.id);
+          window.open(url, '_blank');
         }
       } catch (e) {
         Utils.showErrorDialog('Error', e.message);

--- a/sources/web/datalab/polymer/components/table-preview/table-preview.ts
+++ b/sources/web/datalab/polymer/components/table-preview/table-preview.ts
@@ -34,7 +34,7 @@ class TablePreviewElement extends Polymer.Element {
    */
   public tableId: string;
 
-  private _fileManager: FileManager;
+  private _fileManager: BaseFileManager;
   private _table: gapi.client.bigquery.Table | null;
   private _busy = false;
   private readonly DEFAULT_MODE = 'NULLABLE';

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -39,7 +39,7 @@ class BigQueryFile extends DatalabFile {
  * A file manager that wraps the BigQuery API so that we can browse BQ projects,
  * datasets, and tables like a filesystem.
  */
-class BigQueryFileManager implements FileManager {
+class BigQueryFileManager extends BaseFileManager {
 
   public get(fileId: DatalabFileId): Promise<DatalabFile> {
     if (fileId.path === '/') {
@@ -98,11 +98,11 @@ class BigQueryFileManager implements FileManager {
     throw new UnsupportedMethod('copy', this);
   }
 
-  public getNotebookUrl(_fileId: DatalabFileId): Promise<string> {
+  public getNotebookUrl(_fileId: DatalabFileId): string {
     throw new UnsupportedMethod('getNotebookUrl', this);
   }
 
-  public getEditorUrl(_fileId: DatalabFileId): Promise<string> {
+  public getEditorUrl(_fileId: DatalabFileId): string {
     throw new UnsupportedMethod('getEditorUrl', this);
   }
 

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -23,7 +23,7 @@ class DriveFile extends DatalabFile {
 /**
  * An Google Drive specific file manager.
  */
-class DriveFileManager implements FileManager {
+class DriveFileManager extends BaseFileManager {
 
   private static readonly _directoryMimeType = 'application/vnd.google-apps.folder';
   private static readonly _notebookMimeType = 'application/json';
@@ -107,15 +107,6 @@ class DriveFileManager implements FileManager {
   public copy(file: DatalabFileId, destinationDirectoryId: DatalabFileId): Promise<DatalabFile> {
     return GapiManager.drive.copy(file.path, destinationDirectoryId.path)
       .then((upstreamFile) => this._fromUpstreamFile(upstreamFile));
-  }
-
-  public async getEditorUrl(fileId: DatalabFileId) {
-    return Utils.getHostRoot() + Utils.constants.editorUrlComponent + fileId.toString();
-  }
-
-  public async getNotebookUrl(fileId: DatalabFileId): Promise<string> {
-    return location.protocol + '//' + location.host +
-        Utils.constants.notebookUrlComponent + fileId.toString();
   }
 
   public pathToPathHistory(path: string): DatalabFile[] {

--- a/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
@@ -23,7 +23,7 @@ enum FileManagerType {
 }
 
 interface FileManagerConfig {
-  typeClass: new () => FileManager;
+  typeClass: typeof BaseFileManager;
   displayIcon: string;
   displayName: string;
   name: string;
@@ -82,7 +82,7 @@ class FileManagerFactory {
     ]
   ]);
 
-  private static _fileManagers: { [fileManagerType: string]: FileManager } = {};
+  private static _fileManagers: { [fileManagerType: string]: BaseFileManager } = {};
 
   /** Get the default FileManager. */
   public static getInstance() {
@@ -110,7 +110,7 @@ class FileManagerFactory {
     const config = this.getFileManagerConfig(fileManagerType);
     if (!FileManagerFactory._fileManagers[config.name]) {
 
-      FileManagerFactory._fileManagers[fileManagerType] = new config.typeClass();
+      FileManagerFactory._fileManagers[fileManagerType] = new (config.typeClass as any)();
     }
 
     return FileManagerFactory._fileManagers[fileManagerType];

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -134,7 +134,7 @@ abstract class DatalabFile {
   }
 }
 
-interface FileManager {
+abstract class BaseFileManager {
   // TODO: Consider supporting getting both the file and content objects with
   // one call.
 
@@ -142,7 +142,7 @@ interface FileManager {
    * Returns a DatalabFile object representing the file or directory requested
    * @param fileId id of the requested file.
    */
-  get(fileId: DatalabFileId): Promise<DatalabFile>;
+  abstract get(fileId: DatalabFileId): Promise<DatalabFile>;
 
   /**
    * Returns the string content of the file with the specified id.
@@ -151,12 +151,12 @@ interface FileManager {
    *               useful for downloading notebooks, which are by default read
    *               as JSON, which doesn't preserve formatting.
    */
-  getStringContent(fileId: DatalabFileId, asText?: boolean): Promise<string>;
+  abstract getStringContent(fileId: DatalabFileId, asText?: boolean): Promise<string>;
 
   /**
    * Returns a DatalabFile object for the root directory.
    */
-  getRootFile(): Promise<DatalabFile>;
+  abstract getRootFile(): Promise<DatalabFile>;
 
   /**
    * Saves the given string as a file's content.
@@ -164,13 +164,13 @@ interface FileManager {
    *             save to.
    * @param content string to be saved in the file
    */
-  saveText(file: DatalabFile, content: string): Promise<DatalabFile>;
+  abstract saveText(file: DatalabFile, content: string): Promise<DatalabFile>;
 
   /**
    * Returns a list of file objects that are children of the given container file id.
    * @param containerId file id whose children to list.
    */
-  list(containerId: DatalabFileId): Promise<DatalabFile[]>;
+  abstract list(containerId: DatalabFileId): Promise<DatalabFile[]>;
 
   /**
    * Creates a new Datalab item
@@ -178,7 +178,7 @@ interface FileManager {
    * @param containerId id for the container
    * @param name name for the created item. Default is 'New item'.
    */
-  create(fileType: DatalabFileType, containerId?: DatalabFileId, name?: string): Promise<DatalabFile>;
+  abstract create(fileType: DatalabFileType, containerId?: DatalabFileId, name?: string): Promise<DatalabFile>;
 
   /**
    * Renames an item
@@ -186,13 +186,13 @@ interface FileManager {
    * @param newName new name for the item.
    * @param newContainerId id of the destination path of the renamed item
    */
-  rename(oldFileId: DatalabFileId, newName: string, newContainerId?: DatalabFileId): Promise<DatalabFile>;
+  abstract rename(oldFileId: DatalabFileId, newName: string, newContainerId?: DatalabFileId): Promise<DatalabFile>;
 
   /**
    * Deletes an item
    * @param fileId id for the item to delete
    */
-  delete(fileId: DatalabFileId): Promise<boolean>;
+  abstract delete(fileId: DatalabFileId): Promise<boolean>;
 
   /*
    * Copies an item from source to destination. If an item with the same name
@@ -200,22 +200,27 @@ interface FileManager {
    * @param fileId item to copy
    * @param destinationDirectoryId id of the directory to copy the item into
    */
-  copy(file: DatalabFileId, destinationDirectoryId: DatalabFileId): Promise<DatalabFile>;
+  abstract copy(file: DatalabFileId, destinationDirectoryId: DatalabFileId): Promise<DatalabFile>;
 
   /**
    * Returns the url to open the given file in the notebook editor.
    * @param fileId id for the file to open in the notebook editor.
    */
-  getNotebookUrl(file: DatalabFileId): Promise<string>;
+  getNotebookUrl(fileId: DatalabFileId): string {
+    return location.protocol + '//' + location.host +
+        Utils.constants.notebookUrlComponent + fileId.toString();
+  }
 
   /**
    * Returns the url to open the given file in the text editor.
    * @param fileId id for the file to open in the text editor.
    */
-  getEditorUrl(file: DatalabFileId): Promise<string>;
+  getEditorUrl(fileId: DatalabFileId): string {
+    return Utils.getHostRoot() + Utils.constants.editorUrlComponent + fileId.toString();
+  }
 
   /**
    * Creates a path history from a path string.
    */
-  pathToPathHistory(path: string): DatalabFile[];
+  abstract pathToPathHistory(path: string): DatalabFile[];
 }

--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
@@ -58,7 +58,7 @@ interface GhFileResponse {
  * A file manager that wraps the Github API so that we can browse github
  * repositories.
  */
-class GithubFileManager implements FileManager {
+class GithubFileManager extends BaseFileManager {
 
   public get(fileId: DatalabFileId): Promise<DatalabFile> {
     if (fileId.path === '' || fileId.path === '/') {
@@ -132,15 +132,6 @@ class GithubFileManager implements FileManager {
 
   public copy(_fileId: DatalabFileId, _destinationDirectoryId: DatalabFileId): Promise<DatalabFile> {
     throw new UnsupportedMethod('copy', this);
-  }
-
-  public async getEditorUrl(fileId: DatalabFileId) {
-    return Utils.getHostRoot() + Utils.constants.editorUrlComponent + fileId.toString();
-  }
-
-  public async getNotebookUrl(fileId: DatalabFileId): Promise<string> {
-    return location.protocol + '//' + location.host +
-        Utils.constants.notebookUrlComponent + fileId.toString();
   }
 
   public pathToPathHistory(path: string): DatalabFile[] {

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
@@ -44,7 +44,7 @@ class JupyterFile extends DatalabFile {
 /**
  * An Jupyter-specific file manager.
  */
-class JupyterFileManager implements FileManager {
+class JupyterFileManager extends BaseFileManager {
 
   /**
    * Converts the given JupyterFile into the type understood by the Jupyter
@@ -273,16 +273,10 @@ class JupyterFileManager implements FileManager {
     return ApiManager.sendRequestAsync(path, xhrOptions);
   }
 
-  public async getNotebookUrl(fileId: DatalabFileId) {
+  public getNotebookUrl(fileId: DatalabFileId) {
     // TODO: We will need to get the base path when loading files
     // from a VM running Datalab with Jupyter.
     return location.protocol + '//' + location.host + '/notebooks/' + fileId.path;
-  }
-
-  public async getEditorUrl(fileId: DatalabFileId) {
-    // TODO: We will need to get the base path when loading notebooks
-    // from a VM running Datalab with Jupyter.
-    return Utils.getHostRoot() + Utils.constants.editorUrlComponent + fileId.toString();
   }
 
   public pathToPathHistory(path: string): DatalabFile[] {

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -26,7 +26,7 @@ class MockFile extends DatalabFile {
   }
 }
 
-class MockFileManager implements FileManager {
+class MockFileManager extends BaseFileManager {
   public get(_fileId: DatalabFileId): Promise<DatalabFile> {
     throw new UnsupportedMethod('get', this);
   }
@@ -56,10 +56,10 @@ class MockFileManager implements FileManager {
   public copy(_fileId: DatalabFileId, _destinationDirectoryId: DatalabFileId): Promise<DatalabFile> {
     throw new UnsupportedMethod('copy', this);
   }
-  public getNotebookUrl(_fileId: DatalabFileId): Promise<string> {
+  public getNotebookUrl(_fileId: DatalabFileId): string {
     throw new UnsupportedMethod('getNotebookUrl', this);
   }
-  public getEditorUrl(_fileId: DatalabFileId): Promise<string> {
+  public getEditorUrl(_fileId: DatalabFileId): string {
     throw new UnsupportedMethod('getEditorUrl', this);
   }
   public pathToPathHistory(path: string): DatalabFile[] {


### PR DESCRIPTION
This PR unblocks the file browser operations while a file list fetch is taking place. It does this by:
- Making opening file/notebook a sync operation.
- Making the `_fetchFileList` call non-blocking, so that it can be called while loading the file list. It follows from this that multiple calls to this method can be made, which is a nice addition.

This PR also cleans up the `FileManager` classes by making them extend a base class instead of implementing an interface. This way they can all use the same functions for opening in editors, except for the ones that need to override it.

Not this doesn't fix another bug with double clicking items, where the breadcrumbs can go out of sync with the file list.