### PR TITLE
Extend the reconnection message with more details.

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -245,8 +245,8 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
         Args:
           cancelled_event: A threading.Event instance that indicates we should
             give up on the instance becoming reachable.
-          healthy_event: A threading.Event instance that can be used to indicate
-            that the instance became reachable.
+          healthy_event: A threading.Event instance that can be used to
+            indicate that the instance became reachable.
         """
         health_url = '{0}_info/'.format(datalab_address)
         healthy = False
@@ -271,8 +271,8 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
         This method blocks for as long as the connection is open.
 
         Args:
-          healthy_event: A threading.Event instance that can be used to indicate
-            that the instance became reachable.
+          healthy_event: A threading.Event instance that can be used to
+            indicate that the instance became reachable.
         Returns:
           True iff the Datalab instance became reachable.
         Raises:

--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -23,7 +23,7 @@ import webbrowser
 import utils
 
 
-description = ("""`{0} {1}` creates a persistent connection to a
+description = """`{0} {1}` creates a persistent connection to a
 Datalab instance running in a Google Compute Engine VM.
 
 This is a thin wrapper around the *ssh(1)* command that takes care
@@ -42,16 +42,16 @@ the --no-launch-browser flag.
 This command will attempt to re-establish the connection if it
 gets dropped. However, that connection will only exist while
 this command is running.
-""")
+"""
 
 
-examples = ("""
+examples = """
 To connect to 'example-instance' in zone 'us-central1-a', run:
 
-    $ {0} {1} example-instance --zone us-central1-a""")
+    $ {0} {1} example-instance --zone us-central1-a"""
 
 
-wrong_user_message = (
+wrong_user_message_template = (
     'The specified Datalab instance was created for {0}, but you '
     'are attempting to connect to it as {1}.'
     '\n\n'
@@ -62,18 +62,18 @@ wrong_user_message = (
     '--no-user-checking flag.')
 
 
-web_preview_message = (
+web_preview_message_template = (
     'Click on the *Web Preview* (square button at top-right), '
     'select *Change port > Port {}*, and start using Datalab.')
 
 
-connection_closed_message = ("""
+connection_closed_message_template = """
 Connection closed.
 
 To re-connect to your datalab instance, run the following command:
 
     datalab connect{1}{0}
-""")
+"""
 
 
 # The list of web browsers that we don't want to automatically open.
@@ -185,7 +185,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
           KeyboardInterrupt: When the end user kills the connection
           subprocess.CalledProcessError: If the connection dies on its own
         """
-        if utils.print_info_messages(args):
+        if utils.print_info_message_templates(args):
             print('Connecting to {0} via SSH').format(instance)
 
         cmd = ['ssh']
@@ -227,7 +227,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
         print('\nThe connection to Datalab is now open and will '
               'remain until this command is killed.')
         if in_cloud_shell:
-            print(web_preview_message.format(datalab_port))
+            print(web_preview_message_template.format(datalab_port))
         else:
             print('You can connect to Datalab at ' + datalab_address)
             if not args.no_launch_browser:
@@ -305,7 +305,8 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
                 if args.zone:
                     cli_flags += '--zone {} '.format(args.zone)
                 cli_flags += '--port {} '.format(args.port)
-                print(connection_closed_message.format(instance, cli_flags))
+                print(connection_closed_message_template.format(
+                    instance, cli_flags))
             return
         if remaining_reconnects == 0:
             return
@@ -335,7 +336,7 @@ def maybe_start(args, gcloud_compute, instance, status):
       subprocess.CalledProcessError: If one of the `gcloud` calls fail
     """
     if status != _STATUS_RUNNING:
-        if utils.print_info_messages(args):
+        if utils.print_info_message_templates(args):
             print('Restarting the instance {0} with status {1}'.format(
                 instance, status))
         start_cmd = ['instances', 'start']
@@ -363,7 +364,7 @@ def run(args, gcloud_compute, email='', in_cloud_shell=False, **unused_kwargs):
         args, gcloud_compute, instance)
     for_user = metadata_items.get('for-user', '')
     if (not args.no_user_checking) and for_user and (for_user != email):
-        print(wrong_user_message.format(for_user, email))
+        print(wrong_user_message_template.format(for_user, email))
         return
 
     maybe_start(args, gcloud_compute, instance, status)


### PR DESCRIPTION
This builds on the change from #1759 and extends it so that the printed command
can be directly copied and pasted in order to reconnect.

This introduces the potential to give the user a command to run that won't actually
work (e.g. if their connection failed due to the specified port being unavailable).

To prevent that risk, I've changed the reconnection message so that we only print
it if the initial connection succeeded.

This closes #1519