### PR TITLE
Proxy requests by hostname in addition to URL path.

### DIFF
--- a/sources/web/datalab/reverseProxy.ts
+++ b/sources/web/datalab/reverseProxy.ts
@@ -43,7 +43,7 @@ function getPortFromHost(request: http.ServerRequest) {
       return null;
     }
     const portNumber: string = sr[1];
-    let trimmedHost: string = sr[3];
+    const trimmedHost: string = sr[3];
     const hostname: string = os.hostname();
     if (trimmedHost === hostname) {
       return portNumber;

--- a/sources/web/datalab/reverseProxy.ts
+++ b/sources/web/datalab/reverseProxy.ts
@@ -27,7 +27,7 @@ import url = require('url');
 var appSettings: common.AppSettings;
 var proxy: httpProxy.ProxyServer = httpProxy.createProxyServer(null);
 var regex: any = new RegExp('\/_proxy\/([0-9]+)($|\/)');
-var portInHostRegex: any = new RegExp('^([0-9]+)(\-dot\-|\.)(.*)$');
+var portInHostRegex: any = new RegExp('^([0-9]+)(\-dot\-|\.)(.*)((\:|\/)(.*))$');
 var socketioPort: string = '';
 
 function errorHandler(error: Error, request: http.ServerRequest, response: http.ServerResponse) {
@@ -45,9 +45,7 @@ function getPortFromHost(request: http.ServerRequest) {
     const portNumber: string = sr[1];
     let trimmedHost: string = sr[3];
     const hostname: string = os.hostname();
-    if (trimmedHost === hostname ||
-        trimmedHost.startsWith(hostname+"/") ||
-        trimmedHost.startsWith(hostname+":")) {
+    if (trimmedHost === hostname) {
       return portNumber;
     }
   }

--- a/sources/web/datalab/server.ts
+++ b/sources/web/datalab/server.ts
@@ -144,12 +144,7 @@ function handleRequest(request: http.ServerRequest,
   }
 
   if (requestPath.indexOf('/_nocachecontent/') == 0) {
-    if (process.env.KG_URL) {
-      reverseProxy.handleRequest(request, response, null);
-    }
-    else {
-      noCacheContent.handleRequest(requestPath, response);
-    }
+    noCacheContent.handleRequest(requestPath, response);
     return;
   }
 
@@ -271,14 +266,12 @@ function uncheckedRequestHandler(request: http.ServerRequest, response: http.Ser
 
   logging.logRequest(request, response);
 
-  var reverseProxyPort: string = reverseProxy.getRequestPort(request, urlpath);
-
-  if (urlpath.indexOf('/signin') == 0 || urlpath.indexOf('/signout') == 0 ||
+  if (reverseProxy.isReverseProxyRequest(request)) {
+    reverseProxy.handleRequest(request, response, urlpath);
+  } else if (urlpath.indexOf('/signin') == 0 || urlpath.indexOf('/signout') == 0 ||
       urlpath.indexOf('/oauthcallback') == 0) {
     // Start or return from auth flow.
     auth.handleAuthFlow(request, response, parsed_url, appSettings);
-  } else if (reverseProxyPort) {
-    reverseProxy.handleRequest(request, response, reverseProxyPort);
   } else if (isStaticResource(urlpath, parsed_url.search)) {
     staticHandler(request, response);
   } else {


### PR DESCRIPTION
This change adds support for receiving requests to "${PORT}-dot-$(hostname)",
and forwarding those requests to another server in the container running
on that port.

This is similar to the existing support for proxying requests to
"/_port/${PORT}/", but with one important difference; since the port
number is taken from the host instead of the path, the requests do
not need to be modified and the other server does not need to know
about our proxying logic.

With this change, if I start Datalab locally with the following
command:

    docker run --rm -it \
        --hostname "$(hostname)" \
        -p 127.0.0.1:8082:8080 datalab

then I can send requests to the ungit server at port 8083 by running:

    curl -v 8083-dot-$(hostname):8082

(Assuming I have an /etc/hosts entry for "8083-dot-$(hostname)")