### PR TITLE
Resizable divider styling

### DIFF
--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -35,6 +35,8 @@ the License.
       .right {
         position: absolute;
         left: calc(50% + var(--divider-half-width));
+        background-color: var(--secondary-bg-color);
+        box-shadow: inset 5px 0px 5px -2px var(--box-shadow-color);
       }
       /**
        * Slotted elements should fill the content slots, and be border-boxed so
@@ -56,11 +58,15 @@ the License.
         bottom: 0px;
         left: calc(50% - var(--divider-half-width));
         width: calc(2 * var(--divider-half-width));
-        background-color: var(--selection-bg-color);
+        line-height: 0.5;
+        text-align: center;
+        display: flex;
+        align-items: center;
+        font-weight: bold;
+        color: var(--neutral-fg-color);
       }
       #divider.active {
         user-select: none;
-        background-color: var(--border-color);
       }
     </style>
 
@@ -70,7 +76,11 @@ the License.
         <slot name="left"></slot>
       </div>
 
-      <div id="divider" on-mousedown="{{_mouseDownHandler}}" hidden$="{{disableRight}}"></div>
+      <div id="divider" on-mousedown="{{_mouseDownHandler}}" hidden$="{{disableRight}}">
+        .
+        .
+        .
+      </div>
 
       <div id="rightPane" class="pane right">
         <slot name="right"></slot>

--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.ts
@@ -96,6 +96,12 @@ class ResizableDividerElement extends Polymer.Element {
     // Style the divider while dragging
     this.$.divider.classList.add('active');
     this._lastMouseDownPosition = this.dividerPosition;
+
+    // Disable pointer events on the panes while dragging. This is to avoid
+    // annoying hover effects that flicker as the pointer is moving faster
+    // than the divider element.
+    (this.$.leftPane as HTMLDivElement).style.pointerEvents = 'none';
+    (this.$.rightPane as HTMLDivElement).style.pointerEvents = 'none';
   }
 
   _mouseUpHandler() {
@@ -105,6 +111,10 @@ class ResizableDividerElement extends Polymer.Element {
     // stop styling the handle as active because dragging is done
     this.$.divider.classList.remove('active');
     this._lastMouseUpPosition = this.dividerPosition;
+
+    // Re-enable pointer events on the panes
+    (this.$.leftPane as HTMLDivElement).style.pointerEvents = 'all';
+    (this.$.rightPane as HTMLDivElement).style.pointerEvents = 'all';
   }
 
   _mouseMoveHandler(event: MouseEvent) {


### PR DESCRIPTION
This PR styles the divider to have no background color, and show a three-dot indicator for the resize. The right pane now has a shaded background color and an inset box-shadow.

![image](https://user-images.githubusercontent.com/1424661/31480158-0602ea4e-aed1-11e7-9979-078873fd6550.png)
