### PR TITLE
Use host root for redirect URL

### DIFF
--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -407,6 +407,8 @@ class GapiManager {
   * OAuth 2.0 client ID and scopes (space delimited string) to request access.
   */
   private static _initClient(): Promise<void> {
+    // TODO: Add state parameter to redirect the user back to the current URL
+    // after the OAuth flow finishes.
     return gapi.auth2.init({
       client_id: GapiManager._clientId,
       fetch_basic_profile: true,

--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -410,6 +410,7 @@ class GapiManager {
     return gapi.auth2.init({
       client_id: GapiManager._clientId,
       fetch_basic_profile: true,
+      redirect_uri: Utils.getHostRoot(),
       scope: initialScopeString,
       ux_mode: 'redirect',
     })


### PR DESCRIPTION
This is needed because the URL requiring the redirect can be any arbitrary path, now that file paths are part of the URL.