### PR TITLE
Enable Delete when multiple files selected

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -138,15 +138,15 @@ the License.
 
         <!--Default Add toolbar, contains Add buttons for notebook, file, and folder-->
         <span id="addToolbar">
-          <paper-button class="toolbar-button" on-click="_createNewNotebook">
+          <paper-button id="addNotebookButton" class="toolbar-button" on-click="_createNewNotebook">
             <iron-icon icon="add-box"></iron-icon>
             <span>Notebook</span>
           </paper-button>
-          <paper-button class="toolbar-button" on-click="_createNewFile">
+          <paper-button id="addFileButton" class="toolbar-button" on-click="_createNewFile">
             <iron-icon icon="add-box"></iron-icon>
             <span>File</span>
           </paper-button>
-          <paper-button class="toolbar-button" on-click="_createNewDirectory">
+          <paper-button id="addFolderButton" class="toolbar-button" on-click="_createNewDirectory">
             <iron-icon icon="add-box"></iron-icon>
             <span>Folder</span>
           </paper-button>
@@ -166,37 +166,35 @@ the License.
 
         <!--Default Update toolbar, contains buttons to modify files/folders-->
         <span id="updateToolbar">
-          <paper-button class="toolbar-button" on-click="_altUpload">
+          <paper-button id="uploadButton" class="toolbar-button" on-click="_altUpload">
             <iron-icon icon="file-upload"></iron-icon>
             <span>Upload</span>
           </paper-button>
           <!--This is hidden but its functionality is used by the alt upload button above-->
           <input type="file" id="altFileUpload" multiple style="display: none"
                  on-change="_upload">
-          <paper-button class="toolbar-button" on-click="_openSelectedInEditor"
-                        disabled$={{!selectedFile}}>
+          <paper-button id="editAsTextButton" class="toolbar-button"
+                        on-click="_openSelectedInEditor" disabled$={{!selectedFile}}>
             <iron-icon icon="editor:short-text"></iron-icon>
             <span>Edit as Text</span>
           </paper-button>
-          <paper-button class="toolbar-button" on-click="_copySelectedItem"
+          <!--TODO: Enable copy/move buttons when multiple files are selected-->
+          <paper-button id="copyButton" class="toolbar-button" on-click="_copySelectedItem"
                         disabled$={{!selectedFile}}>
             <iron-icon icon="content-copy"></iron-icon>
             <span>Copy</span>
           </paper-button>
-          <paper-button class="toolbar-button" on-click="_moveSelectedItem"
+          <paper-button id="moveButton" class="toolbar-button" on-click="_moveSelectedItem"
                         disabled$={{!selectedFile}}>
             <iron-icon icon="redo"></iron-icon>
             <span>Move</span>
           </paper-button>
-          <paper-button class="toolbar-button" on-click="_renameSelectedItem"
+          <paper-button id="renameButton" class="toolbar-button" on-click="_renameSelectedItem"
                         disabled$={{!selectedFile}}>
             <iron-icon icon="editor:border-color"></iron-icon>
             <span>Rename</span>
           </paper-button>
-          <!--TODO: Delete operation supports deleting multiple files, but we'll
-          only enable the button when one file is selected for now, until we get
-          the group moving/copying functionality too-->
-          <paper-button class="toolbar-button" on-click="_deleteSelectedItems"
+          <paper-button id="deleteButton" class="toolbar-button" on-click="_deleteSelectedItems"
                         disabled$=[[!_selectedFilesLength]]>
             <iron-icon icon="delete"></iron-icon>
             <span>Delete</span>

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.html
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.html
@@ -197,7 +197,7 @@ the License.
           only enable the button when one file is selected for now, until we get
           the group moving/copying functionality too-->
           <paper-button class="toolbar-button" on-click="_deleteSelectedItems"
-                        disabled$={{!selectedFile}}>
+                        disabled$=[[!_selectedFilesLength]]>
             <iron-icon icon="delete"></iron-icon>
             <span>Delete</span>
           </paper-button>

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -86,6 +86,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
   _fetching: boolean; // Indicates the file list is being fetched and updated
   _fileManagerDisplayName: string;
   _fileManagerDisplayIcon: string;
+  _selectedFilesLength: number;
 
   private _addToolbarCollapseThreshold = 900;
   private _dividerPosition: number;
@@ -151,6 +152,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
         observer: '_pathHistoryIndexChanged',
         type: Number,
         value: -1,
+      },
+      _selectedFilesLength: {
+        type: Number,
+        value: 0,
       },
       _showProgressBar: {
         computed: '_computeShowProgressBar(_fetching, _busy)'
@@ -516,6 +521,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
    */
   _handleSelectionChanged() {
     const selectedIndices = (this.$.files as ItemListElement).selectedIndices;
+    this._selectedFilesLength = selectedIndices.length;
     const newSelectedFile = (selectedIndices.length === 1) ?
         this._fileList[selectedIndices[0]] : null;
     if (newSelectedFile !== this.selectedFile) {

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -63,7 +63,8 @@ window.addEventListener('WebComponentsReady', () => {
 
     function assertEnabledState(id: string, enabled: boolean) {
       const button = testFixture.$[id] as HTMLElement;
-      assert(button.hasAttribute('disabled') === !enabled, id + ' is expected to be enabled');
+      assert(button.hasAttribute('disabled') === !enabled,
+          id + ' is expected to be ' + enabled ? 'enabled' : 'disabled');
     }
 
     before(() => {
@@ -165,33 +166,33 @@ window.addEventListener('WebComponentsReady', () => {
 
       await TestUtils.cancelDialog(dialog);
     });
-  });
 
-  it('enables always-enabled buttons, disables the rest when no file is selected', () => {
-    const files: ItemListElement = testFixture.$.files;
-    files._unselectAll();
-    alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
-    singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
-    multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
-  });
+    it('enables always-enabled buttons, disables the rest when no file is selected', () => {
+      const files: ItemListElement = testFixture.$.files;
+      files._unselectAll();
+      alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+      singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
+      multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
+    });
 
-  it('enables all buttons when one file is selected', () => {
-    const files: ItemListElement = testFixture.$.files;
-    files._unselectAll();
-    files._selectItem(0);
-    alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
-    singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
-    multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
-  });
+    it('enables all buttons when one file is selected', () => {
+      const files: ItemListElement = testFixture.$.files;
+      files._unselectAll();
+      files._selectItem(0);
+      alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+      singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+      multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+    });
 
-  it(`enables always enabled and multi-selection enabled buttons, and
-      disables the rest when two files are selected`, () => {
-    const files: ItemListElement = testFixture.$.files;
-    files._unselectAll();
-    files._selectItem(0);
-    files._selectItem(1);
-    alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
-    singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
-    multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+    it(`enables always enabled and multi-selection enabled buttons, and
+        disables the rest when two files are selected`, () => {
+      const files: ItemListElement = testFixture.$.files;
+      files._unselectAll();
+      files._selectItem(0);
+      files._selectItem(1);
+      alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+      singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
+      multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+    });
   });
 });

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -44,19 +44,26 @@ describe('<file-browser>', () => {
     new MockFile('file3'),
   ];
 
-  const fileAddButtonIds = [
+  const alwaysEnabledButtonIds = [
     'newNotebookButton',
     'newFileButton',
     'newFolderButton',
-  ];
-  const fileOpsButtonIds = [
     'uploadButton',
+  ];
+  const singleSelectionEnabledButtonIds = [
     'editAsTextButton',
     'copyButton',
     'moveButton',
     'renameButton',
+  ];
+  const multiSelectionEnabledButtonIds = [
     'deleteButton',
   ];
+
+  function assertEnabledState(id: string, enabled: boolean) {
+    const button = testFixture.$[id] as HTMLElement;
+    assert(button.hasAttribute('disabled') === !enabled, id + ' is expected to be enabled');
+  }
 
   before(() => {
     SettingsManager.getUserSettingsAsync = (forceRefresh: boolean) => {
@@ -151,56 +158,31 @@ describe('<file-browser>', () => {
     await TestUtils.cancelDialog(dialog);
   });
 
-  it('file operations are disabled when no items selected', () => {
+  it('enables always-enabled buttons, disables the rest when no file is selected', () => {
     const files: ItemListElement = testFixture.$.files;
     files._unselectAll();
-    fileAddButtonIds.forEach((id) => {
-      const button = testFixture.$[id] as HTMLElement;
-      assert(!button.hasAttribute('disabled'), id + ' button should always be enabled');
-    });
-    fileOpsButtonIds.forEach((id) => {
-      const button = testFixture.$[id] as HTMLElement;
-      if (id === 'uploadButton') {
-        assert(!button.hasAttribute('disabled'), 'upload button should always be enabled');
-      } else {
-        assert(button.hasAttribute('disabled'), id + ' should be disabled when no items selected');
-      }
-    });
+    alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+    singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
+    multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
   });
 
-  it('enables file operation buttons when one item is selected', () => {
+  it('enables all buttons when one file is selected', () => {
     const files: ItemListElement = testFixture.$.files;
     files._unselectAll();
     files._selectItem(0);
-    fileAddButtonIds.forEach((id) => {
-      const button = testFixture.$[id] as HTMLElement;
-      assert(!button.hasAttribute('disabled'), id + ' button should always be enabled');
-    });
-    fileOpsButtonIds.forEach((id) => {
-      const button = testFixture.$[id] as HTMLElement;
-      assert(!button.hasAttribute('disabled'),
-          id + ' button should be enabled when one item selected');
-    });
+    alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+    singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+    multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
   });
 
-  it('enables only delete file button when more than one item is selected', () => {
+  it(`enables always enabled and multi-selection enabled buttons, and
+      disables the rest when two files are selected`, () => {
     const files: ItemListElement = testFixture.$.files;
     files._unselectAll();
     files._selectItem(0);
     files._selectItem(1);
-    fileAddButtonIds.forEach((id) => {
-      const button = testFixture.$[id] as HTMLElement;
-      assert(!button.hasAttribute('disabled'), id + ' button should always be enabled');
-    });
-    fileOpsButtonIds.forEach((id) => {
-      const button = testFixture.$[id] as HTMLElement;
-      if (id === 'uploadButton' || id === 'deleteButton') {
-        assert(!button.hasAttribute('disabled'),
-            id + ' should be enabled if more than one item selected');
-      } else {
-        assert(button.hasAttribute('disabled'),
-            id + ' should be disabled when more than one item selected');
-      }
-    });
-  });	
+    alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+    singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
+    multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
+  });
 });

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -74,6 +74,8 @@ window.addEventListener('WebComponentsReady', () => {
           idleTimeoutShutdownCommand: '',
           startuppath: startuppath.path,
           theme: 'light',
+        };
+        return Promise.resolve(mockSettings);
       };
       ApiManager.getBasePath = () => {
         return Promise.resolve('');

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -44,6 +44,20 @@ describe('<file-browser>', () => {
     new MockFile('file3'),
   ];
 
+  const fileAddButtonIds = [
+    'addNotebookButton',
+    'addFileButton',
+    'addFolderButton',
+  ];
+  const fileOpsButtonIds = [
+    'uploadButton',
+    'editAsTextButton',
+    'copyButton',
+    'moveButton',
+    'renameButton',
+    'deleteButton',
+  ];
+
   before(() => {
     SettingsManager.getUserSettingsAsync = (forceRefresh: boolean) => {
       assert(forceRefresh === true, 'file-browser should refresh settings on load');
@@ -98,6 +112,59 @@ describe('<file-browser>', () => {
     const files: ItemListElement = testFixture.$.files;
     files.rows.forEach((row: ItemListRow, i: number) => {
       assert(!row.selected, 'file ' + i + ' should not be selected');
+    });
+  });
+
+  it('file operations are disabled when no items selected', () => {
+    const files: ItemListElement = testFixture.$.files;
+    files._unselectAll();
+    fileAddButtonIds.forEach((id) => {
+      const button = testFixture.$[id] as HTMLElement;
+      assert(!button.hasAttribute('disabled'), id + ' button should always be enabled');
+    });
+    fileOpsButtonIds.forEach((id) => {
+      const button = testFixture.$[id] as HTMLElement;
+      if (id === 'uploadButton') {
+        assert(!button.hasAttribute('disabled'), 'upload button should always be enabled');
+      } else {
+        assert(button.hasAttribute('disabled'), id + ' should be disabled when no items selected');
+      }
+    });
+  });
+
+  it('enables file operation buttons when one item is selected', () => {
+    const files: ItemListElement = testFixture.$.files;
+    files._unselectAll();
+    files._selectItem(0);
+    fileAddButtonIds.forEach((id) => {
+      const button = testFixture.$[id] as HTMLElement;
+      assert(!button.hasAttribute('disabled'), id + ' button should always be enabled');
+    });
+    fileOpsButtonIds.forEach((id) => {
+      const button = testFixture.$[id] as HTMLElement;
+      assert(!button.hasAttribute('disabled'),
+          id + ' button should be enabled when one item selected');
+    });
+  });
+
+  it('enables only delete file button when more than one item is selected', () => {
+    const files: ItemListElement = testFixture.$.files;
+    files._unselectAll();
+    files._selectItem(0);
+    files._selectItem(1);
+    fileAddButtonIds.forEach((id) => {
+      const button = testFixture.$[id] as HTMLElement;
+      assert(!button.hasAttribute('disabled'), id + ' button should always be enabled');
+    });
+    fileOpsButtonIds.forEach((id) => {
+      const button = testFixture.$[id] as HTMLElement;
+      if (id === 'uploadButton' || id === 'deleteButton') {
+        assert(!button.hasAttribute('disabled'),
+            id + ' should be enabled if more than one item selected');
+      } else {
+        assert(button.hasAttribute('disabled'),
+            id + ' should be disabled when more than one item selected');
+      }
     });
   });
 });


### PR DESCRIPTION
The Delete operation already supports multiple files, this PR just enables it in the UI when more than one file is selected.