### PR TITLE
Increase the cloud build timeout

### DIFF
--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -171,4 +171,4 @@ images:
   - 'gcr.io/${PROJECT_ID}/datalab-preview'
   - 'gcr.io/${PROJECT_ID}/datalab-gpu-preview'
 
-timeout: '3600s'
+timeout: '7200s'


### PR DESCRIPTION
With the new CLI validation tests, the cloud builder is doing a lot more work.

This change increases the corresponding timeout to account for the additional work it is now doing