### PR TITLE
Require typescript 2.5.x.

### DIFF
--- a/sources/web/datalab/polymer/package.json
+++ b/sources/web/datalab/polymer/package.json
@@ -21,6 +21,6 @@
     "bower": "^1.8.2",
     "polymer-cli": "^1.5.7",
     "tslint": "^5.7.0",
-    "typescript": "^2.5.3"
+    "typescript": "~2.5.3"
   }
 }


### PR DESCRIPTION
Typescript 2.6 was [released today](https://blogs.msdn.microsoft.com/typescript/2017/10/31/announcing-typescript-2-6/), and now [considers write-only references unused](https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#write-only-references-are-unused). This leads to a build break for Datalab, as there are several write-only references.

This PR just tweaks things by requiring Typescript `>= 2.5.3,<2.6.0`.

PTAL @jimmc @yebrahim @chmeyers @ojarjur 