### PR TITLE
Use one cell for bq query in table overview template

### DIFF
--- a/sources/web/datalab/polymer/templates/BigQueryTableOverview.ipynb
+++ b/sources/web/datalab/polymer/templates/BigQueryTableOverview.ipynb
@@ -17,20 +17,8 @@
    },
    "outputs": [],
    "source": [
-    "%%bq query --name sample\n",
-    "select * from `#${BIGQUERY_FULL_ID}` limit 10"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "df = sample.execute().result().to_dataframe()\n",
-    "df"
+    "%%bq query\n",
+    "SELECT * FROM `#${BIGQUERY_FULL_ID}` LIMIT 10"
    ]
   }
  ],


### PR DESCRIPTION
Use one instead of two cells to execute the query in table overview template.