### PR TITLE
Remove project status from auth panel

### DIFF
--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.html
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.html
@@ -50,7 +50,6 @@ the License.
       </div>
       <div id="signOutGroup" hidden="{{!_signedIn}}">
         <label id="userInfoLabel" class="infoLabel">{{_userInfo}}</label>
-        <label id="projectInfoLabel" class="infoLabel">{{_projectInfo}}</label>
         <paper-button id="signOutButton" title="Sign Out" class="signIoButton" on-click="_signOutClicked">
           Sign Out
         </paper-button>

--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
@@ -19,7 +19,6 @@
  */
 class AuthPanel extends Polymer.Element {
 
-  private _projectInfo: string;
   private _signedIn: boolean;
   private _userInfo: string;
   private _promptOnSignIn = false;
@@ -28,10 +27,6 @@ class AuthPanel extends Polymer.Element {
 
   static get properties() {
     return {
-      _projectInfo: {
-        type: String,
-        value: '',
-      },
       _signedIn: {
         type: Boolean,
         value: false,
@@ -68,7 +63,6 @@ class AuthPanel extends Polymer.Element {
       GapiManager.getSignedInEmail()
         .then((email: string) => {
           this._userInfo = 'Signed in as ' + email;
-          this._projectInfo = 'No project is set';  // TODO
 
           const ev = new Event('signInOutDone');
           this.dispatchEvent(ev);


### PR DESCRIPTION
We're currently not using this, and we don't yet have a way of storing/getting the user's preferred project.