### PR TITLE
Fix bug where root id appeared in breadcrumbs.

### DIFF
--- a/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/drive-file-manager/drive-file-manager.ts
@@ -33,6 +33,7 @@ class DriveFileManager extends BaseFileManager {
 
   private static readonly _directoryMimeType = 'application/vnd.google-apps.folder';
   private static readonly _notebookMimeType = 'application/json';
+  private _rootDriveId: string;
 
   public async get(fileId: DatalabFileId): Promise<DatalabFile> {
     const upstreamFile = await GapiManager.drive.getFile(fileId.path);
@@ -49,6 +50,7 @@ class DriveFileManager extends BaseFileManager {
 
   public async getRootFile(): Promise<DatalabFile> {
     const upstreamFile = await GapiManager.drive.getRoot();
+    this._rootDriveId = upstreamFile.id;
     return this._fromUpstreamFile(upstreamFile);
   }
 
@@ -134,10 +136,14 @@ class DriveFileManager extends BaseFileManager {
     } else {
       // TODO - create the real path to this object, or figure out
       // a better way to handle not having the full path in the breadcrumbs
+      if (!this._rootDriveId) {
+        await this.getRootFile();
+      }
       const fileId = path;  // We assume the entire path is one fileId
+      const filePath = (fileId === this._rootDriveId) ? '' : path;
       const datalabFile: DriveFile = new DriveFile(
         new DatalabFileId(fileId, FileManagerType.DRIVE),
-        path,
+        filePath,
         DatalabFileType.DIRECTORY,
       );
       return [datalabFile];


### PR DESCRIPTION
Previous to this bug fix, if you use browser reload on the main page of Drive files, it would show the root folder's Drive ID in the breadcrumbs. This reverts it to the previous correct behavior of only showing "/" in the breadcrumbs when viewing the root Drive folder, even if you explicitly Drive root folder by id in the URL.