### PR TITLE
Silence a deprecation warning from gcloud.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -588,7 +588,7 @@ def ensure_repo_exists(args, gcloud_repos, repo_name):
       subprocess.CalledProcessError: If the `gcloud` command fails
     """
     list_cmd = ['list', '--quiet',
-                '--filter', 'name:*/repos/{}'.format(repo_name),
+                '--filter', 'name~^.*/repos/{}$'.format(repo_name),
                 '--format', 'value(name)']
     with tempfile.TemporaryFile() as tf:
         gcloud_repos(args, list_cmd, stdout=tf)


### PR DESCRIPTION
The `datalab create` command is using a regex format for listing
the cloud source repositories that will be unsupported by a future
version of gcloud.

That causes gcloud to print a warning message (that does not get
presented to the user) about the format changing.

This commit fixes that by switching to the new format.