### PR TITLE
Fix loading newly created notebooks

### DIFF
--- a/sources/web/datalab/polymer/notebook.ts
+++ b/sources/web/datalab/polymer/notebook.ts
@@ -138,13 +138,15 @@ async function createNew(parentPath: string) {
   toast.open();
 
   try {
-    await GapiManager.loadGapi();
-
     const parentId = DatalabFileId.fromString(parentPath);
     const fileName = queryParams.get('fileName') as string;
     const fileManager = FileManagerFactory.getInstanceForType(
       FileManagerFactory.fileManagerNameToType(parentId.source));
     const newFile = await fileManager.create(DatalabFileType.NOTEBOOK, parentId, fileName);
+
+    if (fileManager instanceof DriveFileManager) {
+      await GapiManager.loadGapi();
+    }
 
     // If this is a template, populate it
     if (queryParams.has('templateName')) {

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -248,11 +248,11 @@ function handleRequest(request: http.ServerRequest,
 /**
  * Returns true iff the supplied path should be handled by the static handler
  */
-function isStaticResource(urlpath: string) {
+function isStaticResource(urlpath: string, search: string) {
   // /static and /custom paths for returning static content
   return urlpath.indexOf('/custom') == 0 ||
          urlpath.indexOf('/static') == 0 ||
-         static_.isExperimentalResource(urlpath);
+         static_.isExperimentalResource(urlpath, search);
 }
 
 /**
@@ -279,7 +279,7 @@ function uncheckedRequestHandler(request: http.ServerRequest, response: http.Ser
     auth.handleAuthFlow(request, response, parsed_url, appSettings);
   } else if (reverseProxyPort) {
     reverseProxy.handleRequest(request, response, reverseProxyPort);
-  } else if (isStaticResource(urlpath)) {
+  } else if (isStaticResource(urlpath, parsed_url.search)) {
     staticHandler(request, response);
   } else {
     handleRequest(request, response, urlpath);


### PR DESCRIPTION
This PR fixes a few things with the experimental UI:
- When creating a new notebook, we now redirect to a new page, serving notebook.js, that does the creation, but this page wasn't served correctly.
- No need to load gapi on the notebook page unless it's actually needed (DriveFileManager).
- Downloading the notebook was broken because of the '/files' handler.