### PR TITLE
More ignored patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.ipynb_checkpoints
+.DS_Store
+package-lock.json
 build
 staging
 *.gradle


### PR DESCRIPTION
.DS_Store for macOS development, package-lock.json for users with node >= 5.0.0.