### PR TITLE
Long list

### DIFF
--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -96,6 +96,11 @@ the License.
         flex: 1;
         max-width: 150px;
       }
+      #longListMessage {
+        display: block;
+        padding: 20px;
+        text-align: center;
+      }
     </style>
 
     <!--Header row-->
@@ -134,6 +139,10 @@ the License.
         <div id="details" class="row-details" hidden$="{{!row.showInlineDetails}}"></div>
       </template>
     </div>
+    <span id="longListMessage" hidden$="[[!filter]]">
+      Showing [[defaultMaxLength]] out of [[rows.length]] items.
+      <a href="#" on-click="_showCompleteList">Show all items.</a>
+    </span>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -122,7 +122,7 @@ the License.
 
     <!--Item list-->
     <div id="listContainer">
-      <template is="dom-repeat" id="list" items="{{rows}}" as="row">
+      <template is="dom-repeat" id="list" items="{{rows}}" as="row" filter="filterMethod">
         <paper-item class="row" selected$={{row.selected}} on-click="_rowClicked"
                     on-dblclick="_rowDoubleClicked">
           <div class="checkbox-col">
@@ -138,11 +138,11 @@ the License.
         </paper-item>
         <div id="details" class="row-details" hidden$="{{!row.showInlineDetails}}"></div>
       </template>
+      <span id="longListMessage" hidden$="[[_completeListShown]]">
+        Showing [[defaultMaxLength]] out of [[rows.length]] items.
+        <a href="#" on-click="_showCompleteList">Show all items.</a>
+      </span>
     </div>
-    <span id="longListMessage" hidden$="[[!filter]]">
-      Showing [[defaultMaxLength]] out of [[rows.length]] items.
-      <a href="#" on-click="_showCompleteList">Show all items.</a>
-    </span>
 
   </template>
 </dom-module>

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -162,6 +162,11 @@ class ItemListElement extends Polymer.Element {
   public columns: string[];
 
   /**
+   * Filter function to show a subset of the rows
+   */
+  public filter: Function|null;
+
+  /**
    * Whether to hide the header row
    */
   public hideHeader: boolean;
@@ -186,7 +191,13 @@ class ItemListElement extends Polymer.Element {
    */
   public inlineDetailsMode: InlineDetailsDisplayMode;
 
+  /**
+   * Number of items to show before considering the list too long.
+   */
+  public readonly defaultMaxLength = 100;
+
   private _lastSelectedIndex = -1;
+  // private _completeListShown = true;
 
   static get is() { return 'item-list'; }
 
@@ -208,6 +219,7 @@ class ItemListElement extends Polymer.Element {
         type: Boolean,
         value: false,
       },
+      filter: Function,
       hideHeader: {
         type: Boolean,
         value: false,
@@ -221,6 +233,7 @@ class ItemListElement extends Polymer.Element {
         value: false,
       },
       rows: {
+        observer: '_rowsChanged',
         type: Array,
         value: () => [],
       },
@@ -244,6 +257,15 @@ class ItemListElement extends Polymer.Element {
       const shadow = '0px ' + yOffset + 'px 10px -5px #ccc';
       headerContainer.style.boxShadow = shadow;
     });
+  }
+
+  _rowsChanged() {
+    this.filter = this.rows.length <= this.defaultMaxLength ? null :
+        (_: any, i: number) => i < this.defaultMaxLength;
+    // if (this.rows.length > this.defaultMaxLength) {
+    //   this._completeListShown = false;
+    //   this.filter = null;
+    // }
   }
 
   /**
@@ -415,10 +437,19 @@ class ItemListElement extends Polymer.Element {
     this.dispatchEvent(ev);
   }
 
-  private _getRowDetailsContainer(index: number) {
+  _getRowDetailsContainer(index: number) {
     const nthDivSelector = 'div.row-details:nth-of-type(' + (index + 1) + ')';
     return this.$.listContainer.querySelector(nthDivSelector);
   }
+
+  _showCompleteList() {
+    // this._completeListShown = true;
+    this.filter = null;
+  }
+
+  // _filterMethod(_: ItemListRow, index: number) {
+  //   return this._completeListShown ? true : index < this.defaultMaxLength;
+  // }
 
 }
 

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -162,11 +162,6 @@ class ItemListElement extends Polymer.Element {
   public columns: string[];
 
   /**
-   * Filter function to show a subset of the rows
-   */
-  public filter: Function|null;
-
-  /**
    * Whether to hide the header row
    */
   public hideHeader: boolean;
@@ -194,10 +189,10 @@ class ItemListElement extends Polymer.Element {
   /**
    * Number of items to show before considering the list too long.
    */
-  public readonly defaultMaxLength = 100;
+  public readonly defaultMaxLength = 50;
 
   private _lastSelectedIndex = -1;
-  // private _completeListShown = true;
+  private _completeListShown = true;
 
   static get is() { return 'item-list'; }
 
@@ -260,12 +255,7 @@ class ItemListElement extends Polymer.Element {
   }
 
   _rowsChanged() {
-    this.filter = this.rows.length <= this.defaultMaxLength ? null :
-        (_: any, i: number) => i < this.defaultMaxLength;
-    // if (this.rows.length > this.defaultMaxLength) {
-    //   this._completeListShown = false;
-    //   this.filter = null;
-    // }
+    this._completeListShown = this.rows.length < this.defaultMaxLength;
   }
 
   /**
@@ -443,14 +433,13 @@ class ItemListElement extends Polymer.Element {
   }
 
   _showCompleteList() {
-    // this._completeListShown = true;
-    this.filter = null;
+    this._completeListShown = true;
+    this.$.list.render();
   }
 
-  // _filterMethod(_: ItemListRow, index: number) {
-  //   return this._completeListShown ? true : index < this.defaultMaxLength;
-  // }
-
+  filterMethod(_: any, i: number) {
+    return this._completeListShown ? true : i < this.defaultMaxLength;
+  }
 }
 
 customElements.define(ItemListElement.is, ItemListElement);


### PR DESCRIPTION
This PR makes the item list render only a limited number of its items (for now 50), with a "Show more" experience when the user scrolls to the end. This avoids a long wait for the first render, and lets the user choose to wait on loading the entire list if desired. Ideally, we should also optimize the list itself to use virtual scrolling, this change is just a stop gap to improve the experience until we do.

![image](https://user-images.githubusercontent.com/1424661/31904961-7e9357a0-b7e1-11e7-926e-754877385273.png)
