### PR TITLE
Fix notebook-app race condition

### DIFF
--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -18,6 +18,12 @@ function initializeDataLab(
     ipy, events, dialog, utils, security, appbar, editapp,
     notebookapp, notebooklist
   ) {
+
+  // Disable add_kernel_help_links as early as possible to avoid a race
+  // condition, where it tries to find some HTML elements that our template
+  // doesn't have, causing the notebook editor to freeze.
+  ipy.MenuBar.prototype.add_kernel_help_links = placeHolder;
+
   var saveFn = function() {
     if (('notebook' in ipy) && ipy.notebook) {
       ipy.notebook.save_checkpoint();

--- a/sources/web/datalab/static/datalab.js
+++ b/sources/web/datalab/static/datalab.js
@@ -18,12 +18,6 @@ function initializeDataLab(
     ipy, events, dialog, utils, security, appbar, editapp,
     notebookapp, notebooklist
   ) {
-
-  // Disable add_kernel_help_links as early as possible to avoid a race
-  // condition, where it tries to find some HTML elements that our template
-  // doesn't have, causing the notebook editor to freeze.
-  ipy.MenuBar.prototype.add_kernel_help_links = placeHolder;
-
   var saveFn = function() {
     if (('notebook' in ipy) && ipy.notebook) {
       ipy.notebook.save_checkpoint();

--- a/sources/web/datalab/static/notebook-app.js
+++ b/sources/web/datalab/static/notebook-app.js
@@ -329,8 +329,6 @@ define(['appbar', 'minitoolbar', 'idle-timeout', 'util'], function(appbar, minit
     });
 
     require(['notebook/js/menubar'], function(ipy) {
-      ipy.MenuBar.prototype.add_kernel_help_links = placeHolder;
-
       // This is just a copy of the one from Jupyter but changes the first
       // line from this.element.find('restore_checkpoint') to
       // $('#restoreButton').


### PR DESCRIPTION
This race condition showed up in long notebooks that had a lot of front-end resources to load, where by the time the `notebook-app.postLoad` executes, the `main.min.js` script had already tried to call the original `add_kernel_help_links`, which hasn't been overridden yet. This caused the UI to freeze completely.