### PR TITLE
Remove unneeded assert typescript declaration

### DIFF
--- a/sources/web/datalab/polymer/test/test-utils.ts
+++ b/sources/web/datalab/polymer/test/test-utils.ts
@@ -16,7 +16,6 @@
 /// <reference path="../node_modules/@types/chai/index.d.ts" />
 /// <reference path="../node_modules/@types/sinon/index.d.ts" />
 
-declare function assert(condition: boolean, message: string): null;
 declare function fixture(element: string): any;
 
 class MockFile extends DatalabFile {


### PR DESCRIPTION
The declaration is redundant after including `chai`. It's inconsistent with the chai declaration, which allows the `message` parameter to be undefined.

Fixes #1835.