### PR TITLE
Fix pluralization for single items in delete dialog.

### DIFF
--- a/sources/web/datalab/polymer/components/delete-dialog/delete-dialog.html
+++ b/sources/web/datalab/polymer/components/delete-dialog/delete-dialog.html
@@ -28,7 +28,7 @@ the License.
     </style>
 
     <span id="text">
-      Are you sure you want to delete the following [[deletedList.length]] items?
+      Are you sure you want to delete the following [[deletedList.length]] [[itemsLabel]]?
     </span>
     <item-list id="list" disable-selection hide-header></item-list>
 

--- a/sources/web/datalab/polymer/components/delete-dialog/delete-dialog.ts
+++ b/sources/web/datalab/polymer/components/delete-dialog/delete-dialog.ts
@@ -33,11 +33,17 @@ class DeleteDialogElement extends BaseDialogElement {
    */
   public deletedList: ItemListRow[];
 
+  /**
+   * Word to use after the count of items, properly pluralized
+   */
+  public itemsLabel: string;
+
   static get is() { return 'delete-dialog'; }
 
   static get properties() {
     return Object.assign(super.properties, {
       deletedList: Array,
+      itemsLabel: String,
     });
   }
 
@@ -48,6 +54,7 @@ class DeleteDialogElement extends BaseDialogElement {
     this.$.theDialog.addEventListener('iron-overlay-opened', () => {
       const listElement = this.$.list as ItemListElement;
       listElement.rows = this.deletedList;
+      this.itemsLabel = (this.deletedList.length === 1) ? 'item' : 'items';
       // The dialog might need resizing if the list is long. Wait for the DOM
       // flush then tell it to resize.
       Polymer.dom.flush();
@@ -66,7 +73,6 @@ class DeleteDialogElement extends BaseDialogElement {
     }
     return this._memoizedTemplate;
   }
-
 }
 
 customElements.define(DeleteDialogElement.is, DeleteDialogElement);

--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -866,10 +866,11 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
       columns: [this._fileList[i].name],
       icon: this._fileList[i].icon,
     }));
+    const title = (num === 1) ? 'Delete 1 item' : 'Delete ' + num + ' items';
     const deleteOptions: DeleteDialogOptions = {
       deletedList,
       okLabel: 'Delete',
-      title: 'Delete ' + num + ' items',
+      title,
     };
 
     const closeResult = await Utils.showDialog(DeleteDialogElement, deleteOptions);


### PR DESCRIPTION
The delete dialog previously when deleting a single item:
![plural-wrong](https://user-images.githubusercontent.com/116825/32681313-cf57eda4-c623-11e7-93fb-8add2251399b.png)

After this fix:
![plural-fixed](https://user-images.githubusercontent.com/116825/32681315-d5e7a394-c623-11e7-998a-aa9c0c0e6c43.png)

