### PR TITLE
Re-enable the jupyter widgets nb extension

### DIFF
--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -85,6 +85,9 @@ fi
 # Verify that we can write to the /tmp directory
 check_tmp_directory
 
+# Make sure widgets notebook extension is installed correctly at /content/.juptyer after docker volume mount.
+jupyter nbextension enable --py widgetsnbextension
+
 # Make sure the notebooks directory exists
 mkdir -p /content/datalab/notebooks
 
@@ -97,7 +100,7 @@ if [ -d /content/datalab/docs ]; then
   if [ -d /content/datalab/docs/.git ]; then
     git fetch origin master; git reset --hard origin/master
   else
-    git init; git remote add origin https://github.com/googledatalab/notebooks.git; git fetch origin; 
+    git init; git remote add origin https://github.com/googledatalab/notebooks.git; git fetch origin;
   fi
   popd
 else
@@ -106,7 +109,7 @@ fi
 (cd /content/datalab/docs; git config core.sparsecheckout true; echo $'intro/\nsamples/\ntutorials/\n*.ipynb\n' > .git/info/sparse-checkout; git checkout master)
 } || echo "Fetching tutorials and samples failed."
 
-# Run the user's custom extension script if it exists. To avoid platform issues with 
+# Run the user's custom extension script if it exists. To avoid platform issues with
 # execution permissions, line endings, etc, we create a local sanitized copy.
 if [ -f /content/datalab/.config/startup.sh ]
 then

--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -85,7 +85,7 @@ fi
 # Verify that we can write to the /tmp directory
 check_tmp_directory
 
-# Make sure widgets notebook extension is installed correctly at /content/.juptyer after docker volume mount.
+# Make sure widgets notebook extension is installed correctly at /content/.jupyter after the docker volume is mounted.
 jupyter nbextension enable --py widgetsnbextension
 
 # Make sure the notebooks directory exists


### PR DESCRIPTION
The datalab-base Dockerfile runs: `jupyter nbextention enable --py widgetsnbextension`

This creates a `/content/.jupyter/nbconfig/notebook.json` file so the widgets are available when Jupyter boots.

When the datalab.service runs, it mounts the persistent disk at `/content`, blowing away that `/content/.jupyter` folder.

This PR enables the widgets extension in run.sh, since that runs AFTER the docker volume is mounted.

Original Error:
![image](https://user-images.githubusercontent.com/2168/35595042-57c2bee0-05e3-11e8-8f10-3e8c7c828056.png)


Before this fix:

```
user@datalab-test ~ $ ls -al /mnt/disks/datalab-pd/content/.jupyter
total 12
drwxr-xr-x  2 root root 4096 Jan 30 18:22 .
drwxr-xr-x 11 root root 4096 Jan 30 18:30 ..
-rw-r--r--  1 root root   26 Jan 30 18:22 migrated
```

After this fix:

```
user@datalab-test ~ $ ls -al /mnt/disks/datalab-pd/content/.jupyter
total 16
drwxr-xr-x  3 root root 4096 Jan 30 19:07 .
drwxr-xr-x 11 root root 4096 Jan 30 22:13 ..
-rw-r--r--  1 root root   26 Jan 30 18:22 migrated
drwxr-xr-x  2 root root 4096 Jan 30 19:07 nbconfig

user@datalab-test ~ $ cat /mnt/disks/datalab-pd/content/.jupyter/nbconfig/notebook.json
{
  "load_extensions": {
    "jupyter-js-widgets/extension": true
  }
}
```
