### PR TITLE
Make sure pointer-events are enabled on toolbar

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
+++ b/sources/web/datalab/polymer/components/datalab-toolbar/datalab-toolbar.html
@@ -55,6 +55,7 @@ the License.
         display: flex;
         height: var(--toolbar-height);
         padding-right: 6px;
+        pointer-events: all;
       }
       paper-icon-button {
         margin-right: 16px;


### PR DESCRIPTION
In some cases the toolbar buttons would have pointer-events set to none by the Polymer template. This makes sure they're clickable.