### PR TITLE
Don't delete /var/lib/dpkg/info/*

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -199,7 +199,6 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
 # Clean up
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/* && \
-    rm -rf /var/lib/dpkg/info/* && \
     rm -rf /tmp/* && \
     rm -rf /root/.cache/* && \
     rm -rf /usr/share/locale/* && \


### PR DESCRIPTION
Removing these files prevents installation of other packages (e.g r-base).