### PR TITLE
Wait for access token

### DIFF
--- a/sources/web/datalab/polymer/modules/api-manager/api-manager.ts
+++ b/sources/web/datalab/polymer/modules/api-manager/api-manager.ts
@@ -167,7 +167,7 @@ class ApiManager {
   }
 
   public static async uploadOauthAccessToken() {
-    const creds = GapiManager.auth.getAccessTokenInfo();
+    const creds = await GapiManager.auth.getAccessTokenInfo();
     const options: XhrOptions = {
       method: 'POST',
       parameters: JSON.stringify(creds)


### PR DESCRIPTION
`getAccessTokenInfo` recently replaced `getCurrentUser`, which used to be async, but that PR missed the `await`.