### PR TITLE
(Issue #1020) Support toggling comments for %%sql cells.

### DIFF
--- a/sources/web/datalab/static/codemirror/mode/sql.js
+++ b/sources/web/datalab/static/codemirror/mode/sql.js
@@ -428,10 +428,10 @@ define(
         } else {
           return context.indent + (closing ? 0 : indentUnit);
         }
-      }
+      },
+      lineComment: "--"
     };
   });
 
   CodeMirror.defineMIME('text/sql', 'sql');
 });
-


### PR DESCRIPTION
This PR adds a lineComment value to the %%sql cell mode.  The effect of this is to allow for toggling comments with the Ctrl+/ keyboard shortcut via the CodeMirror comment.js addon. 

![screen shot 2017-11-12 at 2 50 50 pm](https://user-images.githubusercontent.com/14703692/32704733-c8a9f262-c7be-11e7-8b25-8055224c7cab.png)
