### PR TITLE
Add icon for BQ views.

### DIFF
--- a/sources/web/datalab/polymer/components/datalab-icons/datalab-icons.html
+++ b/sources/web/datalab/polymer/components/datalab-icons/datalab-icons.html
@@ -32,6 +32,10 @@ the License.
             8h2v2H4v-2zm4-4h2v2H8V8zm4 0h2v2h-2V8zm-4 4h2v2H8v-2zm4
             0h2v2h-2v-2z" fill-rule="evenodd"/>
       </g>
+      <g id="bq-view">
+        <path d="M2 2h14v14H2V2z M4 4h10v2h-10v-2z M4 8h10v2h-10v-2z M4 12h2v2h-2v-2z
+            M8 12h2v2h-2v-2z M12 12h2v2h-2v-2z " fill-rule="evenodd"/>
+      </g>
       <g id="drive-logo" transform="scale(.1146)">
         <defs>
           <path id="SVGID_1_" d="M126.02,16H65.98L4,124l29.3,52H158.7l29.3-52L126.02,16z M63.43,124L96,67.8l32.57,56.2H63.43z"/>

--- a/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
+++ b/sources/web/datalab/polymer/modules/bigquery-file-manager/bigquery-file-manager.ts
@@ -257,20 +257,22 @@ class BigQueryFileManager extends BaseFileManager {
   }
 
   private _bqTableToDatalabFile(bqTable: TableResource): DatalabFile {
+    const isView = (bqTable.type === 'VIEW');
     return this._bqProjectDatasetTableIdsToDatalabFile(
       bqTable.tableReference.projectId, bqTable.tableReference.datasetId,
-      bqTable.tableReference.tableId
+      bqTable.tableReference.tableId, isView
     );
   }
 
   private _bqProjectDatasetTableIdsToDatalabFile(
-      projectId: string, datasetId: string, tableId: string): DatalabFile {
+      projectId: string, datasetId: string, tableId: string, isView?: boolean): DatalabFile {
     const path = projectId + '/' + datasetId + '/' + tableId;
+    const icon = isView ? 'datalab-icons:bq-view' : 'datalab-icons:bq-table';
     return new BigQueryFile(
       new DatalabFileId(path, this.myFileManagerType()),
       tableId,
       DatalabFileType.FILE,
-      'datalab-icons:bq-table',
+      icon,
     );
   }
 }


### PR DESCRIPTION
We probably should revisit the BQ icons we are using. For now, this icon provides a bit of visual distinction between BQ tables and views.
![bq-view-icon](https://user-images.githubusercontent.com/116825/34445927-188a2a26-ec8c-11e7-8602-077d0d1617b1.png)
