### PR TITLE
Fix a search-and-replace bug

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -185,7 +185,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
           KeyboardInterrupt: When the end user kills the connection
           subprocess.CalledProcessError: If the connection dies on its own
         """
-        if utils.print_info_message_templates(args):
+        if utils.print_info_messages(args):
             print('Connecting to {0} via SSH').format(instance)
 
         cmd = ['ssh']
@@ -336,7 +336,7 @@ def maybe_start(args, gcloud_compute, instance, status):
       subprocess.CalledProcessError: If one of the `gcloud` calls fail
     """
     if status != _STATUS_RUNNING:
-        if utils.print_info_message_templates(args):
+        if utils.print_info_messages(args):
             print('Restarting the instance {0} with status {1}'.format(
                 instance, status))
         start_cmd = ['instances', 'start']


### PR DESCRIPTION
This change fixes a bug that was introduced by commit 9113d3881ec2921a16e803295f62dbc5123e25e7. The source of the bug was that `utils.print_info_messages` was erroneously changed to `utils.print_info_message_templates` when I tried to rename a group of unrelated variables.