### PR TITLE
Initialize the fake metadata account to be empty

### DIFF
--- a/sources/web/datalab/metadata.ts
+++ b/sources/web/datalab/metadata.ts
@@ -38,7 +38,7 @@ const metadata: FakeMetadata = {
   project: process.env.PROJECT_ID,
   project_number: process.env.PROJECT_NUMBER,
   creds: {
-    account: process.env.DATALAB_GIT_AUTHOR,
+    account: "",
     scopes: "",
     access_token: "",
     expires_in: 0,


### PR DESCRIPTION
This fixes a race condition that can occur if the process.env.DATALAB_GIT_AUTHOR environment variable is not set.