### PR TITLE
Enable binary transfer over wsHttpProxy.

### DIFF
--- a/third_party/externs/ts/node/node.d.ts
+++ b/third_party/externs/ts/node/node.d.ts
@@ -346,8 +346,10 @@ declare module "http" {
     }
     export interface ClientResponse extends events.EventEmitter, stream.Readable {
         statusCode: number;
+        statusMessage: string;
         httpVersion: string;
         headers: any;
+        rawHeaders: string[];
         trailers: any;
         setEncoding(encoding?: string): void;
         pause(): void;


### PR DESCRIPTION
This adds the ability to transfer binary data over the HTTP over WebSocket proxy. It also adds a few more fields to allow generating complete browser Response objects with the result.

Binary transfer is enabled by the requester for backwards compat.