### PR TITLE
Move template-manager line to the end to fix hang problem.

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
+++ b/sources/web/datalab/polymer/components/datalab-app/datalab-app.html
@@ -17,13 +17,13 @@ the License.
 <link rel="import" href="../../bower_components/iron-pages/iron-pages.html">
 
 <link rel="import" href="../../components/datalab-notification/datalab-notification.html">
-<link rel="import" href="../../modules/template-manager/template-manager.html">
 <link rel="import" href="../../components/datalab-sidebar/datalab-sidebar.html">
 <link rel="import" href="../../components/datalab-toolbar/datalab-toolbar.html">
 <link rel="import" href="../../components/resizable-divider/resizable-divider.html">
 <link rel="import" href="../../modules/api-manager/api-manager.html">
 <link rel="import" href="../../modules/file-manager-factory/file-manager-factory.html">
 <link rel="import" href="../../modules/settings-manager/settings-manager.html">
+<link rel="import" href="../../modules/template-manager/template-manager.html">
 
 <dom-module id="datalab-app">
   <template>


### PR DESCRIPTION
It looks to me like there is a problem related to either the ordering or the number of file loads for included files. The symptom is that Chrome hangs with a status line such as "waiting for <some host>". This change seems to reduce the frequency of that problem for me - and it puts the link lines in the correct alphabetical order anyway.