### PR TITLE
Restore name and path in github DatalabFile fields.

### DIFF
--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
@@ -99,6 +99,13 @@ class GithubFileManager extends BaseFileManager {
     const githubPath = await this._githubPathForFileId(fileId, 'get');
     return this._githubApiPathRequest(githubPath)
         .then((response: GhFileResponse) => {
+          // Put in the fields that the blob API doesn't populate
+          if (!response.name) {
+            response.name = fileId.path.split('/').pop() || '';
+          }
+          if (!response.path) {
+            response.path = fileId.path;
+          }
           return this._ghFileToDatalabFile(response);
         });
   }


### PR DESCRIPTION
These fields are not set by the github blob API.

Before (since the blob API change):
![github-name-before](https://user-images.githubusercontent.com/116825/32394610-ee75f034-c09a-11e7-8555-eedc64a78a57.png)

After this fix (restored to how it used to be):
![github-name-after](https://user-images.githubusercontent.com/116825/32394563-c4520eb4-c09a-11e7-84f6-b4ff5447b45e.png)
