### PR TITLE
Improvements to the CLI tarball validation tests:

### DIFF
--- a/tools/cli/tests/end-to-end.py
+++ b/tools/cli/tests/end-to-end.py
@@ -46,6 +46,8 @@ class DatalabInstance(object):
         self.project = project
         self.zone = zone
         name_suffix = generate_unique_id()
+        self.network = "test-network-{0}-{1}".format(
+            test_run_id, name_suffix)
         self.name = "test-instance-{0}-{1}".format(
             test_run_id, name_suffix)
 
@@ -53,8 +55,12 @@ class DatalabInstance(object):
         cmd = ['python', '-u', './tools/cli/datalab.py', '--quiet',
                '--project', self.project,
                '--zone', self.zone,
-               'create', '--no-connect', self.name]
-        print('Creating the datalab instance "{}"'.format(self.name))
+               '--verbosity', 'debug',
+               'create', '--no-connect',
+               '--network-name', self.network, 
+               self.name]
+        print('Creating the instance "{}" with the command "{}"'.format(
+            self.name, ' '.join(cmd)))
         subprocess.check_output(cmd)
         print('Status of the instance: "{}"'.format(self.status()))
         return self
@@ -64,7 +70,21 @@ class DatalabInstance(object):
                '--project', self.project,
                '--zone', self.zone,
                'delete', '--delete-disk', self.name]
+        print('Deleting the instance "{}" with the command "{}"'.format(
+            self.name, ' '.join(cmd)))
         subprocess.check_output(cmd)
+        delete_firewall_cmd = ['gcloud', 'compute', 'firewall-rules', 'delete',
+                              '--project', self.project,
+                              '--quiet', '{}-allow-ssh'.format(self.network)]
+        print('Deleting the firewall for "{}" with the command "{}"'.format(
+            self.network, ' '.join(delete_firewall_cmd)))
+        subprocess.check_output(delete_firewall_cmd)
+        delete_network_cmd = ['gcloud', 'compute', 'networks', 'delete',
+                              '--project', self.project,
+                              '--quiet', self.network]
+        print('Deleting the network "{}" with the command "{}"'.format(
+            self.network, ' '.join(delete_network_cmd)))
+        subprocess.check_output(delete_network_cmd)
 
     def status(self):
         cmd = ['python', '-u', './tools/cli/datalab.py', '--quiet',

--- a/tools/cli/tests/end-to-end.py
+++ b/tools/cli/tests/end-to-end.py
@@ -57,7 +57,7 @@ class DatalabInstance(object):
                '--zone', self.zone,
                '--verbosity', 'debug',
                'create', '--no-connect',
-               '--network-name', self.network, 
+               '--network-name', self.network,
                self.name]
         print('Creating the instance "{}" with the command "{}"'.format(
             self.name, ' '.join(cmd)))
@@ -74,8 +74,8 @@ class DatalabInstance(object):
             self.name, ' '.join(cmd)))
         subprocess.check_output(cmd)
         delete_firewall_cmd = ['gcloud', 'compute', 'firewall-rules', 'delete',
-                              '--project', self.project,
-                              '--quiet', '{}-allow-ssh'.format(self.network)]
+                               '--project', self.project,
+                               '--quiet', '{}-allow-ssh'.format(self.network)]
         print('Deleting the firewall for "{}" with the command "{}"'.format(
             self.network, ' '.join(delete_firewall_cmd)))
         subprocess.check_output(delete_firewall_cmd)


### PR DESCRIPTION
1. Print each command that will be run before it is run (to aid in debugging)
2. Use a new, distinct network for each instance. This prevents issues
   caused by incompatible firewall rules on the `datalab-network` network.