### PR TITLE
Check existing dialogs before opening new ones

### DIFF
--- a/sources/web/datalab/polymer/components/file-browser/file-browser.ts
+++ b/sources/web/datalab/polymer/components/file-browser/file-browser.ts
@@ -759,7 +759,8 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
     const dialogElem = itemType === DatalabFileType.NOTEBOOK ?
         NewNotebookDialogElement :
         InputDialogElement;
-    const closeResult = await Utils.showDialog(dialogElem, inputOptions);
+    const closeResult = await Utils.showDialog(dialogElem, inputOptions) as
+        InputDialogCloseResult;
 
     // Only if the dialog has been confirmed with some user input, create the
     // new file. Then if that is successful, reload the file list
@@ -786,7 +787,7 @@ class FileBrowserElement extends Polymer.Element implements DatalabPageElement {
           const url = Utils.getHostRoot() + Utils.constants.newNotebookUrlComponent +
               this.currentFile.id + '?fileName=' + newName +
               '&templateName=newNotebook' +
-              '&kernel=' + closeResult.kernel;
+              '&kernel=' + (closeResult as NewNotebookDialogCloseResult).kernel;
           window.open(url, '_blank');
         } else {
           await this._fileManager.create(itemType, this.currentFile.id, newName);

--- a/sources/web/datalab/polymer/modules/utils/utils.ts
+++ b/sources/web/datalab/polymer/modules/utils/utils.ts
@@ -77,7 +77,17 @@ class Utils {
    * @param dialogOptions specifies different options for opening the dialog
    */
   public static async showDialog(dialogType: typeof BaseDialogElement,
-                                 dialogOptions: BaseDialogOptions) {
+                                 dialogOptions: BaseDialogOptions)
+                                 : Promise<BaseDialogCloseResult> {
+    // First, make sure another dialog of the same type isn't shown. If it is,
+    // cancel this one.
+    const dialogs = document.querySelectorAll(dialogType.is) as NodeListOf<BaseDialogElement>;
+    if (dialogs.length) {
+      return {
+        confirmed: false,
+      };
+    }
+
     const dialog = document.createElement(dialogType.is) as any;
     document.body.appendChild(dialog);
 


### PR DESCRIPTION
This fixes an issue where dialogs can be opened multiple times if the toolbar buttons are clicked too quickly.

Currently, we have no use case for opening multiple dialogs on top of each other, but this could change. This PR prevents multiple dialogs *of the same type* from opening, allowing an error dialog for example to appear on top of a new notebook dialog if we need.