### PR TITLE
Pin web-component-tester to version 6.3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,4 @@ script:
 - for i in `ls ui/broken/`; do echo ui/broken/$i; base64 ui/broken/$i; echo \"-----\"; done
 - cd ../sources/web/datalab/polymer/test
 - export DISPLAY=:99.0
-# Disabling these tests because they are hanging during cleanup.
-#- npm test -- --verbose -l chrome
+- npm test -- --verbose -l chrome

--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -28,6 +28,6 @@
     "xterm.js": "^2.7.0"
   },
   "devDependencies": {
-    "web-component-tester": "^6.0.0"
+    "web-component-tester": "~6.3.0"
   }
 }

--- a/sources/web/datalab/polymer/package.json
+++ b/sources/web/datalab/polymer/package.json
@@ -19,6 +19,7 @@
     "@types/mocha": "^2.2.41",
     "@types/socket.io-client": "^1.4.30",
     "bower": "^1.8.2",
+    "web-component-tester": "~6.3.0",
     "polymer-cli": "^1.5.7",
     "tslint": "^5.7.0",
     "typescript": "^2.5.3"


### PR DESCRIPTION
Yesterday, a new version of web-component-tester (6.4.0) was released,
and after that release our selenium tests (which run inside of
web-component-tester) started hanging forever.

Pinning to the older version seems to fix this issue.

There is one subtle issue where polymer_cli was installing the latest
version of web-component-tester, so the tests still failed even if we
later installed the older version. We avoid that issue by installing
the older version of web-component-tester before polymer_cli.