### PR TITLE
Require a consent prompt when asking for extra scopes.

### DIFF
--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -339,6 +339,7 @@ class GapiManager {
       return new Promise((resolve, reject) => {
         const options = new gapi.auth2.SigninOptionsBuilder();
         options.setScope(this._getScopeString(scope));
+        options.setPrompt('consent');
         gapi.auth2.getAuthInstance().signIn(options)
           .then(() => {
             resolve();


### PR DESCRIPTION
Otherwise this will endlessly refresh loop if no consent is given.