### PR TITLE
Add some basic version information reporting:

### DIFF
--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -363,9 +363,19 @@ def run(args, gcloud_compute, email='', in_cloud_shell=False, **unused_kwargs):
     status, metadata_items = utils.describe_instance(
         args, gcloud_compute, instance)
     for_user = metadata_items.get('for-user', '')
+    sdk_version = metadata_items.get('created-with-sdk-version', 'UNKNOWN')
+    datalab_version = metadata_items.get(
+        'created-with-datalab-version', 'UNKNOWN')
     if (not args.no_user_checking) and for_user and (for_user != email):
         print(wrong_user_message_template.format(for_user, email))
         return
+
+    if args.diagnose_me:
+        print('Instance {} was created with the following '
+              'Cloud SDK component versions:'
+              '\n\tCloud SDK: {}'
+              '\n\tDatalab: {}'.format(
+                  instance, sdk_version, datalab_version))
 
     maybe_start(args, gcloud_compute, instance, status)
     connect(args, gcloud_compute, email, in_cloud_shell)

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -686,7 +686,8 @@ def prepare(args, gcloud_compute, gcloud_repos):
 
 
 def run(args, gcloud_compute, gcloud_repos,
-        email='', in_cloud_shell=False, gcloud_zone=None, **kwargs):
+        email='', in_cloud_shell=False, gcloud_zone=None,
+        sdk_version='UNKNOWN', datalab_version='UNKNOWN', **kwargs):
     """Implementation of the `datalab create` subcommand.
 
     Args:
@@ -698,6 +699,8 @@ def run(args, gcloud_compute, gcloud_repos,
       in_cloud_shell: Whether or not the command is being run in the
         Google Cloud Shell
       gcloud_zone: The zone that gcloud is configured to use
+      sdk_version: The version of the Cloud SDK being used
+      datalab_version: The version of the datalab CLI being used
     Raises:
       subprocess.CalledProcessError: If a nested `gcloud` calls fails
     """
@@ -725,7 +728,9 @@ def run(args, gcloud_compute, gcloud_repos,
     with tempfile.NamedTemporaryFile(delete=False) as startup_script_file, \
             tempfile.NamedTemporaryFile(delete=False) as user_data_file, \
             tempfile.NamedTemporaryFile(delete=False) as for_user_file, \
-            tempfile.NamedTemporaryFile(delete=False) as os_login_file:
+            tempfile.NamedTemporaryFile(delete=False) as os_login_file, \
+            tempfile.NamedTemporaryFile(delete=False) as sdk_version_file, \
+            tempfile.NamedTemporaryFile(delete=False) as datalab_version_file:
         try:
             startup_script_file.write(_DATALAB_STARTUP_SCRIPT.format(
                 args.image_name, _DATALAB_NOTEBOOKS_REPOSITORY, enable_swap))
@@ -738,17 +743,25 @@ def run(args, gcloud_compute, gcloud_repos,
             for_user_file.close()
             os_login_file.write("FALSE")
             os_login_file.close()
+            sdk_version_file.write(sdk_version)
+            sdk_version_file.close()
+            datalab_version_file.write(datalab_version)
+            datalab_version_file.close()
             metadata_template = (
                 'startup-script={0},' +
                 'user-data={1},' +
                 'for-user={2},' +
-                'enable-oslogin={3}')
+                'enable-oslogin={3},' +
+                'created-with-sdk-version={4},' +
+                'created-with-datalab-version={5}')
             metadata_from_file = (
                 metadata_template.format(
                     startup_script_file.name,
                     user_data_file.name,
                     for_user_file.name,
-                    os_login_file.name))
+                    os_login_file.name,
+                    sdk_version_file.name,
+                    datalab_version_file.name))
             cmd.extend([
                 '--format=none',
                 '--boot-disk-size=20GB',
@@ -768,6 +781,8 @@ def run(args, gcloud_compute, gcloud_repos,
             os.remove(user_data_file.name)
             os.remove(for_user_file.name)
             os.remove(os_login_file.name)
+            os.remove(sdk_version_file.name)
+            os.remove(datalab_version_file.name)
 
     if (not args.no_connect) and (not args.for_user):
         connect.connect(args, gcloud_compute, email, in_cloud_shell)


### PR DESCRIPTION
1. Add the version of the Cloud SDK and datalab component used to
   create an instance to that instance's metadata.
2. When connecting to an instance using the `--diagnose-me` flag,
   report the version info from that instance's metadata entries.