### PR TITLE
Fix item-list index issues while sorting/filtering

### DIFF
--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -381,7 +381,7 @@ class ItemListElement extends Polymer.Element {
     const allElements = this.$.listContainer.querySelectorAll('paper-item') as NodeList;
     return Array.from(allElements)
         .filter((el: HTMLElement) => el.hasAttribute('selected'))
-        .map((el: HTMLElement) => this.$.list.indexForElement(el));
+        .map((el: HTMLElement) => this.$.list.modelForElement(el).itemsIndex);
   }
 
   /**
@@ -403,7 +403,7 @@ class ItemListElement extends Polymer.Element {
    * Selects an item in the list.
    * @param index index of item to select
    */
-  _selectItem(index: number) {
+  _selectItemByDisplayedIndex(index: number) {
     // Get the real item's index
     const element = this.$.listContainer.querySelector('paper-item:nth-of-type(' + (index + 1 ) + ')');
     const itemsIndex = this.$.list.modelForElement(element).itemsIndex;
@@ -415,7 +415,7 @@ class ItemListElement extends Polymer.Element {
    * Unselects an item in the list.
    * @param index index of item to unselect
    */
-  _unselectItem(index: number) {
+  _unselectItemByDisplayedIndex(index: number) {
     const element = this.$.listContainer.querySelector('paper-item:nth-of-type(' + (index + 1 ) + ')');
     const itemsIndex = this.$.list.modelForElement(element).itemsIndex;
     this.set('rows.' + itemsIndex + '.selected', false);
@@ -458,7 +458,7 @@ class ItemListElement extends Polymer.Element {
    */
   _selectAll() {
     this.rows.forEach((_, i) => {
-      this._selectItem(i);
+      this._selectItemByDisplayedIndex(i);
     });
   }
 
@@ -467,7 +467,7 @@ class ItemListElement extends Polymer.Element {
    */
   _unselectAll() {
     this.rows.forEach((_, i) => {
-      this._unselectItem(i);
+      this._unselectItemByDisplayedIndex(i);
     });
   }
 
@@ -502,15 +502,15 @@ class ItemListElement extends Polymer.Element {
       const start = Math.min(this._lastSelectedIndex, displayedIndex);
       const end = Math.max(this._lastSelectedIndex, displayedIndex);
       for (let i = start; i <= end; ++i) {
-        this._selectItem(i);
+        this._selectItemByDisplayedIndex(i);
       }
     } else if (!this.noMultiselect && (e.ctrlKey || e.metaKey)) {
       // If ctrl (or Meta for MacOS) key is pressed, toggle its selection.
 
       if (this.rows[itemsIndex].selected === false) {
-        this._selectItem(displayedIndex);
+        this._selectItemByDisplayedIndex(displayedIndex);
       } else {
-        this._unselectItem(displayedIndex);
+        this._unselectItemByDisplayedIndex(displayedIndex);
       }
     } else {
       // No modifier keys are pressed, proceed normally to select/unselect the item.
@@ -521,14 +521,14 @@ class ItemListElement extends Polymer.Element {
       if (target.tagName === 'PAPER-CHECKBOX') {
         if (this.rows[itemsIndex].selected === false) {
           // Remove this element from the selected elements list if it's being unselected
-          this._unselectItem(displayedIndex);
+          this._unselectItemByDisplayedIndex(displayedIndex);
         } else {
           // Add this element to the selected elements list if it's being selected,
-          this._selectItem(displayedIndex);
+          this._selectItemByDisplayedIndex(displayedIndex);
         }
       } else {
         this._unselectAll();
-        this._selectItem(displayedIndex);
+        this._selectItemByDisplayedIndex(displayedIndex);
       }
     }
 

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -401,24 +401,22 @@ class ItemListElement extends Polymer.Element {
 
   /**
    * Selects an item in the list.
-   * @param index index of item to select
+   * @param index display index of item to select
    */
   _selectItemByDisplayedIndex(index: number) {
     // Get the real item's index
-    const element = this.$.listContainer.querySelector('paper-item:nth-of-type(' + (index + 1 ) + ')');
-    const itemsIndex = this.$.list.modelForElement(element).itemsIndex;
-    this.set('rows.' + itemsIndex + '.selected', true);
+    const realIndex = this._displayIndexToRealIndex(index);
+    this.set('rows.' + realIndex + '.selected', true);
     this._updateItemSelection(index, true);
   }
 
   /**
    * Unselects an item in the list.
-   * @param index index of item to unselect
+   * @param index display index of item to unselect
    */
   _unselectItemByDisplayedIndex(index: number) {
-    const element = this.$.listContainer.querySelector('paper-item:nth-of-type(' + (index + 1 ) + ')');
-    const itemsIndex = this.$.list.modelForElement(element).itemsIndex;
-    this.set('rows.' + itemsIndex + '.selected', false);
+    const realIndex = this._displayIndexToRealIndex(index);
+    this.set('rows.' + realIndex + '.selected', false);
     this._updateItemSelection(index, false);
   }
 
@@ -492,7 +490,7 @@ class ItemListElement extends Polymer.Element {
     }
     const target = e.target as HTMLDivElement;
     const displayedIndex = this.$.list.indexForElement(target);
-    const itemsIndex = this.$.list.modelForElement(target).itemsIndex;
+    const realIndex = this.$.list.modelForElement(target).itemsIndex;
 
     // If shift key is pressed and we had saved the last selected index, select
     // all items from this index till the last selected.
@@ -507,7 +505,7 @@ class ItemListElement extends Polymer.Element {
     } else if (!this.noMultiselect && (e.ctrlKey || e.metaKey)) {
       // If ctrl (or Meta for MacOS) key is pressed, toggle its selection.
 
-      if (this.rows[itemsIndex].selected === false) {
+      if (this.rows[realIndex].selected === false) {
         this._selectItemByDisplayedIndex(displayedIndex);
       } else {
         this._unselectItemByDisplayedIndex(displayedIndex);
@@ -519,7 +517,7 @@ class ItemListElement extends Polymer.Element {
       // the UI, so change the item's selection state to match the checkbox's new value.
       // Otherwise, select this element, unselect all others.
       if (target.tagName === 'PAPER-CHECKBOX') {
-        if (this.rows[itemsIndex].selected === false) {
+        if (this.rows[realIndex].selected === false) {
           // Remove this element from the selected elements list if it's being unselected
           this._unselectItemByDisplayedIndex(displayedIndex);
         } else {
@@ -540,14 +538,20 @@ class ItemListElement extends Polymer.Element {
    * On row double click, fires an event with the clicked item's index.
    */
   _rowDoubleClicked(e: MouseEvent) {
-    const index = this.$.list.modelForElement(e.target).itemsIndex;
-    const ev = new ItemClickEvent('itemDoubleClick', { detail: {index} });
+    const realIndex = this.$.list.modelForElement(e.target).itemsIndex;
+    const ev = new ItemClickEvent('itemDoubleClick', { detail: {realIndex} });
     this.dispatchEvent(ev);
   }
 
   private _getRowDetailsContainer(index: number) {
     const nthDivSelector = 'div.row-details:nth-of-type(' + (index + 1) + ')';
     return this.$.listContainer.querySelector(nthDivSelector);
+  }
+
+  private _displayIndexToRealIndex(index: number) {
+    const element = this.$.listContainer.querySelector(
+        'paper-item:nth-of-type(' + (index + 1 ) + ')');
+    return this.$.list.modelForElement(element).itemsIndex;
   }
 
 }

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -519,7 +519,7 @@ class ItemListElement extends Polymer.Element {
    * the selected rows, otherwise selects it only.
    * Note the distinction between displayIndex, which is the index of the item
    * in the rendered list, and realIndex, which is the index of the item in the
-   * original list that was submitte to the item-list element. These might be
+   * original list that was submitted to the item-list element. These might be
    * different when filtering or sorting.
    */
   _rowClicked(e: MouseEvent) {
@@ -577,7 +577,7 @@ class ItemListElement extends Polymer.Element {
    */
   _rowDoubleClicked(e: MouseEvent) {
     const realIndex = this.$.list.modelForElement(e.target).itemsIndex;
-    const ev = new ItemClickEvent('itemDoubleClick', { detail: {realIndex} });
+    const ev = new ItemClickEvent('itemDoubleClick', { detail: {index: realIndex} });
     this.dispatchEvent(ev);
   }
 

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -168,7 +168,7 @@ window.addEventListener('WebComponentsReady', () => {
     it('enables all buttons when one file is selected', () => {
       const files: ItemListElement = testFixture.$.files;
       files._unselectAll();
-      files._selectItem(0);
+      files._selectItemByDisplayedIndex(0);
       alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
       singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
       multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
@@ -178,8 +178,8 @@ window.addEventListener('WebComponentsReady', () => {
         disables the rest when two files are selected`, () => {
       const files: ItemListElement = testFixture.$.files;
       files._unselectAll();
-      files._selectItem(0);
-      files._selectItem(1);
+      files._selectItemByDisplayedIndex(0);
+      files._selectItemByDisplayedIndex(1);
       alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
       singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
       multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));

--- a/sources/web/datalab/polymer/test/file-browser-test.ts
+++ b/sources/web/datalab/polymer/test/file-browser-test.ts
@@ -168,7 +168,7 @@ window.addEventListener('WebComponentsReady', () => {
     it('enables all buttons when one file is selected', () => {
       const files: ItemListElement = testFixture.$.files;
       files._unselectAll();
-      files._selectItemByDisplayedIndex(0);
+      files._selectItemByDisplayIndex(0);
       alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
       singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
       multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
@@ -178,8 +178,8 @@ window.addEventListener('WebComponentsReady', () => {
         disables the rest when two files are selected`, () => {
       const files: ItemListElement = testFixture.$.files;
       files._unselectAll();
-      files._selectItemByDisplayedIndex(0);
-      files._selectItemByDisplayedIndex(1);
+      files._selectItemByDisplayIndex(0);
+      files._selectItemByDisplayIndex(1);
       alwaysEnabledButtonIds.forEach((id) => assertEnabledState(id, true));
       singleSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, false));
       multiSelectionEnabledButtonIds.forEach((id) => assertEnabledState(id, true));

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -154,7 +154,7 @@ describe('<item-list>', () => {
   });
 
   it('selects items', () => {
-    testFixture._selectItemByDisplayedIndex(1);
+    testFixture._selectItemByDisplayIndex(1);
 
     assert(!isSelected(0), 'first item should not be selected');
     assert(isSelected(1), 'second item should be selected');
@@ -164,8 +164,8 @@ describe('<item-list>', () => {
   });
 
   it('returns selected items', () => {
-    testFixture._selectItemByDisplayedIndex(0);
-    testFixture._selectItemByDisplayedIndex(2);
+    testFixture._selectItemByDisplayIndex(0);
+    testFixture._selectItemByDisplayIndex(2);
 
     assert(JSON.stringify(testFixture.selectedIndices) === '[0,2]',
         'first and third items should be selected');
@@ -189,7 +189,7 @@ describe('<item-list>', () => {
   });
 
   it('selects all items if the Select All checkbox is clicked with one item selected', () => {
-    testFixture._selectItemByDisplayedIndex(1);
+    testFixture._selectItemByDisplayIndex(1);
     const c = testFixture.$.header.querySelector('#selectAllCheckbox') as HTMLElement;
     c.click();
 
@@ -202,11 +202,11 @@ describe('<item-list>', () => {
 
     assert(!c.checked, 'Select All checkbox should start out unchecked');
 
-    testFixture._selectItemByDisplayedIndex(0);
-    testFixture._selectItemByDisplayedIndex(1);
-    testFixture._selectItemByDisplayedIndex(2);
-    testFixture._selectItemByDisplayedIndex(3);
-    testFixture._selectItemByDisplayedIndex(4);
+    testFixture._selectItemByDisplayIndex(0);
+    testFixture._selectItemByDisplayIndex(1);
+    testFixture._selectItemByDisplayIndex(2);
+    testFixture._selectItemByDisplayIndex(3);
+    testFixture._selectItemByDisplayIndex(4);
 
     assert(c.checked, 'Select All checkbox should become checked');
   });
@@ -217,7 +217,7 @@ describe('<item-list>', () => {
     testFixture._selectAll();
     assert(c.checked, 'Select All checkbox should be checked');
 
-    testFixture._unselectItemByDisplayedIndex(1);
+    testFixture._unselectItemByDisplayIndex(1);
     assert(!c.checked, 'Select All checkbox should become unchecked after unselecting an item');
   });
 
@@ -514,6 +514,22 @@ describe('<item-list>', () => {
       Polymer.dom.flush();
       assert(testFixture.$.listContainer.querySelectorAll('.row').length === 5,
           'all rows should show after closing filter box');
+    });
+
+    it('selects only visible items when Select All checkbox is clicked', () => {
+      testFixture.$.filterToggle.click();
+      testFixture._filterString = '3';
+      Polymer.dom.flush();
+      testFixture.$.selectAllCheckbox.click();
+
+      testFixture._filterString = '';
+      Polymer.dom.flush();
+
+      assert(!isSelected(0), 'only third item should be selected');
+      assert(!isSelected(1), 'only third item should be selected');
+      assert(isSelected(2), 'only third item should be selected');
+      assert(!isSelected(3), 'only third item should be selected');
+      assert(!isSelected(4), 'only third item should be selected');
     });
   });
 

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -154,7 +154,7 @@ describe('<item-list>', () => {
   });
 
   it('selects items', () => {
-    testFixture._selectItem(1);
+    testFixture._selectItemByDisplayedIndex(1);
 
     assert(!isSelected(0), 'first item should not be selected');
     assert(isSelected(1), 'second item should be selected');
@@ -164,8 +164,8 @@ describe('<item-list>', () => {
   });
 
   it('returns selected items', () => {
-    testFixture._selectItem(0);
-    testFixture._selectItem(2);
+    testFixture._selectItemByDisplayedIndex(0);
+    testFixture._selectItemByDisplayedIndex(2);
 
     assert(JSON.stringify(testFixture.selectedIndices) === '[0,2]',
         'first and third items should be selected');
@@ -189,7 +189,7 @@ describe('<item-list>', () => {
   });
 
   it('selects all items if the Select All checkbox is clicked with one item selected', () => {
-    testFixture._selectItem(1);
+    testFixture._selectItemByDisplayedIndex(1);
     const c = testFixture.$.header.querySelector('#selectAllCheckbox') as HTMLElement;
     c.click();
 
@@ -202,11 +202,11 @@ describe('<item-list>', () => {
 
     assert(!c.checked, 'Select All checkbox should start out unchecked');
 
-    testFixture._selectItem(0);
-    testFixture._selectItem(1);
-    testFixture._selectItem(2);
-    testFixture._selectItem(3);
-    testFixture._selectItem(4);
+    testFixture._selectItemByDisplayedIndex(0);
+    testFixture._selectItemByDisplayedIndex(1);
+    testFixture._selectItemByDisplayedIndex(2);
+    testFixture._selectItemByDisplayedIndex(3);
+    testFixture._selectItemByDisplayedIndex(4);
 
     assert(c.checked, 'Select All checkbox should become checked');
   });
@@ -217,7 +217,7 @@ describe('<item-list>', () => {
     testFixture._selectAll();
     assert(c.checked, 'Select All checkbox should be checked');
 
-    testFixture._unselectItem(1);
+    testFixture._unselectItemByDisplayedIndex(1);
     assert(!c.checked, 'Select All checkbox should become unchecked after unselecting an item');
   });
 
@@ -682,6 +682,26 @@ describe('<item-list>', () => {
         const columns = renderedRows[i].querySelectorAll('.column');
         assert(columns[0].innerText === testFixture.rows[sortedOrder[i]].columns[0].toString());
       }
+    });
+
+    it('returns the correct selectedIndices result matching clicked items', () => {
+      testFixture.columns = [{
+        name: 'col1',
+        type: ColumnTypeName.NUMBER,
+      }];
+      testFixture.rows = [
+        new ItemListRow({columns: [1]}),
+        new ItemListRow({columns: [2]}),
+        new ItemListRow({columns: [3]}),
+      ];
+      // Reverse the sorting
+      testFixture._sortBy(0);
+
+      const firstRow = getRow(0);
+      firstRow.click();
+      const selectedIndices = testFixture.selectedIndices;
+      assert(selectedIndices.length === 1, 'only one item should be selected');
+      assert(selectedIndices[0] === 2, 'the third index (shown first) should be selected');
     });
   });
 });

--- a/sources/web/datalab/polymer/test/item-list-test.ts
+++ b/sources/web/datalab/polymer/test/item-list-test.ts
@@ -531,6 +531,18 @@ describe('<item-list>', () => {
       assert(!isSelected(3), 'only third item should be selected');
       assert(!isSelected(4), 'only third item should be selected');
     });
+
+    it('returns the correct selectedIndices result matching clicked items when filtering', () => {
+      testFixture.$.filterToggle.click();
+      testFixture._filterString = '2';
+      Polymer.dom.flush();
+
+      const firstRow = getRow(0);
+      firstRow.click();
+      const selectedIndices = testFixture.selectedIndices;
+      assert(selectedIndices.length === 1, 'only one item should be selected');
+      assert(selectedIndices[0] === 1, 'the second index (only one shown) should be selected');
+    });
   });
 
   describe('sorting', () => {
@@ -700,7 +712,7 @@ describe('<item-list>', () => {
       }
     });
 
-    it('returns the correct selectedIndices result matching clicked items', () => {
+    it('returns the correct selectedIndices result matching clicked items when sorted', () => {
       testFixture.columns = [{
         name: 'col1',
         type: ColumnTypeName.NUMBER,


### PR DESCRIPTION
When sorting/filtering, the selected items' real indices should be distinguished from their render index. This PR fixes a bug where this wasn't the element's behavior, and the element returned the render indices of the items selected.

Additionally, this PR also fixes the behavior of Select/Unselect All to only work on the currently visible (filtered) items.

Fixes https://github.com/googledatalab/datalab/issues/1857.