### PR TITLE
Reload the window after signing out

### DIFF
--- a/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
+++ b/sources/web/datalab/polymer/components/auth-panel/auth-panel.ts
@@ -55,7 +55,9 @@ class AuthPanel extends Polymer.Element {
     // If the user explicitly signs out, then set a flag so that we ask for
     // confirmation when he logs back in.
     this._promptOnSignIn = true;
-    GapiManager.signOut();
+    GapiManager.signOut()
+      .catch()
+      .then(() => window.location.reload());
   }
 
   _signInChanged(signedIn: boolean) {


### PR DESCRIPTION
.. in order to send the user back to the oauth login page.

We still need some more work here to detect user sign in status and redirect to oauth page before any HTML is rendered.