### PR TITLE
Expose columns in file browser from file manager

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -471,7 +471,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       return detailsPane;
     };
     const itemList = this.$.files as ItemListElement;
-    itemList.columns = this._fileManager.getColumns(this.currentFile.id);
+    itemList.columns = this._fileManager.getColumnNames(this.currentFile.id);
     itemList.rows = this._fileList.map((file) => {
       const createDetailsElement = file.getInlineDetailsName() ?
           () => createDetailsPaneFromFile(file) : undefined;

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -225,7 +225,6 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
 
     const filesElement = this.$.files as ItemListElement;
     filesElement.inlineDetailsMode = InlineDetailsDisplayMode.SINGLE_SELECT;
-    filesElement.columns = ['Name'];
 
     this.$.breadCrumbs.addEventListener('crumbClicked', (e: ItemClickEvent) => {
       // Take the default root file into account, increment clicked index by one.
@@ -471,11 +470,13 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       detailsPane.file = file;
       return detailsPane;
     };
-    (this.$.files as ItemListElement).rows = this._fileList.map((file) => {
+    const itemList = this.$.files as ItemListElement;
+    itemList.columns = this._fileManager.getColumns(this.currentFile.id);
+    itemList.rows = this._fileList.map((file) => {
       const createDetailsElement = file.getInlineDetailsName() ?
           () => createDetailsPaneFromFile(file) : undefined;
       const row = new ItemListRow({
-          columns: [file.name],
+          columns: file.getColumnValues(),
           createDetailsElement,
           icon: file.icon,
       });

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -93,9 +93,14 @@ the License.
       .column {
         flex: 2;
       }
+      #header > .column {
+        color: var(--primary-fg-color);
+        font-size: 13px;
+      }
       .column + .column {
         flex: 1;
         max-width: 150px;
+        color: var(--neutral-fg-color);
       }
       #filterToggle {
         --paper-icon-button: {
@@ -153,7 +158,7 @@ the License.
         </div>
         <template is="dom-repeat" items="{{columns}}" as="column">
           <div class="column">
-            <strong>{{column}}</strong>
+            <span>{{column}}</span>
           </div>
         </template>
       </div>

--- a/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
+++ b/sources/web/datalab/polymer/components/shared-styles/shared-styles.html
@@ -18,7 +18,7 @@ the License.
       :host {
         --app-animation-duration: 0.3s;
         --app-content-font-family: 'Open Sans', 'Helvetica', sans-serif;
-        --app-content-font-size: 13px;
+        --app-content-font-size: 12px;
         --box-shadow-color: rgba(0, 0, 0, 0.1);
         --collapsed-sidebar-width: 65px;
         --neutral-fg-color: #777;

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -79,6 +79,20 @@ class BigQueryFileManager extends BaseFileManager {
     throw new UnsupportedMethod('list on BigQuery table', this);
   }
 
+  public getColumns(currentFileId?: DatalabFileId) {
+    if (currentFileId) {
+      const len = currentFileId.path.split('/').filter((t) => !!t).length;
+      switch (len) {
+        case 0: return [Utils.constants.columns.project];
+        case 1: return [Utils.constants.columns.dataset];
+        case 2: return [Utils.constants.columns.table];
+        default: return super.getColumns();
+      }
+    } else {
+      return super.getColumns();
+    }
+  }
+
   public create(_fileType: DatalabFileType, _containerId: DatalabFileId, _name: string):
       Promise<DatalabFile> {
     throw new UnsupportedMethod('create', this);
@@ -144,12 +158,12 @@ class BigQueryFileManager extends BaseFileManager {
 
   protected _bqProjectIdToDatalabFile(projectId: string): DatalabFile {
     const path = projectId;
-    return new BigQueryFile({
-      icon: 'datalab-icons:bq-project',
-      id: new DatalabFileId(path, this.myFileManagerType()),
-      name: projectId,
-      type: DatalabFileType.DIRECTORY,
-    } as DatalabFile);
+    return new BigQueryFile(
+      new DatalabFileId(path, this.myFileManagerType()),
+      projectId,
+      DatalabFileType.DIRECTORY,
+      'datalab-icons:bq-project',
+    );
   }
 
   private async _collectAllProjects(accumulatedProjects: ProjectResource[],
@@ -217,12 +231,12 @@ class BigQueryFileManager extends BaseFileManager {
 
   private _bqRootDatalabFile(): DatalabFile {
     const path = '/';
-    return new BigQueryFile({
-      icon: '',
-      id: new DatalabFileId(path, this.myFileManagerType()),
-      name: '/',
-      type: DatalabFileType.FILE,
-    } as DatalabFile);
+    return new BigQueryFile(
+      new DatalabFileId(path, this.myFileManagerType()),
+      '/',
+      DatalabFileType.FILE,
+      '',
+    );
   }
 
   private _bqProjectToDatalabFile(bqProject: ProjectResource): DatalabFile {
@@ -236,12 +250,12 @@ class BigQueryFileManager extends BaseFileManager {
 
   private _bqProjectDatasetIdsToDatalabFile(projectId: string, datasetId: string): DatalabFile {
     const path = projectId + '/' + datasetId;
-    return new BigQueryFile({
-      icon: 'datalab-icons:bq-dataset',
-      id: new DatalabFileId(path, this.myFileManagerType()),
-      name: datasetId,
-      type: DatalabFileType.DIRECTORY,
-    } as DatalabFile);
+    return new BigQueryFile(
+      new DatalabFileId(path, this.myFileManagerType()),
+      datasetId,
+      DatalabFileType.DIRECTORY,
+      'datalab-icons:bq-dataset',
+    );
   }
 
   private _bqTableToDatalabFile(bqTable: TableResource): DatalabFile {
@@ -254,12 +268,12 @@ class BigQueryFileManager extends BaseFileManager {
   private _bqProjectDatasetTableIdsToDatalabFile(
       projectId: string, datasetId: string, tableId: string): DatalabFile {
     const path = projectId + '/' + datasetId + '/' + tableId;
-    return new BigQueryFile({
-      icon: 'datalab-icons:bq-table',
-      id: new DatalabFileId(path, this.myFileManagerType()),
-      name: tableId,
-      type: DatalabFileType.FILE,
-    } as DatalabFile);
+    return new BigQueryFile(
+      new DatalabFileId(path, this.myFileManagerType()),
+      tableId,
+      DatalabFileType.FILE,
+      'datalab-icons:bq-table',
+    );
   }
 }
 

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -79,17 +79,17 @@ class BigQueryFileManager extends BaseFileManager {
     throw new UnsupportedMethod('list on BigQuery table', this);
   }
 
-  public getColumns(currentFileId?: DatalabFileId) {
+  public getColumnNames(currentFileId?: DatalabFileId) {
     if (currentFileId) {
       const len = currentFileId.path.split('/').filter((t) => !!t).length;
       switch (len) {
         case 0: return [Utils.constants.columns.project];
         case 1: return [Utils.constants.columns.dataset];
         case 2: return [Utils.constants.columns.table];
-        default: return super.getColumns();
+        default: return super.getColumnNames();
       }
     } else {
-      return super.getColumns();
+      return super.getColumnNames();
     }
   }
 

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -74,7 +74,7 @@ class DriveFileManager extends BaseFileManager {
     return upstreamFiles.map((file) => this._fromUpstreamFile(file));
   }
 
-  public getColumns() {
+  public getColumnNames() {
     return [
       Utils.constants.columns.name,
       Utils.constants.columns.lastModified,
@@ -148,7 +148,7 @@ class DriveFileManager extends BaseFileManager {
     if (driveFile.type === DatalabFileType.FILE && driveFile.name.endsWith('.ipynb')) {
       driveFile.type = DatalabFileType.NOTEBOOK;
     }
-    driveFile.lastModified = new Date(file.modifiedTime).toDateString();
+    driveFile.lastModified = new Date(file.modifiedTime).toLocaleString();
     if (file.owners) {
       driveFile.owner = file.owners[0].me ? Utils.constants.me : file.owners[0].displayName;
     }

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -106,13 +106,15 @@ abstract class DatalabFile {
   name: string;
   type: DatalabFileType;
 
-  constructor(obj?: DatalabFile) {
-    if (obj) {
-      this.icon = obj.icon;
-      this.name = obj.name;
-      this.id = obj.id;
-      this.type = obj.type;
-    }
+  constructor(id: DatalabFileId, name: string, type: DatalabFileType, icon?: string) {
+    this.id = id;
+    this.name = name;
+    this.type = type;
+    this.icon = icon || '';
+  }
+
+  public getColumnValues(): string[] {
+    return [this.name];
   }
 
   public getPreviewName(): string {
@@ -164,6 +166,12 @@ interface FileManager {
    * @param containerId file id whose children to list.
    */
   list(containerId: DatalabFileId): Promise<DatalabFile[]>;
+
+  /**
+   * Returns a list of column names. A file id for the current file can be  passed
+   * to optionally customize the column names based on the current view.
+   */
+  getColumns(currentFileId?: DatalabFileId): string[];
 
   /**
    * Creates a new Datalab item
@@ -239,6 +247,11 @@ class BaseFileManager implements FileManager {
   list(_containerId: DatalabFileId): Promise<DatalabFile[]> {
     throw new UnsupportedMethod('list', this);
   }
+
+  getColumns(_currentFileId?: DatalabFileId) {
+    return [Utils.constants.columns.name];
+  }
+
   create(_fileType: DatalabFileType, _containerId?: DatalabFileId, _name?: string):
       Promise<DatalabFile> {
     throw new UnsupportedMethod('create', this);

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -171,7 +171,7 @@ interface FileManager {
    * Returns a list of column names. A file id for the current file can be  passed
    * to optionally customize the column names based on the current view.
    */
-  getColumns(currentFileId?: DatalabFileId): string[];
+  getColumnNames(currentFileId?: DatalabFileId): string[];
 
   /**
    * Creates a new Datalab item
@@ -248,7 +248,7 @@ class BaseFileManager implements FileManager {
     throw new UnsupportedMethod('list', this);
   }
 
-  getColumns(_currentFileId?: DatalabFileId) {
+  getColumnNames(_currentFileId?: DatalabFileId) {
     return [Utils.constants.columns.name];
   }
 

--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
@@ -207,12 +207,11 @@ class GithubFileManager extends BaseFileManager {
   // component on the list to see whether it is a file or directory.
   private _ghPathPartsToDatalabFile(parts: string[]): DatalabFile {
     const path = parts.join('/');
-    return new GithubFile({
-      icon: '',
-      id: new DatalabFileId(path, FileManagerType.GITHUB),
-      name: parts[parts.length - 1],
-      type: DatalabFileType.DIRECTORY,
-    } as DatalabFile);
+    return new GithubFile(
+      new DatalabFileId(path, FileManagerType.GITHUB),
+      parts[parts.length - 1],
+      DatalabFileType.DIRECTORY,
+    );
   }
 
   // Gets the requested data, from our cache if we have it and it is
@@ -272,12 +271,11 @@ class GithubFileManager extends BaseFileManager {
 
   private _ghRootDatalabFile(): DatalabFile {
     const path = '/';
-    return new GithubFile({
-      icon: '',
-      id: new DatalabFileId(path, FileManagerType.GITHUB),
-      name: '/',
-      type: DatalabFileType.DIRECTORY,
-    } as DatalabFile);
+    return new GithubFile(
+      new DatalabFileId(path, FileManagerType.GITHUB),
+      '/',
+      DatalabFileType.DIRECTORY,
+    );
   }
 
   private _ghReposResponseToDatalabFiles(response: GhRepoResponse[]):
@@ -298,12 +296,12 @@ class GithubFileManager extends BaseFileManager {
   private _ghRepoToDatalabFile(repo: GhRepoResponse): DatalabFile {
     const type = DatalabFileType.DIRECTORY;
     const icon = Utils.getItemIconString(type);
-    return new GithubFile({
-      icon,
-      id: new DatalabFileId(repo.full_name, FileManagerType.GITHUB),
-      name: repo.name,
+    return new GithubFile(
+      new DatalabFileId(repo.full_name, FileManagerType.GITHUB),
+      repo.name,
       type,
-    } as DatalabFile);
+      icon,
+    );
   }
 
   private _ghDirEntryToDatalabFile(file: GhDirEntryResponse): DatalabFile {
@@ -315,12 +313,12 @@ class GithubFileManager extends BaseFileManager {
     const pathParts = file.url.split('/');
     const prefix = pathParts.slice(4, 6).join('/'); // user and project
     const path = prefix + '/' + file.path;
-    return new GithubFile({
-      icon,
-      id: new DatalabFileId(path, FileManagerType.GITHUB),
-      name: file.name,
+    return new GithubFile(
+      new DatalabFileId(path, FileManagerType.GITHUB),
+      file.name,
       type,
-    } as DatalabFile);
+      icon,
+    );
   }
 
   private _ghFileToDatalabFile(file: GhFileResponse): DatalabFile {
@@ -330,12 +328,12 @@ class GithubFileManager extends BaseFileManager {
     const pathParts = file.url.split('/');
     const prefix = pathParts.slice(4, 6).join('/'); // user and project
     const path = prefix + '/' + file.path;
-    return new GithubFile({
-      icon,
-      id: new DatalabFileId(path, FileManagerType.GITHUB),
-      name: file.name,
+    return new GithubFile(
+      new DatalabFileId(path, FileManagerType.GITHUB),
+      file.name,
       type,
-    } as DatalabFile);
+      icon,
+    );
   }
 
   private _ghFileToContentString(file: GhFileResponse): string {

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
@@ -118,7 +118,7 @@ class JupyterFileManager extends BaseFileManager {
     );
     jupyterFile.created = file.created;
     jupyterFile.format = file.format;
-    jupyterFile.lastModified = new Date(file.last_modified).toDateString();
+    jupyterFile.lastModified = new Date(file.last_modified).toLocaleString();
     jupyterFile.mimetype = file.mimetype;
     jupyterFile.path = file.path;
     jupyterFile.writable = file.writable;
@@ -197,7 +197,7 @@ class JupyterFileManager extends BaseFileManager {
     return files.map((file: any) => JupyterFileManager._upstreamFileToJupyterFile(file));
   }
 
-  public getColumns() {
+  public getColumnNames() {
     return [Utils.constants.columns.name, Utils.constants.columns.lastModified];
   }
 

--- a/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/jupyter-file-manager/jupyter-file-manager.ts
@@ -26,6 +26,15 @@ class JupyterFile extends DatalabFile {
   path: string;
   writable?: boolean;
 
+  constructor(id: DatalabFileId, name: string, type: DatalabFileType, icon?: string) {
+    super(id, name, type, icon);
+    this.path = id.path;
+  }
+
+  public getColumnValues() {
+    return [this.name, this.lastModified || ''];
+  }
+
   public getPreviewName(): string {
     const superPreview = super.getPreviewName();
     if (superPreview) {
@@ -100,15 +109,17 @@ class JupyterFileManager extends BaseFileManager {
    * Converts an object fetched from the Jupyter backend into a JupyterFile.
    */
   private static _upstreamFileToJupyterFile(file: any) {
-    const jupyterFile = new JupyterFile();
+    const fileType = JupyterFileManager._upstreamTypeToDatalabType(file.type);
+    const jupyterFile = new JupyterFile(
+      new DatalabFileId(file.path, FileManagerType.JUPYTER),
+      file.name,
+      fileType,
+      Utils.getItemIconString(fileType),
+    );
     jupyterFile.created = file.created;
     jupyterFile.format = file.format;
-    jupyterFile.type = JupyterFileManager._upstreamTypeToDatalabType(file.type);
-    jupyterFile.icon = Utils.getItemIconString(jupyterFile.type);
-    jupyterFile.id = new DatalabFileId(file.path, FileManagerType.JUPYTER);
-    jupyterFile.lastModified = file.last_modified;
+    jupyterFile.lastModified = new Date(file.last_modified).toDateString();
     jupyterFile.mimetype = file.mimetype;
-    jupyterFile.name = file.name;
     jupyterFile.path = file.path;
     jupyterFile.writable = file.writable;
     return jupyterFile;
@@ -186,15 +197,20 @@ class JupyterFileManager extends BaseFileManager {
     return files.map((file: any) => JupyterFileManager._upstreamFileToJupyterFile(file));
   }
 
+  public getColumns() {
+    return [Utils.constants.columns.name, Utils.constants.columns.lastModified];
+  }
+
   public create(fileType: DatalabFileType, containerId?: DatalabFileId, name?: string) {
-    const jupyterFile = new JupyterFile();
+    const jupyterFile = new JupyterFile(
+      new DatalabFileId(containerId ? containerId.path : '', FileManagerType.JUPYTER),
+      name || 'New item',
+      fileType,
+    );
     jupyterFile.created = new Date().toISOString();
     jupyterFile.format = 'text';
     jupyterFile.lastModified = jupyterFile.created;
     jupyterFile.mimetype = 'text/plain';
-    jupyterFile.name = name || 'New item';
-    jupyterFile.path = containerId ? containerId.path : '';
-    jupyterFile.type = fileType;
     jupyterFile.writable = true;
     const upstreamFile = JupyterFileManager._toUpstreamObject(jupyterFile, '');
     const xhrOptions: XhrOptions = {
@@ -282,13 +298,11 @@ class JupyterFileManager extends BaseFileManager {
       path = path.substr('/tree/'.length);
     }
     const tokens = path.split('/').filter((p) => !!p);
-    const pathHistory = tokens.map((token, i) => {
-      const f = new JupyterFile();
-      f.path = tokens.slice(0, i + 1).join('/');
-      f.name = token;
-      f.id = new DatalabFileId(f.path, FileManagerType.JUPYTER);
-      return f;
-    });
+    const pathHistory = tokens.map((token, i) => new JupyterFile(
+        new DatalabFileId(tokens.slice(0, i + 1).join('/'), FileManagerType.JUPYTER),
+        token,
+        DatalabFileType.DIRECTORY,
+    ));
     return pathHistory;
   }
 

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -32,7 +32,7 @@ class Utils {
     directory: 'folder',
     editorUrlComponent:   '/editor/',
     file: 'file',
-    me: 'Me',
+    me: 'me',
     newNotebookUrlComponent:  '/notebook/new/',
     notebook: 'notebook',
     notebookUrlComponent: '/notebook/',

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -32,6 +32,7 @@ class Utils {
     directory: 'folder',
     editorUrlComponent:   '/editor/',
     file: 'file',
+    me: 'Me',
     newNotebookUrlComponent:  '/notebook/new/',
     notebook: 'notebook',
     notebookUrlComponent: '/notebook/',
@@ -42,6 +43,16 @@ class Utils {
       timeout: 'timeout',
       userSettings: 'userSettings',
     },
+
+    // File browser column names
+    columns: {
+      dataset: 'Dataset',
+      lastModified: 'Last Modified',
+      name: 'Name',
+      owner: 'Owner',
+      project: 'Project',
+      table: 'Table',
+    }
   };
 
   /**

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -15,14 +15,11 @@
 window.addEventListener('WebComponentsReady', () => {
   class MockFile extends DatalabFile {
     constructor(name = '', path = '') {
-      super({
-        getInlineDetailsName: () => '',
-        getPreviewName: () => '',
-        icon: '',
-        id: new DatalabFileId(path, FileManagerType.MOCK),
+      super(
+        new DatalabFileId(path, FileManagerType.MOCK),
         name,
-        type: DatalabFileType.DIRECTORY,
-      });
+        DatalabFileType.DIRECTORY,
+      );
     }
   }
 

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -27,7 +27,7 @@ window.addEventListener('WebComponentsReady', () => {
   }
 
   class MockFileManager extends BaseFileManager {
-    public getColumns() {
+    public getColumnNames() {
       return ['Name', 'Type'];
     }
     public async getRootFile() {
@@ -119,7 +119,7 @@ window.addEventListener('WebComponentsReady', () => {
         assert(files.rows[i].columns[0] === file.name,
             'mock file ' + i + 'name not shown in first column');
         assert(files.rows[i].columns[1] === file.type.toString(),
-            'mock file ' + i + 'type not shown in first column');
+            'mock file ' + i + 'type not shown in second column');
         assert(files.rows[i].icon === file.icon, 'mock file ' + i + ' type not shown as icon');
       });
     });

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -21,9 +21,15 @@ window.addEventListener('WebComponentsReady', () => {
         DatalabFileType.DIRECTORY,
       );
     }
+    getColumnValues() {
+      return [this.name, this.type.toString()];
+    }
   }
 
   class MockFileManager extends BaseFileManager {
+    public getColumns() {
+      return ['Name', 'Type'];
+    }
     public async getRootFile() {
       return new MockFile('root');
     }
@@ -112,15 +118,18 @@ window.addEventListener('WebComponentsReady', () => {
       mockFiles.forEach((file: DatalabFile, i: number) => {
         assert(files.rows[i].columns[0] === file.name,
             'mock file ' + i + 'name not shown in first column');
+        assert(files.rows[i].columns[1] === file.type.toString(),
+            'mock file ' + i + 'type not shown in first column');
         assert(files.rows[i].icon === file.icon, 'mock file ' + i + ' type not shown as icon');
       });
     });
 
-    it('shows Name column in header', () => {
+    it('shows column names returned from the file manager in header', () => {
       const files: ItemListElement = testFixture.$.files;
       const columns = files.$.header.querySelectorAll('.column');
-      assert(columns.length === 1, 'exactly one column is expected');
+      assert(columns.length === 2, 'exactly two column are expected');
       assert(columns[0].innerText === 'Name', 'Name column missing');
+      assert(columns[1].innerText === 'Type', 'Type column missing');
     });
 
     it('starts up with no files selected, and no files running', () => {

--- a/sources/web/datalab/polymer/test/table-inline-details-test.ts
+++ b/sources/web/datalab/polymer/test/table-inline-details-test.ts
@@ -57,8 +57,8 @@ describe('<table-inline-details>', () => {
   };
 
   const mockTabledata: ListTabledataResponse = {
-    kind: 'bigquery#tableDataList',
     etag: 'x',
+    kind: 'bigquery#tableDataList',
     pageToken: '',
     rows: [
       {f: [{ v: 'r1f1' }, { v: 'r1f2' }]},
@@ -69,12 +69,11 @@ describe('<table-inline-details>', () => {
   };
 
   const fileForTableId = (tableId: string) => {
-    return new BigQueryFile({
-      icon: '',
-      id: new DatalabFileId(tableId, FileManagerType.BIG_QUERY),
-      name: '/',
-      type: DatalabFileType.FILE,
-    } as DatalabFile);
+    return new BigQueryFile(
+      new DatalabFileId(tableId, FileManagerType.BIG_QUERY),
+      '/',
+      DatalabFileType.FILE,
+    );
   };
 
   /**

--- a/third_party/externs/ts/gapi/drive.d.ts
+++ b/third_party/externs/ts/gapi/drive.d.ts
@@ -67,6 +67,14 @@ declare namespace gapi.client {
       mimeType: string;
       modifiedTime: string;
       name: string;
+      owners: [{
+        kind: string;
+        displayName: string;
+        photoLink: string;
+        me: boolean;
+        permissionId: string;
+        emailAddress: string;
+      }];
       parents: string[];
       starred: boolean;
       trashed: boolean;


### PR DESCRIPTION
This PR allows each file manager to define its own set of columns to be displayed by a file-browser element. This enables the file browser to then display different columns per source, as a precursor to implementing sort over columns.

A significant portion of this PR is cleanup to the different DatalabFile extended class constructors to make things consistent and easy to extend.

Examples:
![image](https://user-images.githubusercontent.com/1424661/32674008-0dda293a-c65a-11e7-8239-74fd0b8bc21d.png)
[_Drive view now shows last modified and owner columns_]

![image](https://user-images.githubusercontent.com/1424661/32646174-f959573a-c5f3-11e7-8f1e-ea804aa6442b.png)
[_BigQuery view now changes the column name based on the browser level_]