### PR TITLE
Improvements to startup reliability.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -111,7 +111,7 @@ checked_format_disk() {{
   if [ -z "$(blkid ${{PERSISTENT_DISK_DEV}})" ]; then
     format_disk
   else
-    echo "Disk already formatted, but mounting failed"
+    echo "Disk already formatted, but mounting failed; rebooting..."
 
     # The mount failed, but the disk seems to already
     # be formatted. Reboot the machine to try again.
@@ -125,7 +125,7 @@ mount_and_prepare_disk() {{
   ${{MOUNT_CMD}} || checked_format_disk
 
   if [ -z "$(mount | grep ${{MOUNT_DIR}})" ]; then
-    echo "Failed to mount the persistent disk"
+    echo "Failed to mount the persistent disk; rebooting..."
     reboot now
   fi
 

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -106,10 +106,29 @@ format_disk() {{
   fi
 }}
 
+checked_format_disk() {{
+  echo "Checking if the persistent disk needs to be formatted"
+  if [ -z "$(blkid ${{PERSISTENT_DISK_DEV}})" ]; then
+    format_disk
+  else
+    echo "Disk already formatted, but mounting failed"
+
+    # The mount failed, but the disk seems to already
+    # be formatted. Reboot the machine to try again.
+    reboot now
+  fi
+}}
+
 mount_and_prepare_disk() {{
   echo "Trying to mount the persistent disk"
   mkdir -p "${{MOUNT_DIR}}"
-  ${{MOUNT_CMD}} || format_disk
+  ${{MOUNT_CMD}} || checked_format_disk
+
+  if [ -z "$(mount | grep ${{MOUNT_DIR}})" ]; then
+    echo "Failed to mount the persistent disk"
+    reboot now
+  fi
+
   chmod a+w "${{MOUNT_DIR}}"
   mkdir -p "${{MOUNT_DIR}}/content"
 
@@ -200,14 +219,34 @@ users:
   groups: docker
 
 write_files:
+- path: /etc/systemd/system/wait-for-startup-script.service
+  permissions: 0755
+  owner: root
+  content: |
+    [Unit]
+    Description=Wait for the startup script to setup required directories
+    Requires=network-online.target gcr-online.target
+    After=network-online.target gcr-online.target
+
+    [Service]
+    User=root
+    Type=oneshot
+    RemainAfterExit=true
+    ExecStartPre=docker-credential-gcr configure-docker
+    ExecStart=/bin/bash -c 'while [ ! -e /mnt/disks/datalab-pd/tmp ]; do \
+        sleep 1; \
+        done'
+
 - path: /etc/systemd/system/datalab.service
   permissions: 0644
   owner: root
   content: |
     [Unit]
     Description=datalab docker container
-    Requires=network-online.target
-    After=network-online.target
+    Requires=network-online.target gcr-online.target \
+             wait-for-startup-script.service
+    After=network-online.target gcr-online.target \
+          wait-for-startup-script.service
 
     [Service]
     Environment="HOME=/home/datalab"
@@ -253,8 +292,6 @@ write_files:
     RestartSec=1
 
 runcmd:
-- ['while', '[', '!', '-e', '/mnt/disks/datalab-pd/tmp', ']', ';',
-   'do', 'sleep', '1', ';', 'done']
 - systemctl daemon-reload
 - systemctl start datalab.service
 - systemctl start logger.service


### PR DESCRIPTION
This tries to make the startup logic for mounting (and, if necessary,
formatting) the persistent disk more reliable. It does that by
making two changes:

1. Verify that the disk has not already been formatted before
   proceeding with the format command.
2. Configure the Datalab systemd service to not start until after
   we have verified that the startup script has finished creating
   the directories that Datalab needs.

The goal of this change is to prevent the sporadic failures reported
in #1898