### PR TITLE
Remove file status

### DIFF
--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -40,11 +40,6 @@ class BigQueryFile extends DatalabFile {
  * datasets, and tables like a filesystem.
  */
 class BigQueryFileManager extends BaseFileManager {
-
-  public canHostNotebooks() {
-    return false;
-  }
-
   public get(fileId: DatalabFileId): Promise<DatalabFile> {
     if (fileId.path === '/') {
       return Promise.resolve(this._bqRootDatalabFile());

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -153,7 +153,6 @@ class BigQueryFileManager extends BaseFileManager {
       icon: 'datalab-icons:bq-project',
       id: new DatalabFileId(path, this.myFileManagerType()),
       name: projectId,
-      status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
     } as DatalabFile);
   }
@@ -227,7 +226,6 @@ class BigQueryFileManager extends BaseFileManager {
       icon: '',
       id: new DatalabFileId(path, this.myFileManagerType()),
       name: '/',
-      status: DatalabFileStatus.IDLE,
       type: DatalabFileType.FILE,
     } as DatalabFile);
   }
@@ -247,7 +245,6 @@ class BigQueryFileManager extends BaseFileManager {
       icon: 'datalab-icons:bq-dataset',
       id: new DatalabFileId(path, this.myFileManagerType()),
       name: datasetId,
-      status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
     } as DatalabFile);
   }
@@ -266,7 +263,6 @@ class BigQueryFileManager extends BaseFileManager {
       icon: 'datalab-icons:bq-table',
       id: new DatalabFileId(path, this.myFileManagerType()),
       name: tableId,
-      status: DatalabFileStatus.IDLE,
       type: DatalabFileType.FILE,
     } as DatalabFile);
   }

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -129,7 +129,6 @@ class DriveFileManager extends BaseFileManager {
                               file.iconLink : 'editor:insert-drive-file',
       id: new DatalabFileId(file.id, FileManagerType.DRIVE),
       name: file.name,
-      status: DatalabFileStatus.IDLE,
       type: file.mimeType === DriveFileManager._directoryMimeType ?
                               DatalabFileType.DIRECTORY :
                               DatalabFileType.FILE,

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -37,11 +37,6 @@ enum DatalabFileType {
   NOTEBOOK,
 }
 
-enum DatalabFileStatus {
-  IDLE,
-  RUNNING,
-}
-
 /**
  * Unique identifier for a file object.
  */
@@ -109,7 +104,6 @@ abstract class DatalabFile {
   icon: string;
   id: DatalabFileId;
   name: string;
-  status?: DatalabFileStatus;
   type: DatalabFileType;
 
   constructor(obj?: DatalabFile) {
@@ -117,7 +111,6 @@ abstract class DatalabFile {
       this.icon = obj.icon;
       this.name = obj.name;
       this.id = obj.id;
-      this.status = obj.status;
       this.type = obj.type;
     }
   }
@@ -137,12 +130,6 @@ abstract class DatalabFile {
 interface FileManager {
   // TODO: Consider supporting getting both the file and content objects with
   // one call.
-
-  /**
-   * Returns true if we can host notebooks on this filesystem, and thus should
-   * display the Status column in the file browser.
-   */
-  canHostNotebooks(): boolean;
 
   /**
    * Returns a DatalabFile object representing the file or directory requested

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -220,10 +220,6 @@ interface FileManager {
  * functionality for the different FileManager classes.
  */
 class BaseFileManager implements FileManager {
-  canHostNotebooks(): boolean {
-    return true;
-  }
-
   get(_fileId: DatalabFileId): Promise<DatalabFile> {
     throw new UnsupportedMethod('get', this);
   }

--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
@@ -165,7 +165,6 @@ class GithubFileManager extends BaseFileManager {
       icon: '',
       id: new DatalabFileId(path, FileManagerType.GITHUB),
       name: parts[parts.length - 1],
-      status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
     } as DatalabFile);
   }
@@ -193,7 +192,6 @@ class GithubFileManager extends BaseFileManager {
       icon: '',
       id: new DatalabFileId(path, FileManagerType.GITHUB),
       name: '/',
-      status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
     } as DatalabFile);
   }
@@ -220,7 +218,6 @@ class GithubFileManager extends BaseFileManager {
       icon,
       id: new DatalabFileId(repo.full_name, FileManagerType.GITHUB),
       name: repo.name,
-      status: DatalabFileStatus.IDLE,
       type,
     } as DatalabFile);
   }
@@ -238,7 +235,6 @@ class GithubFileManager extends BaseFileManager {
       icon,
       id: new DatalabFileId(path, FileManagerType.GITHUB),
       name: file.name,
-      status: DatalabFileStatus.IDLE,
       type,
     } as DatalabFile);
   }
@@ -254,7 +250,6 @@ class GithubFileManager extends BaseFileManager {
       icon,
       id: new DatalabFileId(path, FileManagerType.GITHUB),
       name: file.name,
-      status: DatalabFileStatus.IDLE,
       type,
     } as DatalabFile);
   }

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
@@ -110,7 +110,6 @@ class JupyterFileManager extends BaseFileManager {
     jupyterFile.mimetype = file.mimetype;
     jupyterFile.name = file.name;
     jupyterFile.path = file.path;
-    jupyterFile.status = DatalabFileStatus.IDLE;
     jupyterFile.writable = file.writable;
     return jupyterFile;
   }
@@ -183,8 +182,6 @@ class JupyterFileManager extends BaseFileManager {
           typeof(container.type));
     }
 
-    // Combine the return values of the two requests to supplement the files
-    // array with the status value.
     const files = container.content;
     return files.map((file: any) => JupyterFileManager._upstreamFileToJupyterFile(file));
   }

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -156,18 +156,6 @@ class Utils {
   }
 
   // TODO: Consider moving to a dedicated strings module
-  public static getFileStatusString(status: DatalabFileStatus) {
-    switch (status) {
-      case DatalabFileStatus.IDLE:
-        return '';
-      case DatalabFileStatus.RUNNING:
-        return 'Running';
-      default:
-        throw new Error('Unknown file status: ' + status);
-    }
-  }
-
-  // TODO: Consider moving to a dedicated strings module
   public static getFileTypeString(type: DatalabFileType) {
     switch (type) {
       case DatalabFileType.DIRECTORY:

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -20,7 +20,6 @@ class MockFile extends DatalabFile {
       icon: '',
       id: new DatalabFileId(path, FileManagerType.MOCK),
       name,
-      status: DatalabFileStatus.IDLE,
       type: DatalabFileType.DIRECTORY,
     });
   }
@@ -99,8 +98,6 @@ describe('<file-browser>', () => {
   it('starts up with no files selected, and no files running', () => {
     const files: ItemListElement = testFixture.$.files;
     files.rows.forEach((row: ItemListRow, i: number) => {
-      assert(row.columns[1] === Utils.getFileStatusString(mockFiles[i].status as DatalabFileStatus),
-          'file ' + i + 'should have an empty status');
       assert(!row.selected, 'file ' + i + ' should not be selected');
     });
   });

--- a/sources/web/datalab/polymer/test/table-inline-details-test.ts
+++ b/sources/web/datalab/polymer/test/table-inline-details-test.ts
@@ -73,7 +73,6 @@ describe('<table-inline-details>', () => {
       icon: '',
       id: new DatalabFileId(tableId, FileManagerType.BIG_QUERY),
       name: '/',
-      status: DatalabFileStatus.IDLE,
       type: DatalabFileType.FILE,
     } as DatalabFile);
   };


### PR DESCRIPTION
With this change, the file browser does not need to look up backends to get the files' running status. The session status can now only be viewed in the Sessions page.