### PR TITLE
Fix file-browser tests for firefox, enable firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ script:
 - for i in `ls ui/broken/`; do echo ui/broken/$i; base64 ui/broken/$i; echo \"-----\"; done
 - cd ../sources/web/datalab/polymer/test
 - export DISPLAY=:99.0
-- npm test -- --verbose -l chrome
+- npm test -- --verbose

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -12,92 +12,94 @@
  * the License.
  */
 
-class MockFile extends DatalabFile {
-  constructor(name = '', path = '') {
-    super({
-      getInlineDetailsName: () => '',
-      getPreviewName: () => '',
-      icon: '',
-      id: new DatalabFileId(path, FileManagerType.MOCK),
-      name,
-      type: DatalabFileType.DIRECTORY,
-    });
-  }
-}
-
-class MockFileManager extends BaseFileManager {
-  public async getRootFile() {
-    return new MockFile('root');
-  }
-  public pathToPathHistory(path: string): DatalabFile[] {
-    return [new MockFile('', path)];
-  }
-}
-
-describe('<file-browser>', () => {
-  let testFixture: FileBrowserElement;
-  const startuppath = new DatalabFileId('testpath', FileManagerType.MOCK);
-
-  const mockFiles = [
-    new MockFile('file1'),
-    new MockFile('file2'),
-    new MockFile('file3'),
-  ];
-
-  before(() => {
-    SettingsManager.getUserSettingsAsync = (forceRefresh: boolean) => {
-      assert(forceRefresh === true, 'file-browser should refresh settings on load');
-      const mockSettings: common.UserSettings = {
-        idleTimeoutInterval: '',
-        idleTimeoutShutdownCommand: '',
-        startuppath: startuppath.path,
-        theme: 'light',
-      };
-      return Promise.resolve(mockSettings);
-    };
-    ApiManager.getBasePath = () => {
-      return Promise.resolve('');
-    };
-    SessionManager.listSessionsAsync = () => {
-      return Promise.resolve([]);
-    };
-    const mockFileManager = new MockFileManager();
-    mockFileManager.list = () => {
-      return Promise.resolve(mockFiles);
-    };
-    FileManagerFactory.getInstance = () => mockFileManager;
-    FileManagerFactory.getInstanceForType = (_) => mockFileManager;
-  });
-
-  beforeEach((done: () => any) => {
-    testFixture = fixture('files-fixture');
-    testFixture.ready()
-      .then(() => {
-        Polymer.dom.flush();
-        done();
+window.addEventListener('WebComponentsReady', () => {
+  class MockFile extends DatalabFile {
+    constructor(name = '', path = '') {
+      super({
+        getInlineDetailsName: () => '',
+        getPreviewName: () => '',
+        icon: '',
+        id: new DatalabFileId(path, FileManagerType.MOCK),
+        name,
+        type: DatalabFileType.DIRECTORY,
       });
-  });
+    }
+  }
 
-  it('gets the startup path correctly', () => {
-    assert(JSON.stringify(testFixture.currentFile.id) === JSON.stringify(startuppath),
-        'incorrect startup path');
-  });
+  class MockFileManager extends BaseFileManager {
+    public async getRootFile() {
+      return new MockFile('root');
+    }
+    public pathToPathHistory(path: string): DatalabFile[] {
+      return [new MockFile('', path)];
+    }
+  }
 
-  it('displays list of files correctly', () => {
-    const files: ItemListElement = testFixture.$.files;
-    assert(files.rows.length === 3, 'should have three files');
+  describe('<file-browser>', () => {
+    let testFixture: FileBrowserElement;
+    const startuppath = new DatalabFileId('testpath', FileManagerType.MOCK);
 
-    mockFiles.forEach((file: DatalabFile, i: number) => {
-      assert(files.rows[i].columns[0] === file.name,
-          'mock file ' + i + 'name not shown in first column');
-      assert(files.rows[i].icon === file.icon, 'mock file ' + i + ' type not shown as icon');
+    const mockFiles = [
+      new MockFile('file1'),
+      new MockFile('file2'),
+      new MockFile('file3'),
+    ];
+
+    before(() => {
+      SettingsManager.getUserSettingsAsync = (forceRefresh: boolean) => {
+        assert(forceRefresh === true, 'file-browser should refresh settings on load');
+        const mockSettings: common.UserSettings = {
+          idleTimeoutInterval: '',
+          idleTimeoutShutdownCommand: '',
+          startuppath: startuppath.path,
+          theme: 'light',
+        };
+        return Promise.resolve(mockSettings);
+      };
+      ApiManager.getBasePath = () => {
+        return Promise.resolve('');
+      };
+      SessionManager.listSessionsAsync = () => {
+        return Promise.resolve([]);
+      };
+      const mockFileManager = new MockFileManager();
+      mockFileManager.list = () => {
+        return Promise.resolve(mockFiles);
+      };
+      FileManagerFactory.getInstance = () => mockFileManager;
+      FileManagerFactory.getInstanceForType = (_) => mockFileManager;
     });
-  });
 
-  it('starts up with no files selected, and no files running', () => {
-    const files: ItemListElement = testFixture.$.files;
-    files.rows.forEach((row: ItemListRow, i: number) => {
-      assert(!row.selected, 'file ' + i + ' should not be selected');
+    beforeEach((done: () => any) => {
+      testFixture = fixture('files-fixture');
+      testFixture.ready()
+        .then(() => {
+          Polymer.dom.flush();
+          done();
+        });
+    });
+
+    it('gets the startup path correctly', () => {
+      assert(JSON.stringify(testFixture.currentFile.id) === JSON.stringify(startuppath),
+          'incorrect startup path');
+    });
+
+    it('displays list of files correctly', () => {
+      const files: ItemListElement = testFixture.$.files;
+      assert(files.rows.length === 3, 'should have three files');
+
+      mockFiles.forEach((file: DatalabFile, i: number) => {
+        assert(files.rows[i].columns[0] === file.name,
+            'mock file ' + i + 'name not shown in first column');
+        assert(files.rows[i].icon === file.icon, 'mock file ' + i + ' type not shown as icon');
+      });
+    });
+
+    it('starts up with no files selected, and no files running', () => {
+      const files: ItemListElement = testFixture.$.files;
+      files.rows.forEach((row: ItemListRow, i: number) => {
+        assert(!row.selected, 'file ' + i + ' should not be selected');
+      });
     });
   });
 });

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -101,41 +101,41 @@ window.addEventListener('WebComponentsReady', () => {
         assert(!row.selected, 'file ' + i + ' should not be selected');
       });
     });
-  });
 
-  it('shows new notebook dialog', async () => {
-    // Make sure no dialogs are shown
-    assert(document.querySelector('input-dialog') === null,
-        'no input dialogs should be shown before clicking new');
-    testFixture.$.newNotebookButton.click();
-    const dialog = TestUtils.getDialog(InputDialogElement);
-    assert(dialog, 'an input dialog should show after clicking new notebook');
-    assert(dialog.$.dialogTitle.innerText === 'New ' + Utils.constants.notebook);
+    it('shows new notebook dialog', async () => {
+      // Make sure no dialogs are shown
+      assert(document.querySelector('input-dialog') === null,
+          'no input dialogs should be shown before clicking new');
+      testFixture.$.newNotebookButton.click();
+      const dialog = TestUtils.getDialog(InputDialogElement);
+      assert(dialog, 'an input dialog should show after clicking new notebook');
+      assert(dialog.$.dialogTitle.innerText === 'New ' + Utils.constants.notebook);
 
-    await TestUtils.cancelDialog(dialog);
-  });
+      await TestUtils.cancelDialog(dialog);
+    });
 
-  it('shows new file dialog', async () => {
-    // Make sure no dialogs are shown
-    assert(document.querySelector('input-dialog') === null,
-        'no input dialogs should be shown before clicking new');
-    testFixture.$.newFileButton.click();
-    const dialog = TestUtils.getDialog(InputDialogElement);
-    assert(dialog, 'an input dialog should show after clicking new file');
-    assert(dialog.$.dialogTitle.innerText === 'New ' + Utils.constants.file);
+    it('shows new file dialog', async () => {
+      // Make sure no dialogs are shown
+      assert(document.querySelector('input-dialog') === null,
+          'no input dialogs should be shown before clicking new');
+      testFixture.$.newFileButton.click();
+      const dialog = TestUtils.getDialog(InputDialogElement);
+      assert(dialog, 'an input dialog should show after clicking new file');
+      assert(dialog.$.dialogTitle.innerText === 'New ' + Utils.constants.file);
 
-    await TestUtils.cancelDialog(dialog);
-  });
+      await TestUtils.cancelDialog(dialog);
+    });
 
-  it('shows new folder dialog', async () => {
-    // Make sure no dialogs are shown
-    assert(document.querySelector('input-dialog') === null,
-        'no input dialogs should be shown before clicking new');
-    testFixture.$.newFolderButton.click();
-    const dialog = TestUtils.getDialog(InputDialogElement);
-    assert(dialog, 'an input dialog should show after clicking new folder');
-    assert(dialog.$.dialogTitle.innerText === 'New ' + Utils.constants.directory);
+    it('shows new folder dialog', async () => {
+      // Make sure no dialogs are shown
+      assert(document.querySelector('input-dialog') === null,
+          'no input dialogs should be shown before clicking new');
+      testFixture.$.newFolderButton.click();
+      const dialog = TestUtils.getDialog(InputDialogElement);
+      assert(dialog, 'an input dialog should show after clicking new folder');
+      assert(dialog.$.dialogTitle.innerText === 'New ' + Utils.constants.directory);
 
-    await TestUtils.cancelDialog(dialog);
+      await TestUtils.cancelDialog(dialog);
+    });
   });
 });

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -106,6 +106,7 @@ window.addEventListener('WebComponentsReady', () => {
       const files: ItemListElement = testFixture.$.files;
       files.rows.forEach((row: ItemListRow, i: number) => {
         assert(!row.selected, 'file ' + i + ' should not be selected');
+      });
     });
 
     it('shows new notebook dialog', async () => {


### PR DESCRIPTION
Looks like an outstanding issue on web component tester: https://github.com/Polymer/web-component-tester/issues/189. The fix for now is to wait for web components to load before running the test, no other changes are made.
Disable white space diffing for this PR.