### PR TITLE
SystemCtl complains if commands aren’t fully path’d.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -232,7 +232,7 @@ write_files:
     User=root
     Type=oneshot
     RemainAfterExit=true
-    ExecStartPre=docker-credential-gcr configure-docker
+    ExecStartPre=/usr/bin/docker-credential-gcr configure-docker
     ExecStart=/bin/bash -c 'while [ ! -e /mnt/disks/datalab-pd/tmp ]; do \
         sleep 1; \
         done'
@@ -250,7 +250,7 @@ write_files:
 
     [Service]
     Environment="HOME=/home/datalab"
-    ExecStartPre=docker-credential-gcr configure-docker
+    ExecStartPre=/usr/bin/docker-credential-gcr configure-docker
     ExecStart=/usr/bin/docker run --rm -u 0 \
        --name=datalab \
        -p 127.0.0.1:8080:8080 \

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -207,6 +207,7 @@ cleanup_tmp
 journalctl -u google-startup-scripts --no-pager > /var/log/startupscript.log
 """
 
+
 _DATALAB_CLOUD_CONFIG = """
 #cloud-config
 


### PR DESCRIPTION
When trying to deploy a custom gcr.io based Docker image, like:

```
$ datalab create --image-name=gcr.io/<PROJECT_ID>/datalab:test datalab-01
```

We get this error:

```
$ sudo journalctl -f -u datalab
systemd[1]: [/etc/systemd/system/datalab.service:8] Executable path is not absolute, ignoring: docker-credential-gcr configure-docker
```

This is fixed by this pull request.