### PR TITLE
Disable user settings by default

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -19,7 +19,6 @@ declare module common {
     theme: string,
     idleTimeoutShutdownCommand: string,
     idleTimeoutInterval: string,
-    oauth2ClientId: string,
     [index: string]: string,
   }
 
@@ -184,6 +183,11 @@ declare module common {
      * List of features that can be optinally enabled.
      */
     gatedFeatures: string[];
+
+    /**
+     * OAuth client ID to use for Google service APIs.
+     */
+    oauth2ClientId: string,
   }
 
   interface TimeoutInfo {

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -48,5 +48,5 @@
   ],
   "supportedFileBrowserSources": ["jupyter"],
   "fakeMetadataAddress": {"host": "metadata.google.internal", "port": 80},
-  "gatedFeatures": []
+  "gatedFeatures": ["timeout", "userSettings"]
 }

--- a/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.ts
+++ b/sources/web/datalab/polymer/components/datalab-editor/datalab-editor.ts
@@ -58,11 +58,13 @@ class DatalabEditorElement extends Polymer.Element {
     super.ready();
 
     // Get the theme.
-    const settings = await SettingsManager.getUserSettingsAsync()
-      .catch(() => Utils.log.error('Could not load user settings.'));
+    if (await SettingsManager.isAppFeatureEnabled(Utils.constants.features.userSettings)) {
+      const settings = await SettingsManager.getUserSettingsAsync()
+        .catch(() => Utils.log.error('Could not load user settings.'));
 
-    if (settings && settings.theme) {
-      this._theme = settings.theme;
+      if (settings && settings.theme) {
+        this._theme = settings.theme;
+      }
     }
 
     // Create the codemirror element and fill it with the file content.

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -95,11 +95,11 @@ the License.
         </div>
         <div class="right">
           <paper-icon-button id="infoButton" icon="info"
-                            on-click="_infoClicked"></paper-icon-button>
-          <paper-icon-button id="settingsButton" icon="settings"
-                            on-click="_settingsClicked"></paper-icon-button>
+                             on-click="_infoClicked"></paper-icon-button>
+          <paper-icon-button id="settingsButton" icon="settings" on-click="_settingsClicked"
+                             hidden="{{!_userSettingsEnabled}}"></paper-icon-button>
           <paper-icon-button id="accountButton" icon="account-circle"
-                            on-click="_accountIconClicked">
+                             on-click="_accountIconClicked">
           </paper-icon-button>
         </div>
       </app-toolbar>

--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.ts
@@ -21,12 +21,14 @@
 class ToolbarElement extends Polymer.Element {
 
   private _timeoutEnabled: boolean;
+  private _userSettingsEnabled: boolean;
 
   static get is() { return 'datalab-toolbar'; }
 
   static get properties() {
     return {
       _timeoutEnabled: Boolean,
+      _userSettingsEnabled: Boolean,
     };
   }
 
@@ -34,7 +36,9 @@ class ToolbarElement extends Polymer.Element {
     super.ready();
 
     this._timeoutEnabled = await SettingsManager.isAppFeatureEnabled(
-        Utils.constants.timeoutFeature);
+        Utils.constants.features.timeout);
+    this._userSettingsEnabled = await SettingsManager.isAppFeatureEnabled(
+        Utils.constants.features.userSettings);
 
     if (this._timeoutEnabled) {
       const authPanel = this.shadowRoot.querySelector('auth-panel');
@@ -49,12 +53,16 @@ class ToolbarElement extends Polymer.Element {
    */
   _accountIconClicked() {
     this.$.accountDropdown.toggle();
-    this.$.accountTimeoutPanel.onOpenChange(this.$.accountDropdown.opened);
+    if (this._timeoutEnabled) {
+      this.$.accountTimeoutPanel.onOpenChange(this.$.accountDropdown.opened);
+    }
   }
 
   _closeAccountDropdown() {
     this.$.accountDropdown.close();
-    this.$.accountTimeoutPanel.onOpenChange(false);
+    if (this._timeoutEnabled) {
+      this.$.accountTimeoutPanel.onOpenChange(false);
+    }
   }
 
   /**
@@ -68,8 +76,10 @@ class ToolbarElement extends Polymer.Element {
    * Opens the settings dialog
    */
   _settingsClicked() {
-    this.$.settingsDialog.open();
-    this.$.settingsElement.loadSettings();
+    if (this._userSettingsEnabled) {
+      this.$.settingsDialog.open();
+      this.$.settingsElement.loadSettings();
+    }
   }
 }
 

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -1141,16 +1141,22 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       }
     }
 
+    const type = FileManagerFactory.fileManagerNameToType(this.fileManagerType);
+    const config = FileManagerFactory.getFileManagerConfig(type);
+
     // Always add the root file to the beginning.
-    const root = await this._fileManager.getRootFile();
+    const root = await this._fileManager.getRootFile()
+      .catch((e) => {
+          Utils.showErrorDialog('Error', 'Could not load files from ' +
+              config.displayName + ': ' + e);
+          throw e;
+        });
     this._pathHistory.unshift(root);
     if (this._pathHistoryIndex === this._pathHistory.length - 1) {
       this._pathHistoryIndexChanged();
     } else {
       this._pathHistoryIndex = this._pathHistory.length - 1;
     }
-    const type = FileManagerFactory.fileManagerNameToType(this.fileManagerType);
-    const config = FileManagerFactory.getFileManagerConfig(type);
     this._fileManagerDisplayIcon = config.displayIcon;
     this._fileManagerDisplayName = config.displayName;
   }

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -1147,10 +1147,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     // Always add the root file to the beginning.
     const root = await this._fileManager.getRootFile()
       .catch((e) => {
-          Utils.showErrorDialog('Error', 'Could not load files from ' +
-              config.displayName + ': ' + e);
-          throw e;
-        });
+        Utils.showErrorDialog('Error', 'Could not load files from ' +
+            config.displayName + ': ' + e);
+        throw e;
+      });
     this._pathHistory.unshift(root);
     if (this._pathHistoryIndex === this._pathHistory.length - 1) {
       this._pathHistoryIndexChanged();

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -34,7 +34,11 @@ class Utils {
     notebookUrlComponent: '/notebook/',
 
     // Feature names
-    timeoutFeature:       'timeout',
+    // tslint:disable-next-line:object-literal-sort-keys
+    features: {
+      timeout: 'timeout',
+      userSettings: 'userSettings',
+    },
   };
 
   /**

--- a/sources/web/datalab/polymer/test/datalab-toolbar-test.ts
+++ b/sources/web/datalab/polymer/test/datalab-toolbar-test.ts
@@ -21,13 +21,47 @@
 describe('<table-preview>', () => {
   let testFixture: ToolbarElement;
 
-  beforeEach(() => {
+  before(() => {
+    SettingsManager.getAppSettingsAsync = () => {
+      const mockSettings: common.AppSettings = {
+        allowHttpOverWebsocket: true, allowOriginOverrides: [], configUrl:
+        '', consoleLogLevel: 'verbose', consoleLogging: true, contentDir: '',
+        datalabBasePath: '', datalabRoot: '', defaultFileManager: 'mock',
+        docsGcsPath: '', enableAutoGCSBackups: true, enableFilesystemIndex:
+        true, fakeMetadataAddress: {host: 'metadata.google.internal', port:
+        80}, feedbackId: '', gatedFeatures: ['userSettings'],
+        idleTimeoutInterval: '', idleTimeoutShutdownCommand: '', instanceId:
+        '', jupyterArgs: [''], knownTutorialsUrl: '', logEndpoint: '',
+        logFileCount: 0, logFilePath: '', logFilePeriod: '', metadataHost:
+        '', nextJupyterPort: 0, numDailyBackups: 0, numHourlyBackups: 0,
+        numWeeklyBackups: 0, oauth2ClientId: '', proxyWebSockets: '',
+        release: '', serverPort: 0, socketioPort: 0, supportUserOverride:
+        true, supportedFileBrowserSources: [''], useWorkspace: true,
+        versionId: '',
+      };
+      return Promise.resolve(mockSettings);
+    };
+    SettingsManager.getUserSettingsAsync = () => {
+      return Promise.resolve({
+        idleTimeoutInterval: '',
+        idleTimeoutShutdownCommand: '',
+        startuppath: '',
+        theme: '',
+      });
+    };
+  });
+
+  beforeEach((done) => {
     GapiManager.listenForSignInChanges = () => Promise.resolve();
     ApiManager.getBasePath = () => {
       return Promise.resolve('testbase');
     };
 
     testFixture = fixture('toolbar-fixture');
+    testFixture.ready().then(() => {
+      Polymer.dom.flush();
+      done();
+    });
   });
 
   it('opens and closes account menu', () => {
@@ -39,35 +73,25 @@ describe('<table-preview>', () => {
     assert(!testFixture.$.accountDropdown.opened, 'account dropdown should close on click');
   });
 
-  it('opens and closes info dialog', (done) => {
-    let hasOpened = false;
-
-    testFixture.$.infoDialog.addEventListener('iron-overlay-closed', () => {
-      assert(hasOpened, 'dialog should have opened on first click');
-      done();
-    });
-
-    testFixture.$.infoDialog.addEventListener('iron-overlay-opened', () => {
-      hasOpened = true;
-      testFixture.$.infoButton.click();
-    });
-
+  it('opens and closes info dialog', () => {
     testFixture.$.infoButton.click();
+    assert(testFixture.$.infoDialog.opened, 'info dropdown should open on click');
+
+    // Click the close button and make sure it also closes the dialog.
+    const closeButton = testFixture.$.infoDialog.querySelector('paper-button');
+    closeButton.click();
+    assert(!testFixture.$.infoDialog.opened,
+        'info dialog should close on clicking close button');
   });
 
-  it('opens and closes settings dialog', (done) => {
-    let hasOpened = false;
-
-    testFixture.$.settingsDialog.addEventListener('iron-overlay-closed', () => {
-      assert(hasOpened, 'dialog should have opened on first click');
-      done();
-    });
-
-    testFixture.$.settingsDialog.addEventListener('iron-overlay-opened', () => {
-      hasOpened = true;
-      testFixture.$.settingsButton.click();
-    });
-
+  it('opens and closes settings dialog', () => {
     testFixture.$.settingsButton.click();
+    assert(testFixture.$.settingsDialog.opened, 'info dropdown should open on click');
+
+    // Click the close button and make sure it also closes the dialog.
+    const closeButton = testFixture.$.settingsDialog.querySelector('paper-button');
+    closeButton.click();
+    assert(!testFixture.$.settingsDialog.opened,
+        'settings dialog should close on clicking close button');
   });
 });

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -50,7 +50,6 @@ describe('<file-browser>', () => {
       const mockSettings: common.UserSettings = {
         idleTimeoutInterval: '',
         idleTimeoutShutdownCommand: '',
-        oauth2ClientId: '',
         startuppath: startuppath.path,
         theme: 'light',
       };


### PR DESCRIPTION
Until we have a good user settings story, this disables the option, unless it's explicitly enabled in the app settings. This change explicitly enables it to keep the current behavior.

This required the optional oauth2 client id to move from user settings to app settings in order not to break the local development story.