### PR TITLE
Use moment.js for relative date in item-list

### DIFF
--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -9,6 +9,7 @@
     "iron-pages": "PolymerElements/iron-pages#^2.0.0",
     "iron-selector": "PolymerElements/iron-selector#^2.0.0",
     "markdown-it": "^8.4.0",
+    "moment": "^2.19.2",
     "neon-animation": "PolymerElements/neon-animation#^2.0.1",
     "paper-behaviors": "PolymerElements/paper-behaviors#^2.0.0",
     "paper-button": "PolymerElements/paper-button#^2.0.0",

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -212,4 +212,5 @@ the License.
   </template>
 </dom-module>
 
+<script src="../../bower_components/moment/moment.js"></script>
 <script src="item-list.js"></script>

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -12,6 +12,9 @@
  * the License.
  */
 
+// moment.js typings
+declare function moment(d: Date): any;
+
 type ColumnType = Date|number|string;
 
 enum ColumnTypeName {
@@ -199,6 +202,11 @@ class ItemListElement extends Polymer.Element {
    */
   public inlineDetailsMode: InlineDetailsDisplayMode;
 
+  /**
+   * Whether dates should be shown as time-ago
+   */
+  public useRelativeDates: boolean;
+
   _filterString: string;
   _showFilterBox: boolean;
 
@@ -256,6 +264,10 @@ class ItemListElement extends Polymer.Element {
         type: Array,
         value: () => [],
       },
+      useRelativeDates: {
+        type: Boolean,
+        value: true,
+      },
     };
   }
 
@@ -282,7 +294,9 @@ class ItemListElement extends Polymer.Element {
   _formatColumnValue(value: ColumnType, i: number, columns: Column[]): string {
     if (columns[i]) {
       if (columns[i].type === ColumnTypeName.DATE) {
-        return (value as Date).toLocaleString();
+        return this.useRelativeDates ?
+                  moment(value as Date).fromNow() :
+                  (value as Date).toLocaleString();
       } else {
         return value.toString();
       }
@@ -309,10 +323,7 @@ class ItemListElement extends Polymer.Element {
 
     this.$.list.sort = (a: ItemListRow, b: ItemListRow) => {
       // Bail out of sort if no columns have been set yet.
-      if (!this.columns.length) {
-        return;
-      }
-      if (a.columns[column] === b.columns[column]) {
+      if (!this.columns.length || a.columns[column] === b.columns[column]) {
         return 0;
       }
       let compResult = -1;

--- a/sources/web/datalab/polymer/package.json
+++ b/sources/web/datalab/polymer/package.json
@@ -20,9 +20,10 @@
     "@types/sinon": "^2.3.7",
     "@types/socket.io-client": "^1.4.30",
     "bower": "^1.8.2",
-    "web-component-tester": "~6.3.0",
+    "moment": "^2.19.2",
     "polymer-cli": "^1.5.7",
     "tslint": "^5.7.0",
-    "typescript": "^2.5.3"
+    "typescript": "^2.5.3",
+    "web-component-tester": "~6.3.0"
   }
 }

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -530,6 +530,7 @@ describe('<item-list>', () => {
 
     beforeEach(async () => {
       testFixture = fixture('item-list-fixture');
+      testFixture.useRelativeDates = false;
       testFixture.rows = rows;
       testFixture.columns = [{
         name: 'col1',
@@ -549,6 +550,21 @@ describe('<item-list>', () => {
         assert(columns[0].innerText === sortedColumns[0]);
         assert(columns[1].innerText === new Date(sortedColumns[1].toString()).toLocaleString());
       }
+    });
+
+    it('uses moment for relative dates when enabled', () => {
+      testFixture.useRelativeDates = true;
+      testFixture.rows = [
+        new ItemListRow({columns: [Date.now()]})
+      ];
+      testFixture.columns = [{
+        name: 'col1',
+        type: ColumnTypeName.DATE,
+      }];
+      const renderedRows = testFixture.$.listContainer.querySelectorAll('.row');
+      assert(renderedRows.length === 1);
+      const columns = renderedRows[0].querySelectorAll('.column');
+      assert(columns[0].innerText === 'a few seconds ago');
     });
 
     it('switches sort to descending order if first column is sorted on again', () => {


### PR DESCRIPTION
This PR adds using moment.js to display relative dates in item-list optionally. This is enabled by default, and can be turned off using an attribute.

![image](https://user-images.githubusercontent.com/1424661/33035591-5fe9b402-ce34-11e7-9e29-6e0ece02e94c.png)

This also addresses a comment from the last PR, to return 0 in the sort function if columns have not been defined yet.