### PR TITLE
Improve the default verbosity.

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -185,7 +185,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
           KeyboardInterrupt: When the end user kills the connection
           subprocess.CalledProcessError: If the connection dies on its own
         """
-        if utils.print_info_messages(args):
+        if utils.print_debug_messages(args):
             print('Connecting to {0} via SSH').format(instance)
 
         cmd = ['ssh']
@@ -336,7 +336,7 @@ def maybe_start(args, gcloud_compute, instance, status):
       subprocess.CalledProcessError: If one of the `gcloud` calls fail
     """
     if status != _STATUS_RUNNING:
-        if utils.print_info_messages(args):
+        if utils.print_debug_messages(args):
             print('Restarting the instance {0} with status {1}'.format(
                 instance, status))
         start_cmd = ['instances', 'start']

--- a/tools/cli/commands/utils.py
+++ b/tools/cli/commands/utils.py
@@ -270,4 +270,16 @@ def print_info_messages(args):
       True iff the verbosity has been set to a level that includes
           info messages.
     """
-    return args.verbosity in ['debug', 'info']
+    return args.verbosity in ['debug', 'info', 'default']
+
+
+def print_debug_messages(args):
+    """Return whether or not debug messages should be printed.
+
+    Args:
+      args: The Namespace instance returned by argparse
+    Returns:
+      True iff the verbosity has been set to a level that includes
+          debug messages.
+    """
+    return args.verbosity == 'debug'


### PR DESCRIPTION
The previous default verbosity level was 'error'. This produces more
concise output, but it caused a good deal of user confusion when
the tool needed to perform a lot of setup steps (like creating a
network), and the user had no indication of what was going on.

The effect of that previous behavior was that the `datalab create`
command would seemingly hang for several minutes without giving
the user any indication whether or not it was making progress.

To avoid that issue, this change modifies the default verbosity
level to provide the user a notification every time the tool
starts to perform a potentially long-running operation.

More specifically, under the new behavior, the tool will print
(by default) a message before it:

1. Creates the network
2. Creates the firewall rule
3. Creates the source repository
4. Creates the notebooks persistent disk

Each of these messages is only printed if the setup step is actually
going to be performed. For instance, if the network already exists,
then no message is printed about the network.

Users who do not want this level of detail can override it by
setting the verbosity level to one of 'warning', 'error', 'critical',
or 'none'.