### PR TITLE
Fix codemirror scrollbar on editor page

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -351,6 +351,11 @@ span.autosave_status {
 /* Edit page */
 #texteditor-backdrop {
   padding: 0px;
+  height: 100%;
+}
+
+#texteditor-backdrop .CodeMirror {
+  height: 100% !important;
 }
 
 /* Terminals page */


### PR DESCRIPTION
Codemirror needs an explicit height setting.