### PR TITLE
Sanitize param values sent to the template creator.

### DIFF
--- a/sources/web/datalab/polymer/modules/template-manager/template-manager.ts
+++ b/sources/web/datalab/polymer/modules/template-manager/template-manager.ts
@@ -44,7 +44,20 @@ class NotebookTemplate {
 
   constructor(fileId: DatalabFileId, parameters: TemplateParameter[]) {
     this.fileId = fileId;
-    this.parameters = parameters;
+    this.parameters = NotebookTemplate._sanitizeParams(parameters);
+  }
+
+  /**
+   * Strictly sanitizes the parameters.
+   */
+  private static _sanitizeParams(params: TemplateParameter[]) {
+    params.forEach((p: TemplateParameter, i) => {
+      params[i].name = p.name.replace(/[^A-Za-z0-9._\-]/g, '');
+      if (typeof p.value === 'string') {
+        params[i].value = p.value.replace(/[^A-Za-z0-9._\-]/g, '');
+      }
+    });
+    return params;
   }
 
   /**


### PR DESCRIPTION
I'm taking a deliberatly aggressive approach here since we don't
currently have a use case where any special characters should be
needed in these strings.