### PR TITLE
Fix a bug in passing the base path to proxied servers.

### DIFF
--- a/sources/web/datalab/reverseProxy.ts
+++ b/sources/web/datalab/reverseProxy.ts
@@ -20,6 +20,7 @@
 import http = require('http');
 import httpProxy = require('http-proxy');
 import logging = require('./logging');
+import path = require('path');
 import url = require('url');
 
 var appSettings: common.AppSettings;
@@ -70,7 +71,7 @@ export function getRequestPort(request: http.ServerRequest, path: string): strin
 export function handleRequest(request: http.ServerRequest,
                               response: http.ServerResponse,
                               port: String) {
-  request.url = request.url.replace(regex, '');
+  request.url = path.join(appSettings.datalabBasePath, request.url.replace(regex, ''));
   let target = 'http://localhost:' + port;
 
   // Only web socket requests (through socket.io) need the basepath appended


### PR DESCRIPTION
This change fixes a bug in the reverse proxy where the base path
(if set) was not being passed to other local servers to which
we proxied.

In particular, this meant the ungit UI could not be loaded if the
base path was set.