### PR TITLE
Support base paths without the trailing slash.

### DIFF
--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -315,7 +315,12 @@ function socketHandler(request: http.ServerRequest, socket: net.Socket, head: Bu
 
 function trimBasePath(requestPath: string): string {
   let pathPrefix = appSettings.datalabBasePath;
-  if (requestPath.indexOf(pathPrefix) == 0) {
+  // The base path has been normalized to include leading and trailing slashes,
+  // but the request path may not include the trailing slash. Therefore, we
+  // first specially handle the case of the base path without the trailing slash
+  if (requestPath+"/" === pathPrefix) {
+    return "/";
+  } else if (requestPath.indexOf(pathPrefix) == 0) {
     let newPath = "/" + requestPath.substring(pathPrefix.length);
     return newPath;
   } else {


### PR DESCRIPTION
Prior to this change, if you set a base path to `/foo/bar/`, then
requests to `/foo/bar/` would resolve to requests to the root path,
but requests to `/foo/bar` would result in a 404 error.

This would happen even if you set the base path to `/foo/bar`, as
the server normalizes the base path to include leading and trailing
slashes (to avoid accidental collisions with things like
`/foo/barbutnotreally`).

This change fixes that issue by explicitly checking for the case
that the request path matches the base path without the trailing slash.