### PR TITLE
Add BigQueryPublicFileManager.

### DIFF
--- a/sources/web/datalab/polymer/components/data-browser/data-browser.html
+++ b/sources/web/datalab/polymer/components/data-browser/data-browser.html
@@ -28,7 +28,7 @@ the License.
       }
     </style>
 
-    <file-browser id="fileBrowser" file-manager-type='bigquery'
+    <file-browser id="fileBrowser" file-manager-type='bigqueryPublic'
         file-id="{{fileId}}" toolbar-mode="data"></file-browser>
 
   </template>

--- a/sources/web/datalab/polymer/components/data-browser/data-browser.ts
+++ b/sources/web/datalab/polymer/components/data-browser/data-browser.ts
@@ -43,6 +43,15 @@ class DataBrowserElement extends Polymer.Element implements DatalabPageElement {
   resizeHandler() {
     this.$.fileBrowser.resizeHandler();
   }
+
+  ready() {
+    super.ready();
+
+    this.$.fileBrowser.fileManagerTypeList = [
+      FileManagerType.BIG_QUERY,
+      FileManagerType.BIG_QUERY_PUBLIC,
+    ];
+  }
 }
 
 customElements.define(DataBrowserElement.is, DataBrowserElement);

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -1175,11 +1175,6 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       if (startuppath) {
         this._pathHistory = this._fileManager.pathToPathHistory(startuppath);
       }
-    } else if (this.fileManagerType === 'bigquery') {
-      // Set the default starting location for bigquery browsing to be
-      // the bigquery-public-data project.
-      this._pathHistory =
-          this._fileManager.pathToPathHistory('bigquery-public-data');
     }
 
     // Always add the root file to the beginning.

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -41,10 +41,6 @@ class BigQueryFile extends DatalabFile {
  */
 class BigQueryFileManager extends BaseFileManager {
 
-  protected myFileManagerType() {
-    return FileManagerType.BIG_QUERY;
-  }
-
   public canHostNotebooks() {
     return false;
   }
@@ -142,6 +138,26 @@ class BigQueryFileManager extends BaseFileManager {
     }
   }
 
+  protected myFileManagerType() {
+    return FileManagerType.BIG_QUERY;
+  }
+
+  protected _listProjects(): Promise<DatalabFile[]> {
+    return this._collectAllProjects([], '')
+      .catch((e: Error) => { Utils.log.error(e); throw e; });
+  }
+
+  protected _bqProjectIdToDatalabFile(projectId: string): DatalabFile {
+    const path = projectId;
+    return new BigQueryFile({
+      icon: 'datalab-icons:bq-project',
+      id: new DatalabFileId(path, this.myFileManagerType()),
+      name: projectId,
+      status: DatalabFileStatus.IDLE,
+      type: DatalabFileType.DIRECTORY,
+    } as DatalabFile);
+  }
+
   private async _collectAllProjects(accumulatedProjects: ProjectResource[],
                                     pageToken: string): Promise<DatalabFile[]> {
     const response: HttpResponse<ListProjectsResponse> =
@@ -157,11 +173,6 @@ class BigQueryFileManager extends BaseFileManager {
       return projects.map(
           this._bqProjectToDatalabFile.bind(this)) as DatalabFile[];
     }
-  }
-
-  protected _listProjects(): Promise<DatalabFile[]> {
-    return this._collectAllProjects([], '')
-      .catch((e: Error) => { Utils.log.error(e); throw e; });
   }
 
   private async _collectAllDatasets(projectId: string,
@@ -223,17 +234,6 @@ class BigQueryFileManager extends BaseFileManager {
 
   private _bqProjectToDatalabFile(bqProject: ProjectResource): DatalabFile {
     return this._bqProjectIdToDatalabFile(bqProject.projectReference.projectId);
-  }
-
-  protected _bqProjectIdToDatalabFile(projectId: string): DatalabFile {
-    const path = projectId;
-    return new BigQueryFile({
-      icon: 'datalab-icons:bq-project',
-      id: new DatalabFileId(path, this.myFileManagerType()),
-      name: projectId,
-      status: DatalabFileStatus.IDLE,
-      type: DatalabFileType.DIRECTORY,
-    } as DatalabFile);
   }
 
   private _bqDatasetToDatalabFile(bqDataset: DatasetResource): DatalabFile {

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -41,6 +41,10 @@ class BigQueryFile extends DatalabFile {
  */
 class BigQueryFileManager extends BaseFileManager {
 
+  protected myFileManagerType() {
+    return FileManagerType.BIG_QUERY;
+  }
+
   public canHostNotebooks() {
     return false;
   }
@@ -57,7 +61,7 @@ class BigQueryFileManager extends BaseFileManager {
   }
 
   public async getRootFile() {
-    return this.get(new DatalabFileId('/', FileManagerType.BIG_QUERY));
+    return this.get(new DatalabFileId('/', this.myFileManagerType()));
   }
 
   public saveText(_file: DatalabFile, _content: string): Promise<DatalabFile> {
@@ -155,7 +159,7 @@ class BigQueryFileManager extends BaseFileManager {
     }
   }
 
-  private _listProjects(): Promise<DatalabFile[]> {
+  protected _listProjects(): Promise<DatalabFile[]> {
     return this._collectAllProjects([], '')
       .catch((e: Error) => { Utils.log.error(e); throw e; });
   }
@@ -210,7 +214,7 @@ class BigQueryFileManager extends BaseFileManager {
     const path = '/';
     return new BigQueryFile({
       icon: '',
-      id: new DatalabFileId(path, FileManagerType.BIG_QUERY),
+      id: new DatalabFileId(path, this.myFileManagerType()),
       name: '/',
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.FILE,
@@ -221,11 +225,11 @@ class BigQueryFileManager extends BaseFileManager {
     return this._bqProjectIdToDatalabFile(bqProject.projectReference.projectId);
   }
 
-  private _bqProjectIdToDatalabFile(projectId: string): DatalabFile {
+  protected _bqProjectIdToDatalabFile(projectId: string): DatalabFile {
     const path = projectId;
     return new BigQueryFile({
       icon: 'datalab-icons:bq-project',
-      id: new DatalabFileId(path, FileManagerType.BIG_QUERY),
+      id: new DatalabFileId(path, this.myFileManagerType()),
       name: projectId,
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
@@ -241,7 +245,7 @@ class BigQueryFileManager extends BaseFileManager {
     const path = projectId + '/' + datasetId;
     return new BigQueryFile({
       icon: 'datalab-icons:bq-dataset',
-      id: new DatalabFileId(path, FileManagerType.BIG_QUERY),
+      id: new DatalabFileId(path, this.myFileManagerType()),
       name: datasetId,
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
@@ -260,10 +264,34 @@ class BigQueryFileManager extends BaseFileManager {
     const path = projectId + '/' + datasetId + '/' + tableId;
     return new BigQueryFile({
       icon: 'datalab-icons:bq-table',
-      id: new DatalabFileId(path, FileManagerType.BIG_QUERY),
+      id: new DatalabFileId(path, this.myFileManagerType()),
       name: tableId,
       status: DatalabFileStatus.IDLE,
       type: DatalabFileType.FILE,
     } as DatalabFile);
+  }
+}
+
+/**
+ * A file manager that is just like BigQueryFileManager except that listing the
+ * project returns a list of projects such as bigquery-public-data that contain
+ * public datasets.
+ */
+class BigQueryPublicFileManager extends BigQueryFileManager {
+  publicProjectNames = [
+    'bigquery-public-data',
+    'gdelt-bq',
+    'lookerdata',
+    'nyc-tlc',
+  ];
+
+  protected myFileManagerType() {
+    return FileManagerType.BIG_QUERY_PUBLIC;
+  }
+
+  protected _listProjects(): Promise<DatalabFile[]> {
+    const datalabFiles = this.publicProjectNames.map(
+        this._bqProjectIdToDatalabFile.bind(this)) as DatalabFile[];
+    return Promise.resolve(datalabFiles);
   }
 }

--- a/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
+++ b/sources/web/datalab/polymer/modules/file-manager-factory/file-manager-factory.ts
@@ -14,6 +14,7 @@
 
 enum FileManagerType {
   BIG_QUERY = 'bigquery',
+  BIG_QUERY_PUBLIC = 'bigqueryPublic',
   DRIVE = 'drive',
   GITHUB = 'github',
   JUPYTER = 'jupyter',
@@ -46,6 +47,14 @@ class FileManagerFactory {
         name: 'bigquery',
         path: 'modules/bigquery-file-manager/bigquery-file-manager.html',
         typeClass: BigQueryFileManager,
+      }
+    ], [
+      FileManagerType.BIG_QUERY_PUBLIC, {
+        displayIcon: 'datalab-icons:bigquery-logo',
+        displayName: 'Public Datasets',
+        name: 'bigqueryPublic',
+        path: 'modules/bigquery-file-manager/bigquery-file-manager.html',
+        typeClass: BigQueryPublicFileManager,
       }
     ], [
       FileManagerType.DRIVE, {
@@ -92,6 +101,7 @@ class FileManagerFactory {
   public static fileManagerNameToType(name: string): FileManagerType {
     switch (name) {
       case 'bigquery': return FileManagerType.BIG_QUERY;
+      case 'bigqueryPublic': return FileManagerType.BIG_QUERY_PUBLIC;
       case 'drive': return FileManagerType.DRIVE;
       case 'github': return FileManagerType.GITHUB;
       case 'jupyter': return FileManagerType.JUPYTER;


### PR DESCRIPTION
... and use it in the Data browser to allow seeing public dataset projects separately from the user's projects.

As in the Files browser, the file manager, which used to display only BigQuery, is now a dropdown list that includes BigQuery and Public Datasets.
![bq-public-datasets](https://user-images.githubusercontent.com/116825/31519689-06b7efca-af58-11e7-810d-151fbc318856.png)
