### PR TITLE
Don't create a swapfile if there is not enough disk space.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -131,7 +131,7 @@ configure_swap() {{
   # Specifically, if the free space on disk is not N times the
   # size of memory, then enabling swap makes no sense.
   #
-  # Arbitrarily choosing a value of N=10 
+  # Arbitrarily choosing a value of N=10
   disk_kb_cutoff=`expr 10 "*" ${{memory_kb}}`
   disk_kb_available=`df --output=avail ${{MOUNT_DIR}} | tail -n 1`
   if [ "${{disk_kb_available}}" -lt "${{disk_kb_cutoff}}" ]; then
@@ -678,8 +678,8 @@ def run(args, gcloud_compute, gcloud_repos,
                 args.image_name, _DATALAB_NOTEBOOKS_REPOSITORY))
             startup_script_file.close()
             user_data_file.write(_DATALAB_CLOUD_CONFIG.format(
-                    args.image_name, enable_backups,
-                    console_log_level, escaped_email, initial_user_settings))
+                args.image_name, enable_backups,
+                console_log_level, escaped_email, initial_user_settings))
             user_data_file.close()
             for_user_file.write(user_email)
             for_user_file.close()

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -127,9 +127,14 @@ configure_swap() {{
   mem_total_value=`echo "${{mem_total_line}}" | cut -d ':' -f 2`
   memory_kb=`echo "${{mem_total_value}}" | cut -d 'k' -f 1 | tr -d '[:space:]'`
 
+  # Before proceeding, check if we have more disk than memory.
+  # Specifically, if the free space on disk is not N times the
+  # size of memory, then enabling swap makes no sense.
+  #
+  # Arbitrarily choosing a value of N=10 
   disk_kb_cutoff=`expr 10 "*" ${{memory_kb}}`
-  disk_kb=`df --output=size ${{MOUNT_DIR}} | tail -n 1`
-  if [ "${{disk_kb}}" -lt "${{disk_kb_cutoff}}" ]; then
+  disk_kb_available=`df --output=avail ${{MOUNT_DIR}} | tail -n 1`
+  if [ "${{disk_kb_available}}" -lt "${{disk_kb_cutoff}}" ]; then
     return
   fi
 

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -126,6 +126,13 @@ configure_swap() {{
   mem_total_line=`cat /proc/meminfo | grep MemTotal`
   mem_total_value=`echo "${{mem_total_line}}" | cut -d ':' -f 2`
   memory_kb=`echo "${{mem_total_value}}" | cut -d 'k' -f 1 | tr -d '[:space:]'`
+
+  disk_kb_cutoff=`expr 10 "*" ${{memory_kb}}`
+  disk_kb=`df --output=size ${{MOUNT_DIR}} | tail -n 1`
+  if [ "${{disk_kb}}" -lt "${{disk_kb_cutoff}}" ]; then
+    return
+  fi
+
   swapfile="${{MOUNT_DIR}}/swapfile"
 
   # Create the swapfile if it is either missing or not big enough


### PR DESCRIPTION
This change adds a check to the Datalab instance startup script where
the swapfile creation/usage is prevented if the free disk space is not at
least 10x the size of memory.

This is the first step towards addressing #1839, but the full issue
won't be fixed until we also provide a way to turn off swap entirely
for users who do not want it.