### PR TITLE
Fix toolbar-button style

### DIFF
--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -116,6 +116,7 @@ the License.
         min-width: 35px;
         border-radius: 0px;
         white-space: nowrap;
+        justify-content: start;
       }
       .toolbar-button:hover {
         background-color: var(--selection-bg-color);


### PR DESCRIPTION
`center` doesn't work for all cases on `paper-button`, especially with long inner text, such as the "Open in Notebook" button.