### PR TITLE
Fix editor script load issue

### DIFF
--- a/sources/web/datalab/polymer/editor.html
+++ b/sources/web/datalab/polymer/editor.html
@@ -24,7 +24,6 @@ the License.
 
     <link rel="import" href="{base_url}components/datalab-app/datalab-app.html">
     <link rel="import" href="{base_url}components/datalab-editor/datalab-editor.html">
-    <link rel="import" href="{base_url}modules/utils/utils.html">
     <link id="themeStylesheet" rel="stylesheet" href="{base_url}index.css">
   </head>
   <body>
@@ -46,6 +45,6 @@ the License.
 
     <datalab-editor></datalab-editor>
 
-    <script src="editor.js"></script>
+    <script src="{base_url}editor.js"></script>
   </body>
 </html>

--- a/sources/web/datalab/polymer/notebook.html
+++ b/sources/web/datalab/polymer/notebook.html
@@ -29,6 +29,6 @@
     <paper-toast id="datalabNotification" text="Creating notebook..." duration="0"></paper-toast>
     <iframe id="editor" sandbox="allow-forms allow-scripts allow-popups allow-modals allow-popups-to-escape-sandbox allow-same-origin"></iframe>
 
-    <script src="notebook.js"></script>
+    <script src="{base_url}notebook.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Editor script load was failing because of the missing base_url placeholder.