### PR TITLE
Fix font-size for divider

### DIFF
--- a/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
+++ b/sources/web/datalab/polymer/components/resizable-divider/resizable-divider.html
@@ -59,6 +59,7 @@ the License.
         left: calc(50% - var(--divider-half-width));
         width: calc(2 * var(--divider-half-width));
         line-height: 0.5;
+        font-size: 13px;
         text-align: center;
         display: flex;
         align-items: center;


### PR DESCRIPTION
Since we're using a css trick to show the three vertical dots, font size must be fixed.