### PR TITLE
Silence flake8 complaints about bare except.

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -253,7 +253,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
                 if health_resp.getcode() == 200:
                     healthy = True
                     break
-            except:
+            except Exception:
                 continue
 
         if healthy:

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -25,7 +25,7 @@ import utils
 try:
     # If we are running in Python 2, builtins is available in 'future'.
     from builtins import input as read_input
-except:
+except Exception:
     # We don't want to require the installation of future, so fallback
     # to using raw_input from Py2.
     read_input = raw_input
@@ -534,7 +534,7 @@ def ensure_disk_exists(args, gcloud_compute, disk_name, report_errors=False):
     except subprocess.CalledProcessError:
         try:
             create_disk(args, gcloud_compute, disk_name, report_errors)
-        except:
+        except Exception:
             if (not args.zone) and (not args.quiet):
                 # We take this failure as a sign that gcloud might need
                 # to prompt for a zone. As such, we do that prompting
@@ -592,7 +592,7 @@ def ensure_repo_exists(args, gcloud_repos, repo_name):
         if not matching_repos:
             try:
                 create_repo(args, gcloud_repos, repo_name)
-            except:
+            except Exception:
                 raise RepositoryException(repo_name)
 
 

--- a/tools/cli/commands/creategpu.py
+++ b/tools/cli/commands/creategpu.py
@@ -23,7 +23,7 @@ import connect
 try:
     # If we are running in Python 2, builtins is available in 'future'.
     from builtins import input as read_input
-except:
+except Exception:
     # We don't want to require the installation of future, so fallback
     # to using raw_input from Py2.
     read_input = raw_input

--- a/tools/cli/commands/utils.py
+++ b/tools/cli/commands/utils.py
@@ -133,7 +133,7 @@ def prompt_for_zone(args, gcloud_compute, instance=None):
     try:
         zone_number = int(selected)
         return zone_map[zone_number]
-    except:
+    except Exception:
         if selected not in matching_zones:
             print('Zone {} not recognized'.format(selected))
             return prompt_for_zone(args, gcloud_compute, instance=instance)

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -108,7 +108,7 @@ try:
     with open(os.devnull, 'w') as dn:
         subprocess.call(['gcloud', '--version'], stderr=dn, stdout=dn)
     gcloud_cmd = 'gcloud'
-except:
+except Exception:
     gcloud_cmd = 'gcloud.cmd'
 
 


### PR DESCRIPTION
Some time between flake8 version 3.3 and 3.5 it became an error to have a bare except statement, which caused our builds to break. This change silences those errors.