### PR TITLE
Add filter to item-list

### DIFF
--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -5,6 +5,7 @@
     "app-layout": "PolymerElements/app-layout#^2.0.2",
     "app-route": "PolymerElements/app-route#^2.0.2",
     "codemirror": "^5.27.2",
+    "iron-a11y-keys": "PolymerElements/iron-a11y-keys#^2.0.0",
     "iron-icons": "PolymerElements/iron-icons#^2.0.1",
     "iron-pages": "PolymerElements/iron-pages#^2.0.0",
     "iron-selector": "PolymerElements/iron-selector#^2.0.0",

--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -5,7 +5,6 @@
     "app-layout": "PolymerElements/app-layout#^2.0.2",
     "app-route": "PolymerElements/app-route#^2.0.2",
     "codemirror": "^5.27.2",
-    "iron-a11y-keys": "PolymerElements/iron-a11y-keys#^2.0.0",
     "iron-icons": "PolymerElements/iron-icons#^2.0.1",
     "iron-pages": "PolymerElements/iron-pages#^2.0.0",
     "iron-selector": "PolymerElements/iron-selector#^2.0.0",

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -575,6 +575,10 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
         this._pathHistory.slice(rootBreadcrumbs, this._pathHistoryIndex + 1).map((p) => p.name);
 
     this.currentFile = this._pathHistory[this._pathHistoryIndex];
+
+    // Reset any filter on the item list
+    (this.$.files as ItemListElement).resetFilter();
+
     this._setFileIdPropertyToCurrentFile();
     this._fetchFileList();
   }

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -14,10 +14,12 @@ the License.
 
 <link rel="import" href="../../modules/utils/utils.html">
 
+<link rel="import" href="../../bower_components/iron-a11y-keys/iron-a11y-keys.html">
 <link rel="import" href="../../bower_components/iron-icons/editor-icons.html">
 <link rel="import" href="../../bower_components/iron-icons/hardware-icons.html">
 <link rel="import" href="../../bower_components/paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
 
 <dom-module id="item-list">
   <template>
@@ -96,6 +98,46 @@ the License.
         flex: 1;
         max-width: 150px;
       }
+      #filterToggle {
+        --paper-icon-button: {
+          width: 38px;
+          height: 38px;
+        };
+      }
+      .filterShown--true {
+        color: var(--selection-fg-color);
+      }
+      .filterShown--false {
+        color: var(--disabled-fg-color);
+      }
+      #search-div {
+        position: relative;
+      }
+      #search-icon {
+        position: absolute;
+        top: 5px;
+        right: 10px;
+        color: var(--disabled-fg-color);
+        width: 22px;
+        height: 22px;
+      }
+      #searchBox {
+        height: 35px;
+        width: 100%;
+        border: solid 1px var(--border-color);
+        text-indent: 75px;
+        padding: 5px;
+        box-sizing: border-box;
+        background-color: var(--primary-bg-color);
+        color: var(--primary-fg-color);
+        outline: none;
+      }
+      #searchBox:hover {
+        border: solid 1px var(--outline-color);
+      }
+      #searchBox:active {
+        border: solid 1px var(--outline-color);
+      }
     </style>
 
     <!--Header row-->
@@ -106,12 +148,20 @@ the License.
           <paper-checkbox id="selectAllCheckbox" on-checked-changed="_selectAllChanged"
                           checked={{_isAllSelected}} hidden$="{{_hideCheckboxes}}">
           </paper-checkbox>
+          <paper-icon-button id="filterToggle" class$="filterShown--[[_showFilterBox]]"
+                             icon="filter-list" on-click="_toggleFilter"></paper-icon-button>
         </div>
         <template is="dom-repeat" items="{{columns}}" as="column">
           <div class="column">
             <strong>{{column}}</strong>
           </div>
         </template>
+      </div>
+      <div id="search-div" hidden$="[[!_showFilterBox]]">
+        <iron-a11y-keys id="searchKeys" keys="enter" on-keys-pressed="_filter"></iron-a11y-keys>
+        <iron-icon icon="filter-list" id="search-icon"></iron-icon>
+        <input id="searchBox" placeholder="Filter by [[columns.0]]"
+               value="{{_searchValue::input}}"></input>
       </div>
     </div>
 

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -14,7 +14,6 @@ the License.
 
 <link rel="import" href="../../modules/utils/utils.html">
 
-<link rel="import" href="../../bower_components/iron-a11y-keys/iron-a11y-keys.html">
 <link rel="import" href="../../bower_components/iron-icons/editor-icons.html">
 <link rel="import" href="../../bower_components/iron-icons/hardware-icons.html">
 <link rel="import" href="../../bower_components/paper-checkbox/paper-checkbox.html">
@@ -115,7 +114,7 @@ the License.
       }
       #filter-icon {
         position: absolute;
-        top: 5px;
+        top: 8px;
         right: 10px;
         color: var(--disabled-fg-color);
         width: 18px;
@@ -149,7 +148,8 @@ the License.
                           checked={{_isAllSelected}} hidden$="{{_hideCheckboxes}}">
           </paper-checkbox>
           <paper-icon-button id="filterToggle" class$="filterShown--[[_showFilterBox]]"
-                             icon="filter-list" on-click="_toggleFilter"></paper-icon-button>
+                             icon="filter-list" on-click="_toggleFilter"
+                             title="Filter by [[columns.0]]"></paper-icon-button>
         </div>
         <template is="dom-repeat" items="{{columns}}" as="column">
           <div class="column">

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -100,8 +100,8 @@ the License.
       }
       #filterToggle {
         --paper-icon-button: {
-          width: 38px;
-          height: 38px;
+          width: 34px;
+          height: 34px;
         };
       }
       .filterShown--true {
@@ -110,18 +110,18 @@ the License.
       .filterShown--false {
         color: var(--disabled-fg-color);
       }
-      #search-div {
+      #filter-div {
         position: relative;
       }
-      #search-icon {
+      #filter-icon {
         position: absolute;
         top: 5px;
         right: 10px;
         color: var(--disabled-fg-color);
-        width: 22px;
-        height: 22px;
+        width: 18px;
+        height: 18px;
       }
-      #searchBox {
+      #filterBox {
         height: 35px;
         width: 100%;
         border: solid 1px var(--border-color);
@@ -132,10 +132,10 @@ the License.
         color: var(--primary-fg-color);
         outline: none;
       }
-      #searchBox:hover {
+      #filterBox:hover {
         border: solid 1px var(--outline-color);
       }
-      #searchBox:active {
+      #filterBox:active {
         border: solid 1px var(--outline-color);
       }
     </style>
@@ -157,17 +157,17 @@ the License.
           </div>
         </template>
       </div>
-      <div id="search-div" hidden$="[[!_showFilterBox]]">
-        <iron-a11y-keys id="searchKeys" keys="enter" on-keys-pressed="_filter"></iron-a11y-keys>
-        <iron-icon icon="filter-list" id="search-icon"></iron-icon>
-        <input id="searchBox" placeholder="Filter by [[columns.0]]"
-               value="{{_searchValue::input}}"></input>
+      <div id="filter-div" hidden$="[[!_showFilterBox]]">
+        <iron-icon icon="filter-list" id="filter-icon"></iron-icon>
+        <input id="filterBox" placeholder="Filter by [[columns.0]]"
+               value="{{_filterString::input}}"></input>
       </div>
     </div>
 
     <!--Item list-->
     <div id="listContainer">
-      <template is="dom-repeat" id="list" items="{{rows}}" as="row">
+      <template is="dom-repeat" id="list" items="{{rows}}" as="row"
+                filter="{{_computeFilter(_filterString)}}">
         <paper-item class="row" selected$={{row.selected}} on-click="_rowClicked"
                     on-dblclick="_rowDoubleClicked">
           <div class="checkbox-col">

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -186,6 +186,7 @@ class ItemListElement extends Polymer.Element {
    */
   public inlineDetailsMode: InlineDetailsDisplayMode;
 
+  _filterString: string;
   _showFilterBox: boolean;
 
   private _lastSelectedIndex = -1;
@@ -227,6 +228,7 @@ class ItemListElement extends Polymer.Element {
         value: false,
       },
       rows: {
+        observer: '_rowsChanged',
         type: Array,
         value: () => [],
       },
@@ -252,8 +254,28 @@ class ItemListElement extends Polymer.Element {
     });
   }
 
+  _rowsChanged() {
+    this._filterString = '';
+  }
+
   _toggleFilter() {
     this._showFilterBox = !this._showFilterBox;
+    if (this._showFilterBox) {
+      this.$.filterBox.focus();
+    } else {
+      this._filterString = '';
+    }
+  }
+
+  _computeFilter(filterString: string) {
+    if (!filterString) {
+      // set filter to null to disable filtering
+      return null;
+    } else {
+      // return a filter function for the current search string
+      filterString = filterString.toLowerCase();
+      return (item: ItemListRow) => item.columns[0].toLowerCase().indexOf(filterString) > -1;
+    }
   }
 
   /**

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -228,7 +228,6 @@ class ItemListElement extends Polymer.Element {
         value: false,
       },
       rows: {
-        observer: '_rowsChanged',
         type: Array,
         value: () => [],
       },
@@ -254,8 +253,7 @@ class ItemListElement extends Polymer.Element {
     });
   }
 
-  _rowsChanged() {
-    // Reset the filter if the items change
+  resetFilter() {
     this._filterString = '';
   }
 

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -255,11 +255,15 @@ class ItemListElement extends Polymer.Element {
   }
 
   _rowsChanged() {
+    // Reset the filter if the items change
     this._filterString = '';
   }
 
   _toggleFilter() {
     this._showFilterBox = !this._showFilterBox;
+
+    // If the filter box is now visible, focus it.
+    // If not, reset the filter to go back to showing the full list.
     if (this._showFilterBox) {
       this.$.filterBox.focus();
     } else {
@@ -394,7 +398,7 @@ class ItemListElement extends Polymer.Element {
       return;
     }
     const target = e.target as HTMLDivElement;
-    const index = this.$.list.indexForElement(target);
+    const index = this.$.list.modelForElement(target).itemsIndex;
 
     // If shift key is pressed and we had saved the last selected index, select
     // all items from this index till the last selected.
@@ -442,7 +446,7 @@ class ItemListElement extends Polymer.Element {
    * On row double click, fires an event with the clicked item's index.
    */
   _rowDoubleClicked(e: MouseEvent) {
-    const index = this.$.list.indexForElement(e.target);
+    const index = this.$.list.modelForElement(e.target).itemsIndex;
     const ev = new ItemClickEvent('itemDoubleClick', { detail: {index} });
     this.dispatchEvent(ev);
   }

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -186,6 +186,8 @@ class ItemListElement extends Polymer.Element {
    */
   public inlineDetailsMode: InlineDetailsDisplayMode;
 
+  _showFilterBox: boolean;
+
   private _lastSelectedIndex = -1;
 
   static get is() { return 'item-list'; }
@@ -199,6 +201,10 @@ class ItemListElement extends Polymer.Element {
       _isAllSelected: {
         computed: '_computeIsAllSelected(selectedIndices)',
         type: Boolean,
+      },
+      _showFilterBox: {
+        type: Boolean,
+        value: false,
       },
       columns: {
         type: Array,
@@ -244,6 +250,10 @@ class ItemListElement extends Polymer.Element {
       const shadow = '0px ' + yOffset + 'px 10px -5px #ccc';
       headerContainer.style.boxShadow = shadow;
     });
+  }
+
+  _toggleFilter() {
+    this._showFilterBox = !this._showFilterBox;
   }
 
   /**

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -485,7 +485,8 @@ describe('<item-list>', () => {
       testFixture._filterString = 'COLUMN 4';
       Polymer.dom.flush();
       const rows = testFixture.$.listContainer.querySelectorAll('.row');
-      assert(rows.length === 1, 'should show all rows, since filtering is case insensitive');
+      assert(rows.length === 1,
+          'should show one row containing "column 4", since filtering is case insensitive');
       assert(rows[0].children[1].innerText === 'first column 4',
           'filter should return the fourth item');
     });

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -437,7 +437,7 @@ describe('<item-list>', () => {
           'fifth details container should be hidden');
     });
 
-    it('should hide the filter box by default', () => {
+    it('hides the filter box by default', () => {
       assert(testFixture.$.filterBox.offsetHeight === 0, 'filter box should not show by default');
     });
 
@@ -482,10 +482,12 @@ describe('<item-list>', () => {
 
     it('ignores case when filtering', () => {
       testFixture.$.filterToggle.click();
-      testFixture._filterString = 'FIRST';
+      testFixture._filterString = 'COLUMN 4';
       Polymer.dom.flush();
       const rows = testFixture.$.listContainer.querySelectorAll('.row');
-      assert(rows.length === 5, 'should show all rows, since filtering is case insensitive');
+      assert(rows.length === 1, 'should show all rows, since filtering is case insensitive');
+      assert(rows[0].children[1].innerText === 'first column 4',
+          'filter should return the fourth item');
     });
 
     it('resets filter when filter box is closed', () => {

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -436,5 +436,80 @@ describe('<item-list>', () => {
       assert(fifthDetailsContainer.getAttribute('hidden') != null,
           'fifth details container should be hidden');
     });
+
+    it('should hide the filter box by default', () => {
+      assert(testFixture.$.filterBox.offsetHeight === 0, 'filter box should not show by default');
+    });
+
+    it('shows/hides filter box when toggle is clicked', () => {
+      testFixture.$.filterToggle.click();
+      assert(testFixture.$.filterBox.offsetHeight > 0,
+          'filter box should show when toggle is clicked');
+
+      testFixture.$.filterToggle.click();
+      assert(testFixture.$.filterBox.offsetHeight === 0,
+          'filter box should hide when toggle is clicked again');
+    });
+
+    it('filters items when typing characters in the filter box', () => {
+      testFixture.$.filterToggle.click();
+      testFixture._filterString = '3';
+      Polymer.dom.flush();
+      const rows = testFixture.$.listContainer.querySelectorAll('.row');
+      assert(rows.length === 1, 'only one item has "3" in its name');
+      assert(rows[0].children[1].innerText === 'first column 3',
+          'filter should only return the third item');
+    });
+
+    it('shows all items when filter string is deleted', () => {
+      testFixture.$.filterToggle.click();
+      testFixture._filterString = '3';
+      Polymer.dom.flush();
+      testFixture._filterString = '';
+      Polymer.dom.flush();
+      const rows = testFixture.$.listContainer.querySelectorAll('.row');
+      assert(rows.length === 5, 'should show all rows after filter string is deleted');
+    });
+
+    it('filters items based on first column only', () => {
+      testFixture.$.filterToggle.click();
+      testFixture._filterString = 'second';
+      Polymer.dom.flush();
+      const rows = testFixture.$.listContainer.querySelectorAll('.row');
+      assert(rows.length === 0,
+          'should not show any rows, since no row has "second" in its first column');
+    });
+
+    it('ignores case when filtering', () => {
+      testFixture.$.filterToggle.click();
+      testFixture._filterString = 'FIRST';
+      Polymer.dom.flush();
+      const rows = testFixture.$.listContainer.querySelectorAll('.row');
+      assert(rows.length === 5, 'should show all rows, since filtering is case insensitive');
+    });
+
+    it('resets filter when filter box is closed', () => {
+      testFixture.$.filterToggle.click();
+      testFixture._filterString = '3';
+      Polymer.dom.flush();
+      testFixture.$.filterToggle.click();
+      Polymer.dom.flush();
+      assert(testFixture.$.listContainer.querySelectorAll('.row').length === 5,
+          'all rows should show after closing filter box');
+    });
+
+    it('resets filter when rows change', () => {
+      testFixture.$.filterToggle.click();
+      testFixture._filterString = '3';
+      Polymer.dom.flush();
+
+      testFixture.rows = [...testFixture.rows];
+      Polymer.dom.flush();
+
+      assert(testFixture._filterString === '', 'should reset filter string after changing rows');
+      assert(testFixture.$.listContainer.querySelectorAll('.row').length === 5,
+          'all rows should show after changing rows');
+    });
+
   });
 });

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -501,18 +501,5 @@ describe('<item-list>', () => {
           'all rows should show after closing filter box');
     });
 
-    it('resets filter when rows change', () => {
-      testFixture.$.filterToggle.click();
-      testFixture._filterString = '3';
-      Polymer.dom.flush();
-
-      testFixture.rows = [...testFixture.rows];
-      Polymer.dom.flush();
-
-      assert(testFixture._filterString === '', 'should reset filter string after changing rows');
-      assert(testFixture.$.listContainer.querySelectorAll('.row').length === 5,
-          'all rows should show after changing rows');
-    });
-
   });
 });


### PR DESCRIPTION
This PR adds filtering capability to item list. The filter only works on the first column of the item list for now, which covers the common cases. We can expand on this later as needed.

In order to do this, I switched the way we get the selection index to use the clicked item's true order in the original list, as opposed to its order in the rendered (filtered) list.

This design isn't final, it's just a rough way to get filter functionality into the UI. It's a toggle that shows up next to the first column in the header, which on click shows an input box underneath the header. Items will change as the user types in that box, without needing to hit Enter. Filtering is case-insensitive for now to simplify the implementation and the UI.

![image](https://user-images.githubusercontent.com/1424661/32590221-ee45ce8c-c521-11e7-98f5-61efc8b39d05.png)
[_Tooltip when hovering over filter icon_]

![image](https://user-images.githubusercontent.com/1424661/32590232-0826b348-c522-11e7-943a-e3892c5aaf6d.png)
[_Clicking filter icon opens the filter box and focuses it_]
