### PR TITLE
Always print out the nested command on failure.

### DIFF
--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -357,8 +357,10 @@ def run():
             email=get_email_address(),
             in_cloud_shell=('DEVSHELL_CLIENT_PORT' in os.environ),
             gcloud_zone=gcloud_zone)
-    except subprocess.CalledProcessError:
+    except subprocess.CalledProcessError as e:
         print('A nested call to gcloud failed.')
+        print('Command: ["' + '","'.join(e.cmd) + '"]')
+        print('Return code: '+ str(e.returncode))
     except Exception as e:
         if utils.print_debug_messages(args):
             traceback.print_exc(e)

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -361,9 +361,9 @@ def run():
         if utils.print_debug_messages(args):
             print('A nested call to gcloud failed.')
             print('Command: ["' + '","'.join(e.cmd) + '"]')
-            print('Return code: '+ str(e.returncode))
+            print('Return code: ' + str(e.returncode))
             if e.output:
-                print('Output: ' +str(e.output))
+                print('Output: ' + str(e.output))
         else:
             print('A nested call to gcloud failed, '
                   'use --verbosity=debug for more info.')

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -358,9 +358,15 @@ def run():
             in_cloud_shell=('DEVSHELL_CLIENT_PORT' in os.environ),
             gcloud_zone=gcloud_zone)
     except subprocess.CalledProcessError as e:
-        print('A nested call to gcloud failed.')
-        print('Command: ["' + '","'.join(e.cmd) + '"]')
-        print('Return code: '+ str(e.returncode))
+        if utils.print_debug_messages(args):
+            print('A nested call to gcloud failed.')
+            print('Command: ["' + '","'.join(e.cmd) + '"]')
+            print('Return code: '+ str(e.returncode))
+            if e.output:
+                print('Output: ' +str(e.output))
+        else:
+            print('A nested call to gcloud failed, '
+                  'use --verbosity=debug for more info.')
     except Exception as e:
         if utils.print_debug_messages(args):
             traceback.print_exc(e)


### PR DESCRIPTION
This way users will always have at least something to look at when we report that a gcloud command fails.