### PR TITLE
Report actual test exit code instead of "tee"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,4 +41,4 @@ script:
 - cd ../sources/web/datalab/polymer/test
 - export DISPLAY=:99.0
 - export TEST_LOG="${HOME}/${TRAVIS_JOB_NUMBER}_npm_test.log"
-- timeout 2m bash -c "npm test -- --verbose | tee '${TEST_LOG}'" || grep "Test run ended with great success" "${TEST_LOG}"
+- timeout 2m bash -c "npm test -- --verbose | tee '${TEST_LOG}'; exit ${PIPESTATUS[0]}" || grep "Test run ended with great success" "${TEST_LOG}"


### PR DESCRIPTION
If Polymer tests fail within the timeout (2m), the exit code that is actually returned is that of "tee", which is always zero, so the failure is never reported. This fixes that by reporting the first exit status in the pipe, which is that of the test command.