### PR TITLE
Fix a bug where the port-in-hostname regex was too strict.

### DIFF
--- a/sources/web/datalab/reverseProxy.ts
+++ b/sources/web/datalab/reverseProxy.ts
@@ -27,7 +27,7 @@ import url = require('url');
 var appSettings: common.AppSettings;
 var proxy: httpProxy.ProxyServer = httpProxy.createProxyServer(null);
 var regex: any = new RegExp('\/_proxy\/([0-9]+)($|\/)');
-var portInHostRegex: any = new RegExp('^([0-9]+)(\-dot\-|\.)(.*)((\:|\/)(.*))$');
+var portInHostRegex: any = new RegExp('^([0-9]+)(\-dot\-|\.)(.*)(((\:|\/)(.*))?)$');
 var socketioPort: string = '';
 
 function errorHandler(error: Error, request: http.ServerRequest, response: http.ServerResponse) {


### PR DESCRIPTION
The regex used to parse a port number out of a hostname (e.g.
'<PORT>-dot-myhost.com'), was meant to support an actual port
number being in the hostname (e.g. '<PORT1>-dot-myhost.com:<PORT2>').

That was how I tested the previous change; by adding a local host
entry for "8083-dot-localhost" and then connecting to
"8083-dot-localhost:8081" to view the ungit UI of a Datalab instance.

However, the previous version of that regex inadvertantly required
the ":<PORT>" suffix in the host header. This meant that the
feature did not work when tried against a real hostname.

This change fixes that by making the ":<PORT>" suffix optional.