### PR TITLE
Try Polymer's Typescript decorators on item-list

### DIFF
--- a/sources/web/datalab/polymer/bower.json
+++ b/sources/web/datalab/polymer/bower.json
@@ -25,6 +25,7 @@
     "paper-toast": "PolymerElements/paper-toast#^2.0.0",
     "paper-tooltip": "PolymerElements/paper-tooltip#^2.0.0",
     "polymer": "Polymer/polymer#^2.0.2",
+    "polymer-decorators": "Polymer/polymer-decorators#^0.1.2",
     "socket.io-client": "^2.0.3",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.9",
     "xterm.js": "^2.7.0"

--- a/sources/web/datalab/polymer/components/item-list/item-list.html
+++ b/sources/web/datalab/polymer/components/item-list/item-list.html
@@ -21,6 +21,7 @@ the License.
 <link rel="import" href="../../bower_components/paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../../bower_components/polymer-decorators/polymer-decorators.html">
 
 <dom-module id="item-list">
   <template>

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -162,102 +162,70 @@ class ItemClickEvent extends CustomEvent {
  * If the "disable-selection" attribute is specified, the checkboxes are
  * hidden, and clicking items does not select them.
  */
+@Polymer.decorators.customElement('item-list')
 class ItemListElement extends Polymer.Element {
 
   /**
    * List of data rows, each implementing the row interface
    */
-  public rows: ItemListRow[];
+  @Polymer.decorators.property({type: Array})
+  public rows: ItemListRow[] = [];
 
   /**
    * List of string data columns names
    */
-  public columns: Column[];
+  @Polymer.decorators.property({type: Array})
+  public columns: Column[] = [];
 
   /**
    * Whether to hide the header row
    */
-  public hideHeader: boolean;
+  @Polymer.decorators.property({type: Boolean})
+  public hideHeader = false;
 
   /**
    * Whether to disable item selection
    */
-  public disableSelection: boolean;
+  @Polymer.decorators.property({type: Boolean})
+  public disableSelection = false;
 
   /**
    * Whether to disable multi-selection
    */
-  public noMultiselect: boolean;
+  @Polymer.decorators.property({type: Boolean})
+  public noMultiselect = false;
 
   /**
    * The list of currently selected indices
    */
-  public selectedIndices: number[];
+  @Polymer.decorators.property({
+      computed: '_computeSelectedIndices(rows.*)', notify: true, type: Array})
+  public selectedIndices: number[] = [];
 
   /**
    * Display mode for inline details
    */
-  public inlineDetailsMode: InlineDetailsDisplayMode;
+  @Polymer.decorators.property({type: Object})
+  public inlineDetailsMode = InlineDetailsDisplayMode.NONE;
+
+  @Polymer.decorators.property({type: Boolean})
+  _showFilterBox = false;
+
+  @Polymer.decorators.property({
+      computed: '_computeIsAllSelected(selectedIndices)', type: Boolean})
+  _isAllSelected: boolean;
+
+  @Polymer.decorators.property({
+      computed: '_computeHideCheckboxes(disableSelection, noMultiselect)', type: Boolean})
+  _hideCheckboxes: boolean;
 
   _filterString: string;
-  _showFilterBox: boolean;
 
   private _currentSort = {
     asc: true,   // ascending or descending
     column: -1,  // index of current sort column
   };
   private _lastSelectedIndex = -1;
-
-  static get is() { return 'item-list'; }
-
-  static get properties() {
-    return {
-      _hideCheckboxes: {
-        computed: '_computeHideCheckboxes(disableSelection, noMultiselect)',
-        type: Boolean,
-      },
-      _isAllSelected: {
-        computed: '_computeIsAllSelected(selectedIndices)',
-        type: Boolean,
-      },
-      _showFilterBox: {
-        type: Boolean,
-        value: false,
-      },
-      columns: {
-        observer: '_updateSortIcons',
-        type: Array,
-        value: () => [],
-      },
-      disableSelection: {
-        type: Boolean,
-        value: false,
-      },
-      hideHeader: {
-        type: Boolean,
-        value: false,
-      },
-      inlineDetailsMode: {
-        type: Number,
-        value: InlineDetailsDisplayMode.NONE,
-      },
-      noMultiselect: {
-        type: Boolean,
-        value: false,
-      },
-      rows: {
-        observer: '_updateSortIcons',
-        type: Array,
-        value: () => [],
-      },
-      selectedIndices: {
-        computed: '_computeSelectedIndices(rows.*)',
-        notify: true,
-        type: Array,
-        value: () => [],
-      },
-    };
-  }
 
   ready() {
     super.ready();
@@ -335,6 +303,7 @@ class ItemListElement extends Polymer.Element {
     this._updateSortIcons();
   }
 
+  @Polymer.decorators.observe(['rows', 'columns'])
   _updateSortIcons() {
     // Make sure all elements have rendered.
     Polymer.dom.flush();
@@ -604,5 +573,3 @@ class ItemListElement extends Polymer.Element {
   }
 
 }
-
-customElements.define(ItemListElement.is, ItemListElement);

--- a/sources/web/datalab/polymer/tsconfig.json
+++ b/sources/web/datalab/polymer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "experimentalDecorators": true,
     "noImplicitReturns": true,
     "noImplicitAny": true,
     "noImplicitThis": true,
@@ -17,5 +18,8 @@
   ],
   "exclude": [
     "bower_components"
+  ],
+  "files": [
+    "bower_components/polymer-decorators/global.d.ts"
   ]
 }


### PR DESCRIPTION
This is an exploratory PR to try out Polymer's Typescript decorators, which are now at a state that I feel supports all of our scenarios. It simplifies the syntax and removes some of the boilerplate, with the caveat of an extra include and having to pay attention to some details, such as on declaring an observer using [one of two ways](https://github.com/polymer/polymer-decorators#observetargets-string).

I'm trying them out on a fairly well test component: `item-list`, and it looks like the behavior is unchanged. Let me know what you think, if this looks cleaner I can go ahead and proceed with the rest of the components.