### PR TITLE
Enable chunked mode for item-list by default

### DIFF
--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -117,7 +117,7 @@ the License.
 
     <!--Item list-->
     <div id="listContainer">
-      <template is="dom-repeat" id="list" items="{{rows}}" as="row">
+      <template is="dom-repeat" id="list" items="{{rows}}" as="row" initial-count="100">
         <paper-item class="row" selected$={{row.selected}} on-click="_rowClicked"
                     on-dblclick="_rowDoubleClicked">
           <div class="checkbox-col">


### PR DESCRIPTION
This helps with rendering very large lists of items (see [docs](https://www.polymer-project.org/1.0/docs/devguide/templates#large-list-perf)).
A better fix is to use iron-list to do virtual scrolling, but this removes some flexibility from the design of the item-list component, which right now is capable of displaying preview data inlined with the list item.