### PR TITLE
Ensure the `datalab` user exists before doing anything else.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -59,6 +59,10 @@ _DATALAB_NOTEBOOKS_REPOSITORY = 'datalab-notebooks'
 
 _DATALAB_BASE_STARTUP_SCRIPT = """#!/bin/bash
 
+# First, make sure the `datalab` user exists with their
+# home directory setup correctly.
+useradd datalab
+
 PERSISTENT_DISK_DEV="/dev/disk/by-id/google-datalab-pd"
 MOUNT_DIR="/mnt/disks/datalab-pd"
 MOUNT_CMD="mount -o discard,defaults ${{PERSISTENT_DISK_DEV}} ${{MOUNT_DIR}}"


### PR DESCRIPTION
This change updates the startup script to make sure that the
`datalab` user is created (including setting up its home directory
with the correct permissions) prior to doing anything else.

This prevents issues where a later startup script action (running
as root) could cause the `/home/datalab` directory to be created
being owned by `root` instead of `datalab`.

This fixes #1936