### PR TITLE
Make Data tab no longer be hidden.

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.html
@@ -90,7 +90,7 @@ the License.
       <div class="button-placeholder"></div>
       <iron-selector class="container" attr-for-selected="id" selected={{page}}
                      class="drawer-list" role="navigation">
-        <a href="/data" id="data" hidden$="{{!_showDataTab}}">
+        <a href="/data" id="data">
           <paper-button class="sidebar-button">
             <div class="sidebar-button-container">
               <iron-icon class="sidebar-button-icon" icon="av:library-books"></iron-icon>

--- a/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
+++ b/sources/web/datalab/polymer/components/datalab-sidebar/datalab-sidebar.ts
@@ -24,29 +24,15 @@ class SidebarElement extends Polymer.Element {
    */
   public page: string;
 
-  // TODO - remove _showDataTab once the Data tab is ready to be visible
-  private _showDataTab = false;
-
   static get is() { return 'datalab-sidebar'; }
 
   static get properties() {
     return {
-      _showDataTab: {
-        type: Boolean,
-        value: false,
-      },
       page: {
         type: String,
         value: 'files',
       },
     };
-  }
-
-  public ready() {
-    super.ready();
-    if (location.pathname.startsWith('/data')) {
-      this._showDataTab = true;
-    }
   }
 }
 


### PR DESCRIPTION
Previously, the Data tab would only appear after the user manually visited the /data page. With this change, the Data tab is always visible.