### PR TITLE
Add a facility to warn users of versions with known issues.

### DIFF
--- a/tools/cli/commands/utils.py
+++ b/tools/cli/commands/utils.py
@@ -368,6 +368,18 @@ def maybe_prompt_for_zone(args, gcloud_compute, instance):
     return
 
 
+def print_warning_messages(args):
+    """Return whether or not warning messages should be printed.
+
+    Args:
+      args: The Namespace instance returned by argparse
+    Returns:
+      True iff the verbosity has been set to a level that includes
+          warning messages.
+    """
+    return args.verbosity in ['debug', 'info', 'default', 'warning']
+
+
 def print_info_messages(args):
     """Return whether or not info messages should be printed.
 


### PR DESCRIPTION
This change was prompted by the recent issue we had with version
20180105, where an issue was discovered, but we did not have a
good means of notifying users about the issue.

With this change, the CLI will download a versions info file from
https://storage.googleapis.com/cloud-datalab/version-issues.js
that contains a JSON object reporting known issues for any
affected versions of the CLI. It will then check the current
version against that object and report any matching warnings.