### PR TITLE
Fix upload button on Firefox

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -295,6 +295,7 @@ i.material-icons {
 }
 #uploadButton {
   padding: 4px 8px;
+  margin: 0;
 }
 #editorButton {
   display: none;

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -83,11 +83,11 @@
                               style="display:none;">
                             <i class="material-icons">add_box</i> Terminal
                           </button>
-                          <button id="uploadButton" type="button" class="toolbar-btn" title="Upload notebook(s)">
+                          <label id="uploadButton" class="toolbar-btn" title="Upload notebook(s)">
                             <i class="material-icons">file_upload</i>
                             <input type="file" name="datafile" class="fileinput" multiple="multiple" value="Upload" style="cursor: pointer" />
                             Upload
-                          </button>
+                          </label>
                           <button id="duplicateButton" type="button" class="toolbar-btn duplicate-button" title="Create a copy of the selected item(s)">
                             <i class="material-icons">content_copy</i> Copy
                           </button>


### PR DESCRIPTION
Fixes https://github.com/googledatalab/datalab/issues/1815.

Interactive elements aren't allowed inside of `button`s, this is why this fails on Firefox. This PR switches the container to `label`.
