### PR TITLE
Use Anaconda base packages (with MKL support) by default

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -63,7 +63,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -f -p $DATALAB_CONDA_DIR && \
     rm ~/miniconda.sh && \
-    conda config --system --add channels conda-forge && \
+    conda config --system --append channels conda-forge && \
     conda config --system --set show_channel_urls true && \
     conda update --all --quiet --yes && \
     conda create --yes --quiet --name $PYTHON_2_ENV python=2.7 \


### PR DESCRIPTION
Changed the command adding the conda-forge channel from an  --add to an --append so that it doesn't override the default conda channel. This will install base packages before conda-forge ones, the opposite of which is happening now. Performance wise this means MKL pacakges will be installed rather than openblas, which should make for a nice speed boost.

For more info see - https://conda.io/docs/user-guide/tasks/manage-channels.html#after-conda-4-1-0