### PR TITLE
Remove commented python3 ipykernel install line

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -165,8 +165,6 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         tensorflow==1.5.0 && \
 # Make pip3 a copy of pip for the Python 3 environment.
     cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
-# Install Python3 IPython kernel
-    #python -m ipykernel install && \
     source deactivate && \
     # Install Python2 IPython kernel within the Python3 Jupyter directory since
     # we will be running Jupyter from the Python3 conda env.


### PR DESCRIPTION
The line `#python -m ipykernel install && \` was mistakenly left in the Dockerfile. Since things work with it commented, I'm just going to remove it.

For the record, the only change I observed when **uncommenting** it was running

    !jupyter kernelspec list

in the python 2 kernel went from returning:

    Available kernels:
      python2    /usr/local/envs/py2env/share/jupyter/kernels/python2

to returning:

    Available kernels:
      python2    /usr/local/envs/py2env/share/jupyter/kernels/python2
      python3    /usr/local/share/jupyter/kernels/python3