### PR TITLE
Request fewer Drive scopes.

### DIFF
--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -511,11 +511,12 @@ class GapiManager {
       case GapiScopes.CLOUD:
         return 'https://www.googleapis.com/auth/cloud-platform';
       case GapiScopes.DRIVE:
-        return ['https://www.googleapis.com/auth/drive',
-                'https://www.googleapis.com/auth/drive.appfolder',
-                'https://www.googleapis.com/auth/drive.readonly.metadata',
-                'https://www.googleapis.com/auth/drive.install',
-                'https://www.googleapis.com/auth/drive.file'].join(' ');
+        const driveScopeList = [
+            'https://www.googleapis.com/auth/drive',
+            'https://www.googleapis.com/auth/drive.appfolder',
+            'https://www.googleapis.com/auth/drive.install',
+        ];
+        return driveScopeList.join(' ');
       case GapiScopes.SIGNIN:
           return 'profile email';
       default:


### PR DESCRIPTION
drive.file and drive.readonly.metadata are subsumed by drive so are not needed.