### PR TITLE
Hide the input element for file upload

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -291,6 +291,7 @@ i.material-icons {
   font-weight: normal;
 }
 .alternate_upload input.fileinput {
+  visibility: hidden;
   height: 40px;
 }
 #uploadButton {


### PR DESCRIPTION
Only the element's functionality is needed, the label is the click target.