### PR TITLE
Populate template notebooks in a new tab

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -17,6 +17,7 @@ the License.
 <link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
 
 <link rel="import" href="../../components/datalab-notification/datalab-notification.html">
+<link rel="import" href="../../modules/template-manager/template-manager.html">
 <link rel="import" href="../../components/datalab-sidebar/datalab-sidebar.html">
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
 <link rel="import" href="../../components/resizable-divider/resizable-divider.html">

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
@@ -117,24 +117,57 @@ class TableInlineDetailsElement extends Polymer.Element {
 
     if (this._table) {
       const dict = {
-        BIGQUERY_DATASET_ID: this._table.tableReference.datasetId,
-        BIGQUERY_FULL_ID: this._table.id.replace(':', '.'),
-        BIGQUERY_PROJECT_ID: this._table.tableReference.projectId,
-        BIGQUERY_TABLE_DESCRIPTION: this._table.description,
-        BIGQUERY_TABLE_ID: this._table.tableReference.tableId,
+        BIGQUERY_DATASET_ID: this._table.tableReference.datasetId || '',
+        BIGQUERY_FULL_ID: this._table.id.replace(':', '.') || '',
+        BIGQUERY_PROJECT_ID: this._table.tableReference.projectId || '',
+        BIGQUERY_TABLE_DESCRIPTION: this._table.description || '',
+        BIGQUERY_TABLE_ID: this._table.tableReference.tableId || '',
       };
-      const template = new BigQueryTableOverviewTemplate(dict, this);
 
-      try {
-        const notebook = await TemplateManager.newNotebookFromTemplate(template);
+      const appSettings = await SettingsManager.getAppSettingsAsync();
 
-        if (notebook) {
-          const url = FileManagerFactory.getInstanceForType(notebook.id.source)
-              .getNotebookUrl(notebook.id);
-          window.open(url, '_blank');
+      // TODO(jimmc): Look for a user preference for baseDir
+      const baseType = (appSettings.defaultFileManager || 'drive');
+      const baseDir = baseType + '/';
+      // TODO(jimmc): Allow specifying a path with baseDir. For now, we are
+      // just using the root of the filesystem as the default location.
+      const baseName = 'temp';
+      // Add some more stuff to the name to make it different each time.
+      // We are not checking to see if the file exists, so it is not
+      // guaranteed to produce a unique filename, but since we are doing
+      // it based on the current time down to the second, and it is scoped
+      // only to this user, the odds of a collision are pretty low.
+      const dateStr = new Date().toISOString();
+      const yearStr =
+          dateStr.slice(0, 4) + dateStr.slice(5, 7) + dateStr.slice(8, 10);
+      const timeStr =
+          dateStr.slice(11, 13) + dateStr.slice(14, 16) + dateStr.slice(17, 19);
+      const moreName = yearStr + '_' + timeStr;
+      const fileName = baseName + '_' + moreName + '.ipynb';
+      const options: DirectoryPickerDialogOptions = {
+        big: true,
+        fileId: baseDir,
+        fileName,
+        okLabel: 'Save Here',
+        title: 'New Notebook',
+        withFileName: true,
+      };
+
+      const closeResult =
+          await Utils.showDialog(DirectoryPickerDialogElement, options) as
+              DirectoryPickerDialogCloseResult;
+
+      if (closeResult.confirmed && closeResult.fileName) {
+        let instanceName = closeResult.fileName;
+        if (!instanceName.endsWith('.ipynb')) {
+          instanceName += '.ipynb';
         }
-      } catch (e) {
-        Utils.showErrorDialog('Error', e.message);
+
+        const params = encodeURIComponent(JSON.stringify(dict));
+        const url = Utils.getHostRoot() + Utils.constants.newNotebookUrlComponent +
+            closeResult.selectedDirectory.id.toString() + '?fileName=' + instanceName +
+            '&templateName=bigqueryOverview&params=' + params;
+        window.open(url, '_blank');
       }
     }
   }

--- a/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
+++ b/sources/web/datalab/polymer/components/table-inline-details/table-inline-details.ts
@@ -166,7 +166,7 @@ class TableInlineDetailsElement extends Polymer.Element {
         const params = encodeURIComponent(JSON.stringify(dict));
         const url = Utils.getHostRoot() + Utils.constants.newNotebookUrlComponent +
             closeResult.selectedDirectory.id.toString() + '?fileName=' + instanceName +
-            '&templateName=bigqueryOverview&params=' + params;
+            '&templateName=' + TEMPLATE_NAME.bigqueryOverview + '&params=' + params;
         window.open(url, '_blank');
       }
     }

--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -351,10 +351,10 @@ class GapiManager {
 
   /**
    * Starts the sign-in flow using gapi.
-   * If the user has not previously authorized our app, this will open a pop-up window
+   * If the user has not previously authorized our app, this will redirect to oauth url
    * to ask the user to select an account and to consent to our use of the scopes.
-   * If the user has previously signed in and the doPrompt flag is false, the pop-up will
-   * appear momentarily before automatically closing. If the doPrompt flag is set, then
+   * If the user has previously signed in and the doPrompt flag is false, the redirect will
+   * happen momentarily before automatically closing. If the doPrompt flag is set, then
    * the user will be prompted as if authorization has not previously been provided.
    */
    public static signIn(doPrompt: boolean): Promise<gapi.auth2.GoogleUser> {

--- a/sources/web/datalab/polymer/modules/template-manager/template-manager.ts
+++ b/sources/web/datalab/polymer/modules/template-manager/template-manager.ts
@@ -26,6 +26,10 @@ interface TemplateParameter {
   value: string | number;
 }
 
+enum TEMPLATE_NAME {
+  bigqueryOverview = 'bigqueryOverview',
+}
+
 /**
  * This models a notebook template, including its path on disk as well as a
  * list of its required parameters.
@@ -133,14 +137,14 @@ class BigQueryTableOverviewTemplate extends NotebookTemplate {
 class TemplateManager extends Polymer.Element {
 
   public static async newNotebookFromTemplate(name: string, params: {}) {
-    let templateType: any;
+    let templateClassName: new ({}) => NotebookTemplate;
     switch (name) {
-      case 'bigqueryOverview':
-        templateType = BigQueryTableOverviewTemplate; break;
+      case TEMPLATE_NAME.bigqueryOverview:
+        templateClassName = BigQueryTableOverviewTemplate; break;
       default:
         throw new Error('Unknown template name: ' + name);
     }
-    const template = new templateType(params);
+    const template = new templateClassName(params);
 
     const templateStringContent = await this.getTemplateStringContent(template.fileId);
     let templateNotebookContent: NotebookContent;

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -36,7 +36,9 @@ class Utils {
 
   /**
    * Resolves the given URL using the datalab-app element's base URI. This
-   * obviously requires the element to exist on the calling document.
+   * obviously requires the element to exist on the calling document. If we
+   * move away from requiring a datalab-app element on each entrypoint page,
+   * we will need some other common element here.
    */
   public static resolveUrlToDatalabApp(url: string) {
     const mod = Polymer.DomModule.import('datalab-app', '');

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -30,8 +30,18 @@ class Utils {
 
   public static constants = {
     editorUrlComponent:   '/editor/',
+    newNotebookUrlComponent:  '/notebook/new/',
     notebookUrlComponent: '/notebook/',
   };
+
+  /**
+   * Resolves the given URL using the datalab-app element's base URI. This
+   * obviously requires the element to exist on the calling document.
+   */
+  public static resolveUrlToDatalabApp(url: string) {
+    const mod = Polymer.DomModule.import('datalab-app', '');
+    return Polymer.ResolveUrl.resolveUrl(url, mod.assetpath);
+  }
 
   /**
    * Opens a dialog with the specified options. It uses the Datalab custom element

--- a/sources/web/datalab/polymer/notebook.html
+++ b/sources/web/datalab/polymer/notebook.html
@@ -9,6 +9,7 @@
     <link rel="shortcut icon" href="{base_url}images/favicon.ico">
 
     <link id="themeStylesheet" rel="stylesheet" href="{base_url}index.light.css">
+    <link rel="import" href="{base_url}bower_modules/paper-toast/paper-toast.html">
     <link rel="import" href="{base_url}components/datalab-app/datalab-app.html">
     <link rel="import" href="{base_url}modules/template-manager/template-manager.html">
   </head>
@@ -27,6 +28,7 @@
       }
     </style>
 
+    <paper-toast id="datalabNotification" text="Creating notebook..." duration="0"></paper-toast>
     <iframe id="editor" sandbox="allow-forms allow-scripts allow-popups allow-modals allow-popups-to-escape-sandbox allow-same-origin"></iframe>
 
     <script src="notebook.js"></script>

--- a/sources/web/datalab/polymer/notebook.html
+++ b/sources/web/datalab/polymer/notebook.html
@@ -10,6 +10,7 @@
 
     <link id="themeStylesheet" rel="stylesheet" href="{base_url}index.light.css">
     <link rel="import" href="{base_url}components/datalab-app/datalab-app.html">
+    <link rel="import" href="{base_url}modules/template-manager/template-manager.html">
   </head>
   <body>
     <style>

--- a/sources/web/datalab/polymer/notebook.html
+++ b/sources/web/datalab/polymer/notebook.html
@@ -9,9 +9,7 @@
     <link rel="shortcut icon" href="{base_url}images/favicon.ico">
 
     <link id="themeStylesheet" rel="stylesheet" href="{base_url}index.light.css">
-    <link rel="import" href="{base_url}bower_modules/paper-toast/paper-toast.html">
     <link rel="import" href="{base_url}components/datalab-app/datalab-app.html">
-    <link rel="import" href="{base_url}modules/template-manager/template-manager.html">
   </head>
   <body>
     <style>

--- a/sources/web/datalab/polymer/notebook.ts
+++ b/sources/web/datalab/polymer/notebook.ts
@@ -89,13 +89,13 @@ function sendMessageToNotebookEditor(message: IframeMessage) {
   }
 }
 
-async function createNew(path: string) {
+async function createNew(parentPath: string) {
   toast.open();
 
   try {
-    await GapiManager.listenForSignInChanges(() => null);
+    await GapiManager.loadGapi();
 
-    const parentId = DatalabFileId.fromString(path.substr('new/'.length));
+    const parentId = DatalabFileId.fromString(parentPath);
     const fileName = queryParams.get('fileName') as string;
     const fileManager = FileManagerFactory.getInstanceForType(
       FileManagerFactory.fileManagerNameToType(parentId.source));
@@ -119,12 +119,12 @@ async function createNew(path: string) {
 if (location.pathname.startsWith(Utils.constants.notebookUrlComponent) && iframe) {
   window.top.addEventListener('message', processMessageEvent);
 
-  const path = location.pathname.substr(Utils.constants.notebookUrlComponent.length);
-
-  if (path.startsWith('new/') && queryParams.has('fileName')) {
+  if (location.pathname.startsWith(Utils.constants.newNotebookUrlComponent) &&
+      queryParams.has('fileName')) {
     // If this is a new notebook being created, make sure it's created and populated
-    // first (if it's a template), then set the iframe path.
-    createNew(path);
+    // first (if it's a template), then redirect this window to that new file.
+    const parentPath = location.pathname.substr(Utils.constants.newNotebookUrlComponent.length);
+    createNew(parentPath);
   } else {
     // Set the iframe source to load the notebook editor resources.
     // TODO: Currently this is one-directional, iframe wrapper url -> iframe
@@ -136,6 +136,7 @@ if (location.pathname.startsWith(Utils.constants.notebookUrlComponent) && iframe
     // to load the notebook editor resources as opposed to the notebook shell
     // (this file). Both resources are loaded at /notebook in order to make any
     // links in the editor relative to /notebook as well.
+    const path = location.pathname.substr(Utils.constants.notebookUrlComponent.length);
     iframe.src = Utils.constants.notebookUrlComponent + path +
         '?inIframe#fileId=' + path;
   }

--- a/third_party/externs/ts/polymer/polymer.d.ts
+++ b/third_party/externs/ts/polymer/polymer.d.ts
@@ -28,6 +28,7 @@ interface ElementDefinitionOptions {
 
 interface PolymerTemplate extends Node {
   content: HTMLElement;
+  assetpath: string;
 }
 
 declare module Polymer {
@@ -119,6 +120,10 @@ declare module Polymer {
 
   class dom {
     static flush(): null;
+  }
+
+  class ResolveUrl {
+    static resolveUrl(url: string, base: string): string;
   }
 
   function importHref(href: string,


### PR DESCRIPTION
This PR makes populating template-based notebooks take place in a new tab as soon as the user picks a location for the notebook. The template name and parameters are sent as querystring parameters, and the notebook is populated and saved in the newly created tab, while showing a toast that says "Creating notebook.." This toast then disappears and the page is redirected to open the new notebook.
This does not get blocked by popup blockers, while also keeping the focus on the newly created notebook.
The PR takes the opportunity to refactor the way templating works around resource path resolution. Now the resolution is a simple `Utils` call, instead of keeping around a reference of some Polymer element.

![image](https://user-images.githubusercontent.com/1424661/31648659-dc54ef34-b2c3-11e7-96fd-411f898daf73.png)
