### PR TITLE
Don't delete the h5py tests directory.

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -72,6 +72,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         futures==3.2.0 \
         google-api-python-client==1.6.2 \
         httplib2==0.10.3 \
+        h5py==2.7.1 \
         ipykernel==4.5.2 \
         ipywidgets==6.0.0 \
         jinja2==2.8 \
@@ -110,8 +111,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         ggplot==0.6.8 \
         google-cloud-dataflow==2.0.0 \
         lime==0.1.1.23 \
-        tensorflow==1.5.0 \
-        h5py==2.7.1 && \
+        tensorflow==1.5.0 && \
     source deactivate && \
 # Clean up before setting up the Python3 env.
     conda clean -tipsy && \
@@ -123,6 +123,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         crcmod==1.7 \
         google-api-python-client==1.6.2 \
         httplib2==0.10.3 \
+        h5py==2.7.1 \
         ipykernel==4.5.2 \
         ipywidgets==6.0.0 \
         jinja2==2.8 \
@@ -161,8 +162,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         bs4==0.0.1 \
         ggplot==0.6.8 \
         lime==0.1.1.23 \
-        tensorflow==1.5.0 \
-        h5py==2.7.1 && \
+        tensorflow==1.5.0 && \
 # Make pip3 a copy of pip for the Python 3 environment.
     cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
 # Install Python3 IPython kernel
@@ -175,7 +175,9 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     source deactivate && \
 # Clean up Python packages
     conda clean -tipsy && \
-    find $DATALAB_CONDA_DIR/envs/*/lib -type d -name tests | xargs rm -rf && \
+# Delete tests directories, except for h5py since importing it takes a
+# dependency on it's tests directory.
+    find $DATALAB_CONDA_DIR/envs/*/lib -type d -name tests | grep -v h5py | xargs rm -rf && \
 # Setup Node.js using LTS 6.10
     cd / && \
     mkdir -p /tools/node && \


### PR DESCRIPTION
h5py references it's tests directory during import, so removing it will make it fail to import.

Moving back to using the conda version of the package instead of pip since conda wasn't the issue.