### PR TITLE
Use mono-space font in help pane

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -575,6 +575,9 @@ div.selected .CodeMirror-linenumber, div#texteditor-container .CodeMirror-linenu
 div.modal-dialog pre, div.modal-dialog code, #help code, #help pre {
   font-size: 13px !important;
 }
+#help {
+  font-family: 'Source Code Pro';
+}
 #help pre {
   border: none;
 }

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -576,7 +576,7 @@ div.modal-dialog pre, div.modal-dialog code, #help code, #help pre {
   font-size: 13px !important;
 }
 #help {
-  font-family: 'Source Code Pro';
+  font-family: 'Source Code Pro', monospace;
 }
 #help pre {
   border: none;


### PR DESCRIPTION
Fixes https://github.com/googledatalab/datalab/issues/1443.

![image](https://user-images.githubusercontent.com/1424661/31905600-8f8cd3c2-b7e3-11e7-9d9e-e9c63abe2a81.png)
