### PR TITLE
Switching to Tensorflow 1.4

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -15,7 +15,7 @@
 # We use different base images for GPU vs CPU Dockerfiles, so we expect
 # that the appropriate image is pulled and tagged locally.
 # CPU should use ubuntu:16.04
-# and GPU uses nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04
+# and GPU uses nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04
 FROM datalab-external-base-image
 MAINTAINER Google Cloud DataLab
 
@@ -86,7 +86,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir crcmod==1.7 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir pillow==3.4.1 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir google-cloud-dataflow==2.0.0 && \
-    pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow==1.2.1 && \
+    pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow==1.4.1 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir python-snappy==0.5.1 && \
     pip install -U --upgrade-strategy only-if-needed --no-cache-dir xgboost==0.6a2 && \
     find /usr/local/lib/python2.7 -type d -name tests | xargs rm -rf && \
@@ -136,7 +136,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     pip3 install -U --upgrade-strategy only-if-needed --no-cache-dir bs4==0.0.1 && \
     pip3 install -U --upgrade-strategy only-if-needed --no-cache-dir crcmod==1.7 && \
     pip3 install -U --upgrade-strategy only-if-needed --no-cache-dir pillow==3.4.1 && \
-    pip3 install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow==1.2.1 && \
+    pip3 install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow==1.4.1 && \
     pip3 install -U --upgrade-strategy only-if-needed --no-cache-dir python-snappy==0.5.1 && \
     pip3 install -U --upgrade-strategy only-if-needed --no-cache-dir xgboost==0.6a2 && \
 # Install IPython related packages with no-deps, to ensure that we don't

--- a/containers/base/Dockerfile.gpu
+++ b/containers/base/Dockerfile.gpu
@@ -16,7 +16,7 @@ FROM datalab-core-gpu
 MAINTAINER Google Cloud DataLab
 
 # Download and Install GPU specific packages
-RUN pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow-gpu==1.2.1 tflearn h5py && \
-    pip3 install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow-gpu==1.2.1 tflearn h5py
+RUN pip install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow-gpu==1.4.1 tflearn h5py && \
+    pip3 install -U --upgrade-strategy only-if-needed --no-cache-dir tensorflow-gpu==1.4.1 tflearn h5py
 
 

--- a/containers/base/build.gpu.sh
+++ b/containers/base/build.gpu.sh
@@ -32,11 +32,11 @@ fi
 
 trap 'rm -rf pydatalab' exit
 
-docker pull nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04
+docker pull nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04
 # Docker tag flags changed in an incompatible way between versions.
 # The Datalab Jenkins build still uses the old one, so try it both ways.
-if ! $(docker tag -f nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04 datalab-external-base-image); then
-  docker tag nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04 datalab-external-base-image
+if ! $(docker tag -f nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04 datalab-external-base-image); then
+  docker tag nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04 datalab-external-base-image
 fi
 docker build ${DOCKER_BUILD_ARGS} -t datalab-core-gpu .
 docker build ${DOCKER_BUILD_ARGS} -f Dockerfile.gpu -t datalab-base-gpu .

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -66,10 +66,10 @@ steps:
 
 ## Second, we build the GPU base image
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['pull', 'nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04']
+  args: ['pull', 'nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04']
   id:   'pullNvidiaUbuntu'
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'nvidia/cuda:8.0-cudnn5-devel-ubuntu16.04', 'datalab-external-base-image']
+  args: ['tag', 'nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04', 'datalab-external-base-image']
   id:   'tagNvidiaUbuntu'
   waitFor: ['buildBase', 'pullNvidiaUbuntu']
 - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
Switching to Tensorflow 1.4

Updating to cuDNN v6 for GPU images as that version is required by TF
1.4, this has the additional benefit of adding support for P100 GPUs.

Fixes https://github.com/googledatalab/datalab/issues/1879 and https://github.com/googledatalab/datalab/issues/1803
  