### PR TITLE
Fix race condition in gapi code.

### DIFF
--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.html
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.html
@@ -14,6 +14,7 @@ the License.
 
 <link rel="import" href="../../components/shared-styles/shared-styles.html">
 <link rel="import" href="../../modules/gapi-manager/gapi-manager.html">
+<link rel="import" href="../../modules/utils/utils.html">
 
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
 

--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
@@ -42,8 +42,8 @@ class AuthPanel extends Polymer.Element {
   ready() {
     super.ready();
     GapiManager.listenForSignInChanges(this._signInChanged.bind(this))
-      .catch(() => {
-        // TODO: handle errors authenticating
+      .catch((e) => {
+        Utils.showErrorDialog('Authentication error', e.message);
       });
   }
 

--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -440,21 +440,22 @@ class GapiManager {
   * Initialize the client with API key and People API, and initialize OAuth with an
   * OAuth 2.0 client ID and scopes (space delimited string) to request access.
   */
-  private static _initClient() {
+  private static _initClient(): Promise<void> {
     // TODO: Add state parameter to redirect the user back to the current URL
     // after the OAuth flow finishes.
-    try {
-      const auth2 = gapi.auth2.init({
-        client_id: GapiManager._clientId,
-        fetch_basic_profile: true,
-        redirect_uri: Utils.getHostRoot(),
-        scope: initialScopeString,
-        ux_mode: 'redirect',
-      });
-      this._currentUser = auth2.currentUser.get();
-    } catch (e) {
-      throw new Error('Error in gapi auth: ' + e.details);
-    }
+    return gapi.auth2.init({
+      client_id: GapiManager._clientId,
+      fetch_basic_profile: true,
+      redirect_uri: Utils.getHostRoot(),
+      scope: initialScopeString,
+      ux_mode: 'redirect',
+    })
+    // The return value of gapi.auth2.init is not a normal promise
+    .then(() => {
+      this._currentUser = gapi.auth2.getAuthInstance().currentUser.get();
+    }, (errorReason: any) => {
+      throw new Error('Error in gapi auth: ' + errorReason.details);
+    });
   }
 
   /**


### PR DESCRIPTION
This rolls back a piece of #1777. The key issue is that we need to use a 'then' on the return from api.auth2.init before we grab the currentUser to avoid sometimes getting a null result.
The user-visible symptom of this problem is an error dialog saying 'Cannot read property getEmail of undefined.'

I also added code to catch and display an auth error from this updated code. Here is what that looks like for a bad client ID:
![datalab-auth-error](https://user-images.githubusercontent.com/116825/32290765-45fca414-bef8-11e7-936e-be911890efe9.png)
