### PR TITLE
Fix a bug where the repo cloning was being interrupted.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -94,6 +94,8 @@ populate_repo() {{
 
 format_disk() {{
   echo "Formatting the persistent disk"
+  docker-credential-gcr configure-docker
+  docker pull {0}
   mkfs.ext4 -F \
     -E lazy_itable_init=0,lazy_journal_init=0,discard \
     ${{PERSISTENT_DISK_DEV}}

--- a/tools/cli/commands/creategpu.py
+++ b/tools/cli/commands/creategpu.py
@@ -148,11 +148,11 @@ write_files:
     RestartSec=1
 
 runcmd:
+- ['while', '[', '!', '-e', '/mnt/disks/datalab-pd/tmp', ']', ';',
+   'do', 'sleep', '1', ';', 'done']
 - systemctl daemon-reload
 - systemctl enable cos-gpu-installer.service
 - systemctl start cos-gpu-installer.service
-- ['while', '[', '!', '-e', '/mnt/disks/datalab-pd/tmp', ']', ';',
-   'do', 'sleep', '1', ';', 'done']
 - systemctl start datalab.service
 - systemctl start logger.service
 """


### PR DESCRIPTION
This fixes an issue that appears to have only occurred with the
COS-based GPU instances, where the instance would fail to clone
the 'datalab-notebooks' repository.

The root cause was that the instance would reboot while the startup
script was running. That would interrupt it after the disk was
formatted, but before the repository was cloned. This, in turn
caused the repo to never be cloned, as subsequent startups would
see that the disk was already formatted.

This change tries to mitigate the likelihood of that happening
by moving the long running operation (downloading the Datalab
image to run the 'git clone' command) to before the disk is
formatted.