### PR TITLE
Disable file search by default, except on GCP VMs

### DIFF
--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -10,7 +10,6 @@
   "defaultFileManager": "jupyter",
   "docsGcsPath": "gs://cloud-datalab/deploy/docs/",
   "enableAutoGCSBackups": false,
-  "enableFilesystemIndex": false,
   "fakeMetadataAddress": {"host": "metadata.google.internal", "port": 80},
   "feedbackId": "",
   "gatedFeatures": ["timeout", "userSettings"],

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -10,7 +10,7 @@
   "defaultFileManager": "jupyter",
   "docsGcsPath": "gs://cloud-datalab/deploy/docs/",
   "enableAutoGCSBackups": false,
-  "enableFilesystemIndex": true,
+  "enableFilesystemIndex": false,
   "fakeMetadataAddress": {"host": "metadata.google.internal", "port": 80},
   "feedbackId": "",
   "gatedFeatures": ["timeout", "userSettings"],

--- a/sources/web/datalab/fileSearch.ts
+++ b/sources/web/datalab/fileSearch.ts
@@ -16,12 +16,13 @@
 /// <reference path="../../../third_party/externs/ts/chokidar/chokidar.d.ts" />
 /// <reference path="common.d.ts" />
 
-import http = require('http');
-import url = require('url');
-import fs = require('fs');
-import path = require('path');
-import logging = require('./logging');
 import chokidar = require('chokidar');
+import fs = require('fs');
+import http = require('http');
+import info = require('./info');
+import logging = require('./logging');
+import path = require('path');
+import url = require('url');
 
 let appSettings: common.AppSettings;
 let fileIndex: string[] = [];
@@ -54,7 +55,7 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
     fullResultSize: results.length,
     tooManyFiles: tooManyFiles,
     indexReady: indexReady,
-    indexingEnabled: appSettings.enableFilesystemIndex,
+    indexingEnabled: appSettings.enableFilesystemIndex || info.getVmInfo().vm_name,
   }));
   response.end();
 }
@@ -131,7 +132,8 @@ function filter(pattern: string, data: string[]): string[] {
  */
 export function createHandler(settings: common.AppSettings): http.RequestHandler {
   appSettings = settings;
-  if (appSettings.enableFilesystemIndex) {
+  // Always enable the filesystem index on GCP VMs
+  if (appSettings.enableFilesystemIndex || info.getVmInfo().vm_name) {
     indexFiles();
   }
 

--- a/sources/web/datalab/fileSearch.ts
+++ b/sources/web/datalab/fileSearch.ts
@@ -55,7 +55,7 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
     fullResultSize: results.length,
     tooManyFiles: tooManyFiles,
     indexReady: indexReady,
-    indexingEnabled: appSettings.enableFilesystemIndex || info.getVmInfo().vm_name,
+    indexingEnabled: appSettings.enableFilesystemIndex,
   }));
   response.end();
 }
@@ -132,8 +132,12 @@ function filter(pattern: string, data: string[]): string[] {
  */
 export function createHandler(settings: common.AppSettings): http.RequestHandler {
   appSettings = settings;
-  // Always enable the filesystem index on GCP VMs
-  if (appSettings.enableFilesystemIndex || info.getVmInfo().vm_name) {
+  // Unless it has been explicitly disabled, always enable the filesystem index
+  // on GCP VMs
+  if (appSettings.enableFilesystemIndex === undefined && info.getVmInfo().vm_name) {
+    appSettings.enableFilesystemIndex = true;
+  }
+  if (appSettings.enableFilesystemIndex) {
     indexFiles();
   }
 


### PR DESCRIPTION
We've seen a few users hit slowdown issues with a MacOS bug with the Chokidar package we're using for indexing, so we're disabling indexing by default unless the host is a GCP VM, which don't have the slowdown issue.