### PR TITLE
Fix firefox rename button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.ipynb_checkpoints
 .DS_Store
+sources/web/datalab/package-lock.json
 build
 staging
 *.gradle

--- a/sources/web/datalab/static/appbar.html
+++ b/sources/web/datalab/static/appbar.html
@@ -8,7 +8,9 @@
     <a id="homeLink"><img id="logoImg" alt="Google Cloud DataLab" style="display:none" /></a>
   </span>
   <span id="save_widget" class="pull-left save_widget">
-    <button class="toolbar-btn" title="Rename notebook"><span id="notebook_name" class="filename"></span></button>
+    <label class="toolbar-btn rename" title="Rename notebook">
+      <span id="notebook_name" class="filename"></span>
+    </label>
     <span class="autosave_status"></span>
   </span>
   <div class="btn-toolbar pull-right right-toolbar">

--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -327,6 +327,10 @@ div.end_space {
 #notebook_name:hover {
   background-color: transparent;
 }
+span.save_widget label.rename {
+  vertical-align: text-top;
+  cursor: pointer;
+}
 span.save_widget span.filename {
   margin-left: 0px;
   border: none;


### PR DESCRIPTION
The root cause is similar to https://github.com/googledatalab/datalab/issues/1815. So is the fix.
Also adding datalab's `package-lock.json` to gitignore.