### PR TITLE
Only allow valid names for new files.

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -766,6 +766,16 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
         // Make sure the name ends with .ipynb for notebooks for convenience
         if (itemType === DatalabFileType.NOTEBOOK && !newName.endsWith('.ipynb')) {
           newName += '.ipynb';
+        } else if (itemType === DatalabFileType.FILE) {
+          if (newName.endsWith('.ipynb')) {
+            Utils.showErrorDialog('Invalid filename', 'Only notebooks can end with .ipynb');
+            return;
+          }
+          const fileNameError = this._fileManager.newFileNameError(newName);
+          if (fileNameError) {
+            Utils.showErrorDialog('Invalid filename', fileNameError);
+            return;
+          }
         }
 
         this._busy = true;

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -54,10 +54,10 @@ class DriveFileManager extends BaseFileManager {
 
   public newFileNameError(fileName: string): string | null {
     // Must match _getWhitelistFilePredicates()
-    if (fileName.indexOf('.ipynb') > -1 || fileName.indexOf('.txt') > -1) {
+    if (fileName.endsWith('.txt')) {
       return null;
     } else {
-      return 'File name must include .txt';
+      return 'File name must end with .txt';
     }
   }
 

--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -52,6 +52,15 @@ class DriveFileManager extends BaseFileManager {
     return this._fromUpstreamFile(upstreamFile);
   }
 
+  public newFileNameError(fileName: string): string | null {
+    // Must match _getWhitelistFilePredicates()
+    if (fileName.indexOf('.ipynb') > -1 || fileName.indexOf('.txt') > -1) {
+      return null;
+    } else {
+      return 'File name must include .txt';
+    }
+  }
+
   public saveText(file: DatalabFile, text: string): Promise<DatalabFile> {
     return GapiManager.drive.patchContent(file.id.path, text)
       .then((upstreamFile) => this._fromUpstreamFile(upstreamFile));
@@ -157,6 +166,7 @@ class DriveFileManager extends BaseFileManager {
 
   protected _getWhitelistFilePredicates() {
     return [
+      // Must match newFileNameIsValid()
       'name contains \'.ipynb\'',
       'name contains \'.txt\'',
       'mimeType = \'' + DriveFileManager._directoryMimeType + '\'',

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -154,6 +154,13 @@ interface FileManager {
   getRootFile(): Promise<DatalabFile>;
 
   /**
+   * Checks whether the given filename is valid for this file manager.
+   * Return an error message if the file would not be returned from list().
+   * Returns null if the name is valid.
+   */
+  newFileNameError(filename: string): string | null;
+
+  /**
    * Saves the given string as a file's content.
    * @param file object containing information about the destination file to
    *             save to.
@@ -238,6 +245,10 @@ class BaseFileManager implements FileManager {
 
   getRootFile(): Promise<DatalabFile> {
     throw new UnsupportedMethod('getRootFile', this);
+  }
+
+  newFileNameError(_filename: string): string | null {
+    return null;
   }
 
   saveText(_file: DatalabFile, _content: string): Promise<DatalabFile> {

--- a/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
+++ b/sources/web/datalab/polymer/modules/file-manager/file-manager.ts
@@ -154,7 +154,7 @@ interface FileManager {
   getRootFile(): Promise<DatalabFile>;
 
   /**
-   * Checks whether the given filename is valid for this file manager.
+   * Checks whether the given non-notebook filename is valid for this file manager.
    * Return an error message if the file would not be returned from list().
    * Returns null if the name is valid.
    */

--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
@@ -124,10 +124,10 @@ class GithubFileManager extends BaseFileManager {
 
   public newFileNameError(fileName: string): string | null {
     // Must match _ghDirEntriesResponseToDatalabFiles()
-    if (fileName.indexOf('.ipynb') > -1 || fileName.indexOf('.txt') > -1) {
+    if (fileName.endsWith('.txt')) {
       return null;
     } else {
-      return 'File name must include .txt';
+      return 'File name must end with .txt';
     }
   }
 

--- a/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/github-file-manager/github-file-manager.ts
@@ -122,6 +122,15 @@ class GithubFileManager extends BaseFileManager {
     return this.get(new DatalabFileId('/', FileManagerType.GITHUB));
   }
 
+  public newFileNameError(fileName: string): string | null {
+    // Must match _ghDirEntriesResponseToDatalabFiles()
+    if (fileName.indexOf('.ipynb') > -1 || fileName.indexOf('.txt') > -1) {
+      return null;
+    } else {
+      return 'File name must include .txt';
+    }
+  }
+
   public saveText(_file: DatalabFile, _content: string): Promise<DatalabFile> {
     throw new UnsupportedMethod('saveText', this);
   }
@@ -193,7 +202,7 @@ class GithubFileManager extends BaseFileManager {
         '/contents/' + pathParts.slice(2).join('/');
     const directory = await this._githubApiPathRequest(githubTreePath) as GhFileResponse[];
     for (const file of directory) {
-      if (file.name === fileName) {
+      if (file && file.name === fileName) {
         // Return the Blob API link.
         return file.git_url.replace('https://api.github.com', '');
       }
@@ -285,6 +294,7 @@ class GithubFileManager extends BaseFileManager {
 
   private _ghDirEntriesResponseToDatalabFiles(response: GhDirEntryResponse[]):
       DatalabFile[] {
+    // Must match newFileNameIsValid()
     return response.filter((file) =>
       file.name.endsWith('.ipynb') ||
       file.name.endsWith('.txt') ||


### PR DESCRIPTION
If you try to create a file with name ending in .ipynb you will see this:

![file-no-ipynb](https://user-images.githubusercontent.com/116825/32680409-619237ec-c61f-11e7-9a98-988bbc8d7375.png)

If you try to create a file that does not include .txt in the name, you will see this:

![file-txt](https://user-images.githubusercontent.com/116825/32680422-6ff571a0-c61f-11e7-8e07-54d9e4174485.png)


