### PR TITLE
Add missing Name column, + regression test

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -220,6 +220,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
     const filesElement = this.$.files as ItemListElement;
     filesElement.inlineDetailsMode = InlineDetailsDisplayMode.SINGLE_SELECT;
+    filesElement.columns = ['Name'];
 
     this.$.breadCrumbs.addEventListener('crumbClicked', (e: ItemClickEvent) => {
       // Take the default root file into account, increment clicked index by one.

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -94,6 +94,13 @@ describe('<file-browser>', () => {
     });
   });
 
+  it('shows Name column in header', () => {
+    const files: ItemListElement = testFixture.$.files;
+    const columns = files.$.header.querySelectorAll('.column');
+    assert(columns.length === 1, 'exactly one column is expected');
+    assert(columns[0].innerText === 'Name', 'Name column missing');
+  });
+
   it('starts up with no files selected, and no files running', () => {
     const files: ItemListElement = testFixture.$.files;
     files.rows.forEach((row: ItemListRow, i: number) => {


### PR DESCRIPTION
Looks like we dropped displaying the Name column in the header at some point.