### PR TITLE
Move build dependencies to be installed by npm instead of requiring global binaries

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -31,21 +31,6 @@ function install_node() {
   export "PATH=${PATH}:/tools/node/bin"
 }
 
-function install_bower() {
-  echo "Installing Bower"
-  npm install -g bower
-}
-
-function install_polyer_cli() {
-  echo "Installing Polymer CLI"
-  npm install -g polymer-cli
-}
-
-function install_typescript() {
-  echo "Installing Typescript"
-  npm install -g typescript
-}
-
 function install_git() {
   echo "Updating apt repository"
   apt-get update -y -qq
@@ -65,9 +50,6 @@ function install_prereqs() {
 
   # Use -v instead of -h to test npm installation, since -h returns non-zero
   npm -v >/dev/null 2>&1 || install_node
-  tsc -h >/dev/null 2>&1  || install_typescript
-  bower -h >/dev/null 2>&1  || install_bower
-  polymer -h >/dev/null 2>&1  || install_polyer_cli
   source ./tools/initenv.sh
 }
 

--- a/sources/web/build.sh
+++ b/sources/web/build.sh
@@ -54,10 +54,9 @@ cd ../..
 # End experimental UI build step
 
 # Compile the nodejs server
-tsc --module commonjs --noImplicitAny \
-    --outDir $WEB_DIR \
-    --target es6 \
-    ./datalab/*.ts
+cd datalab
+npm run transpile -- --outDir $WEB_DIR 
+cd ..
 
 rsync -avpq ./datalab/config/ $WEB_DIR/config
 rsync -avpq ./datalab/static/ $WEB_DIR/static

--- a/sources/web/build.sh
+++ b/sources/web/build.sh
@@ -55,6 +55,7 @@ cd ../..
 
 # Compile the nodejs server
 cd datalab
+npm install
 npm run transpile -- --outDir $WEB_DIR 
 cd ..
 

--- a/sources/web/datalab/package.json
+++ b/sources/web/datalab/package.json
@@ -17,6 +17,10 @@
     "node": "0.10.x"
   },
   "scripts": {
+    "transpile": "tsc --module commonjs --noImplicitAny --target es6 ./*.ts",
     "start": "node app.js"
+  },
+  "devDependencies": {
+    "typescript": "^2.5.3"
   }
 }

--- a/sources/web/datalab/polymer/package.json
+++ b/sources/web/datalab/polymer/package.json
@@ -18,6 +18,8 @@
     "@types/gapi.client.cloudresourcemanager": "^1.0.0",
     "@types/mocha": "^2.2.41",
     "@types/socket.io-client": "^1.4.30",
+    "bower": "^1.8.2",
+    "polymer-cli": "^1.5.7",
     "tslint": "^5.7.0",
     "typescript": "^2.5.3"
   }


### PR DESCRIPTION
This PR follows up on https://github.com/googledatalab/datalab/pull/1731 to move more build dependencies to `package.json` instead of requiring them to have been installed globally.