### PR TITLE
Pin typescript to 2.7.1

### DIFF
--- a/sources/web/datalab/package.json
+++ b/sources/web/datalab/package.json
@@ -21,6 +21,6 @@
     "start": "node app.js"
   },
   "devDependencies": {
-    "typescript": "^2.5.3"
+    "typescript": "2.7.1"
   }
 }

--- a/sources/web/datalab/polymer/components/datalab-notification/datalab-notification.ts
+++ b/sources/web/datalab/polymer/components/datalab-notification/datalab-notification.ts
@@ -19,7 +19,7 @@
  * @param show whether the notification toast should be shown or hidden. Default true.
  * @param sticky whether the notification should stick around until dismissed. Default false.
  */
-class NotificationEvent extends CustomEvent {
+class NotificationEvent extends CustomEvent<any> {
   constructor(message = '', show = true, sticky = false) {
 
     const eventInit = {

--- a/sources/web/datalab/polymer/components/item-list/item-list.ts
+++ b/sources/web/datalab/polymer/components/item-list/item-list.ts
@@ -140,7 +140,7 @@ class ItemListRow {
 /**
  * CustomEvent that gets dispatched when an item is clicked or double clicked
  */
-class ItemClickEvent extends CustomEvent {
+class ItemClickEvent extends CustomEvent<any> {
   detail: {
     index: number;
   };

--- a/sources/web/datalab/polymer/modules/api-manager/api-manager.ts
+++ b/sources/web/datalab/polymer/modules/api-manager/api-manager.ts
@@ -26,7 +26,7 @@ interface XhrOptions {
   method?: string;
   noCache?: boolean;
   parameters?: string | FormData;
-  successCodes?: [number];
+  successCodes?: number[];
 }
 
 /**

--- a/sources/web/datalab/polymer/modules/terminal-manager/terminal-manager.ts
+++ b/sources/web/datalab/polymer/modules/terminal-manager/terminal-manager.ts
@@ -39,7 +39,7 @@ class TerminalManager {
   /**
    * Returns a list of active terminal sessions.
    */
-  public static listTerminalsAsync(): Promise<[JupyterTerminal]> {
+  public static listTerminalsAsync(): Promise<JupyterTerminal[]> {
     return ApiManager.sendRequestAsync(ApiManager.getServiceUrl(ServiceId.TERMINALS));
   }
 

--- a/sources/web/datalab/polymer/package.json
+++ b/sources/web/datalab/polymer/package.json
@@ -22,6 +22,6 @@
     "bower": "^1.8.2",
     "polymer-cli": "^1.5.7",
     "tslint": "^5.7.0",
-    "typescript": "^2.5.3"
+    "typescript": "2.6.2"
   }
 }

--- a/sources/web/datalab/polymer/package.json
+++ b/sources/web/datalab/polymer/package.json
@@ -22,6 +22,6 @@
     "bower": "^1.8.2",
     "polymer-cli": "^1.5.7",
     "tslint": "^5.7.0",
-    "typescript": "2.6.2"
+    "typescript": "2.7.1"
   }
 }

--- a/sources/web/datalab/static.ts
+++ b/sources/web/datalab/static.ts
@@ -256,7 +256,7 @@ function requestHandler(request: http.ServerRequest, response: http.ServerRespon
 
   console.log('static request: ' + pathname);
   // List of resources that are passed through with the same name.
-  const staticResourcesList: [string] = [
+  const staticResourcesList: string[] = [
     'appbar.html',
     'appbar.js',
     'util.js',


### PR DESCRIPTION
Fixes related to latest tsc 2.7.1, and pining typescript to this version to prevent further breaks.
The main break is related to https://github.com/Microsoft/TypeScript/issues/21549.