### PR TITLE
Use packages from conda defaults channel first

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -63,7 +63,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -f -p $DATALAB_CONDA_DIR && \
     rm ~/miniconda.sh && \
-    conda config --system --add channels conda-forge && \
+    conda config --system --append channels conda-forge && \
     conda config --system --set show_channel_urls true && \
     conda update --all --quiet --yes && \
     conda create --yes --quiet --name $PYTHON_2_ENV python=2.7 \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -63,6 +63,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -f -p $DATALAB_CONDA_DIR && \
     rm ~/miniconda.sh && \
+    conda update conda --quiet --yes && \
     conda config --system --append channels conda-forge && \
     conda config --system --set show_channel_urls true && \
     conda update --all --quiet --yes && \


### PR DESCRIPTION
The current installation of conda uses --add to add the conda-forge channel which results in the demotion of packages from the defaults channel. Since conda-forge packages use open_blas (non-mkl) versions of packages such as numpy are installed affecting performance. 

By first updating conda to a version post 4.1 we can use --append to add the conda-forge channel so that default packages still take precedence. Then mkl versions of packages will be installed by default. This should result in a nice performance boost for many users.