### PR TITLE
Support pulling from private gcr repositories

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -194,6 +194,7 @@ write_files:
 
     [Service]
     Environment="HOME=/home/datalab"
+    ExecStartPre=docker-credential-gcr configure-docker
     ExecStart=/usr/bin/docker run --rm -u 0 \
        --name=datalab \
        -p 127.0.0.1:8080:8080 \


### PR DESCRIPTION
Configure docker with GCR credentials to access private repositories inside.
Useful for using customized images.
Tested with both public and private repositories.
Resolves #1822

Contributed under the @tapad CLA.