### PR TITLE
Fix delete dialog not showing item names

### DIFF
--- a/sources/web/datalab/polymer/components/delete-dialog/delete-dialog.html
+++ b/sources/web/datalab/polymer/components/delete-dialog/delete-dialog.html
@@ -30,7 +30,7 @@ the License.
     <span id="text">
       Are you sure you want to delete the following [[deletedList.length]] [[itemsLabel]]?
     </span>
-    <item-list id="list" disable-selection hide-header></item-list>
+    <item-list id="list" columns='["Name"]' disable-selection hide-header></item-list>
 
   </template>
 </dom-module>


### PR DESCRIPTION
The column name is needed in order to show the items.