### PR TITLE
Add gated features, disable timeout

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -179,6 +179,11 @@ declare module common {
      * The host/port on which to serve the fake metadata service, if active.
      */
     fakeMetadataAddress: {host: "metadata.google.internal"|"metadata"|null, port: number};
+
+    /**
+     * List of features that can be optinally enabled.
+     */
+    gatedFeatures: string[];
   }
 
   interface TimeoutInfo {

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -47,5 +47,6 @@
     "--ip=\"127.0.0.1\""
   ],
   "supportedFileBrowserSources": ["jupyter"],
-  "fakeMetadataAddress": {"host": "metadata.google.internal", "port": 80}
+  "fakeMetadataAddress": {"host": "metadata.google.internal", "port": 80},
+  "gatedFeatures": []
 }

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -17,6 +17,7 @@ the License.
 <link rel="import" href="../../components/datalab-settings/datalab-settings.html">
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 <link rel="import" href="../../components/timeout-panel/timeout-panel.html">
+<link rel="import" href="../../modules/settings-manager/settings-manager.html">
 
 <link rel="import" href="../../bower_components/app-layout/app-header/app-header.html">
 <link rel="import" href="../../bower_components/app-layout/app-toolbar/app-toolbar.html">
@@ -108,7 +109,7 @@ the License.
     below the toolbar-->
     <paper-dialog id="accountDropdown" class="account-dropdown">
       <auth-panel></auth-panel>
-      <timeout-panel id="accountTimeoutPanel"></timeout-panel>
+      <timeout-panel id="accountTimeoutPanel" hidden="{{!_timeoutEnabled}}"></timeout-panel>
     </paper-dialog>
 
     <!--Info dialog. This shows centered in the middle of the window-->

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
@@ -20,13 +20,27 @@
  */
 class ToolbarElement extends Polymer.Element {
 
+  private _timeoutEnabled: boolean;
+
   static get is() { return 'datalab-toolbar'; }
 
-  ready() {
+  static get properties() {
+    return {
+      _timeoutEnabled: Boolean,
+    };
+  }
+
+  async ready() {
     super.ready();
-    const authPanel = this.shadowRoot.querySelector('auth-panel');
-    if (authPanel) {
-      authPanel.addEventListener('signInOutDone', this._closeAccountDropdown.bind(this));
+
+    this._timeoutEnabled = await SettingsManager.isAppFeatureEnabled(
+        Utils.constants.timeoutFeature);
+
+    if (this._timeoutEnabled) {
+      const authPanel = this.shadowRoot.querySelector('auth-panel');
+      if (authPanel) {
+        authPanel.addEventListener('signInOutDone', this._closeAccountDropdown.bind(this));
+      }
     }
   }
 

--- a/sources/web/datalab/polymer/modules/settings-manager/settings-manager.ts
+++ b/sources/web/datalab/polymer/modules/settings-manager/settings-manager.ts
@@ -60,6 +60,15 @@ class SettingsManager {
   }
 
   /**
+   * Returns true iff the given feature is listed in the enabled gated features list.
+   */
+  public static async isAppFeatureEnabled(featureName: string) {
+    const settings = await this.getAppSettingsAsync();
+    const features = settings.gatedFeatures || [];
+    return features.indexOf(featureName) > -1;
+  }
+
+  /**
    * Sets a user setting.
    * @param setting name of the setting to change.
    * @param value new setting value.

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -32,6 +32,9 @@ class Utils {
     editorUrlComponent:   '/editor/',
     newNotebookUrlComponent:  '/notebook/new/',
     notebookUrlComponent: '/notebook/',
+
+    // Feature names
+    timeoutFeature:       'timeout',
   };
 
   /**


### PR DESCRIPTION
This PR disables the timeout by default. With this change, there are no more `/api/basepath` requests until a backend is actually needed, such as when browsing the list of sessions, terminals, or opening a notebook.