### PR TITLE
Make the command-line tool work in Python 3.

### DIFF
--- a/tools/cli/commands/__init__.py
+++ b/tools/cli/commands/__init__.py
@@ -11,3 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import absolute_import
+
+from . import create, creategpu, connect, list, stop, delete, utils
+
+__all__ = [create, creategpu, connect, list, stop, delete, utils]

--- a/tools/cli/commands/connect.py
+++ b/tools/cli/commands/connect.py
@@ -14,13 +14,19 @@
 
 """Methods for implementing the `datalab connect` command."""
 
+from __future__ import absolute_import
+
 import os
 import subprocess
 import threading
-import urllib2
 import webbrowser
 
-import utils
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+from . import utils
 
 
 description = """`{0} {1}` creates a persistent connection to a
@@ -253,7 +259,7 @@ def connect(args, gcloud_compute, email, in_cloud_shell):
         print('Waiting for Datalab to be reachable at ' + datalab_address)
         while not cancelled_event.is_set():
             try:
-                health_resp = urllib2.urlopen(health_url)
+                health_resp = urlopen(health_url)
                 if health_resp.getcode() == 200:
                     healthy = True
                     break

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -530,7 +530,7 @@ def has_unexpected_firewall_rules(args, gcloud_compute, network_name):
     with tempfile.TemporaryFile() as tf:
         gcloud_compute(args, list_cmd, stdout=tf)
         tf.seek(0)
-        matching_rules = tf.read().strip()
+        matching_rules = tf.read().decode('utf-8').strip()
         if matching_rules and (matching_rules != rule_name):
             return True
     return False
@@ -648,7 +648,7 @@ def ensure_repo_exists(args, gcloud_repos, repo_name):
     with tempfile.TemporaryFile() as tf:
         gcloud_repos(args, list_cmd, stdout=tf)
         tf.seek(0)
-        matching_repos = tf.read().strip()
+        matching_repos = tf.read().decode('utf-8').strip()
         if not matching_repos:
             try:
                 create_repo(args, gcloud_repos, repo_name)

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -14,13 +14,14 @@
 
 """Methods for implementing the `datalab create` command."""
 
+from __future__ import absolute_import
+
 import json
 import os
 import subprocess
 import tempfile
 
-import connect
-import utils
+from . import connect, utils
 
 try:
     # If we are running in Python 2, builtins is available in 'future'.
@@ -28,7 +29,7 @@ try:
 except Exception:
     # We don't want to require the installation of future, so fallback
     # to using raw_input from Py2.
-    read_input = raw_input
+    read_input = raw_input  # noqa: F821
 
 
 description = ("""`{0} {1}` creates a new Datalab instances running in a Google

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -726,12 +726,18 @@ def run(args, gcloud_compute, gcloud_repos,
     escaped_email = user_email.replace("'", "''")
     initial_user_settings = json.dumps({"idleTimeoutInterval": idle_timeout}) \
         if idle_timeout else ''
-    with tempfile.NamedTemporaryFile(delete=False) as startup_script_file, \
-            tempfile.NamedTemporaryFile(delete=False) as user_data_file, \
-            tempfile.NamedTemporaryFile(delete=False) as for_user_file, \
-            tempfile.NamedTemporaryFile(delete=False) as os_login_file, \
-            tempfile.NamedTemporaryFile(delete=False) as sdk_version_file, \
-            tempfile.NamedTemporaryFile(delete=False) as datalab_version_file:
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as startup_script_file, \
+            tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as user_data_file, \
+            tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as for_user_file, \
+            tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as os_login_file, \
+            tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as sdk_version_file, \
+            tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as datalab_version_file:
         try:
             startup_script_file.write(_DATALAB_STARTUP_SCRIPT.format(
                 args.image_name, _DATALAB_NOTEBOOKS_REPOSITORY, enable_swap))

--- a/tools/cli/commands/creategpu.py
+++ b/tools/cli/commands/creategpu.py
@@ -14,13 +14,13 @@
 
 """Methods for implementing the `datalab beta creategpu` command."""
 
+from __future__ import absolute_import
+
 import json
 import os
 import tempfile
 
-import create
-import connect
-import utils
+from . import create, connect, utils
 
 
 description = ("""`{0} {1}` creates a new Datalab instance running in a Google

--- a/tools/cli/commands/creategpu.py
+++ b/tools/cli/commands/creategpu.py
@@ -267,12 +267,18 @@ def run(args, gcloud_beta_compute, gcloud_repos,
     escaped_email = user_email.replace("'", "''")
     initial_user_settings = json.dumps({"idleTimeoutInterval": idle_timeout}) \
         if idle_timeout else ''
-    with tempfile.NamedTemporaryFile(delete=False) as startup_script_file, \
-            tempfile.NamedTemporaryFile(delete=False) as user_data_file, \
-            tempfile.NamedTemporaryFile(delete=False) as for_user_file, \
-            tempfile.NamedTemporaryFile(delete=False) as os_login_file, \
-            tempfile.NamedTemporaryFile(delete=False) as sdk_version_file, \
-            tempfile.NamedTemporaryFile(delete=False) as datalab_version_file:
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as startup_script_file, \
+            tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as user_data_file, \
+            tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as for_user_file, \
+            tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as os_login_file, \
+            tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as sdk_version_file, \
+            tempfile.NamedTemporaryFile(mode='w', delete=False) \
+            as datalab_version_file:
         try:
             startup_script_file.write(create._DATALAB_STARTUP_SCRIPT.format(
                 args.image_name, create._DATALAB_NOTEBOOKS_REPOSITORY,

--- a/tools/cli/commands/delete.py
+++ b/tools/cli/commands/delete.py
@@ -14,7 +14,9 @@
 
 """Methods for implementing the `datalab delete` command."""
 
-import utils
+from __future__ import absolute_import
+
+from . import utils
 
 
 description = ("""`{0} {1}` deletes the given Datalab instance's

--- a/tools/cli/commands/stop.py
+++ b/tools/cli/commands/stop.py
@@ -14,7 +14,9 @@
 
 """Methods for implementing the `datalab stop` command."""
 
-import utils
+from __future__ import absolute_import
+
+from . import utils
 
 
 description = ("""`{0} {1}` stops the given Datalab instance's

--- a/tools/cli/commands/utils.py
+++ b/tools/cli/commands/utils.py
@@ -26,7 +26,7 @@ try:
 except Exception:
     # We don't want to require the installation of future, so fallback
     # to using raw_input from Py2.
-    read_input = raw_input
+    read_input = raw_input  # noqa: F821
 
 
 def prompt_for_confirmation(
@@ -288,7 +288,7 @@ def describe_instance(args, gcloud_compute, instance):
         try:
             gcloud_compute(args, get_cmd, stdout=stdout, stderr=stderr)
             stdout.seek(0)
-            json_result = stdout.read().strip()
+            json_result = stdout.read().decode('utf-8').strip()
             status_tags_and_metadata = json.loads(json_result)
             tags = status_tags_and_metadata.get('tags', {})
             _check_datalab_tag(instance, tags)
@@ -333,7 +333,7 @@ def instance_notebook_disk(args, gcloud_compute, instance):
         try:
             gcloud_compute(args, get_cmd, stdout=stdout, stderr=stderr)
             stdout.seek(0)
-            instance_json = json.loads(stdout.read().strip())
+            instance_json = json.loads(stdout.read().decode('utf-8').strip())
             disk_configs = instance_json.get('disks', [])
             for cfg in disk_configs:
                 if cfg['deviceName'] == 'datalab-pd':

--- a/tools/cli/commands/utils.py
+++ b/tools/cli/commands/utils.py
@@ -143,11 +143,11 @@ def call_gcloud_quietly(args, gcloud_surface, cmd, report_errors=True):
             if report_errors:
                 stdout.seek(0)
                 stderr.seek(0)
-                print(stdout.read())
+                print(stdout.read().decode('utf-8'))
                 sys.stderr.write(stderr.read())
             raise
         stderr.seek(0)
-        gcloud_stderr = stderr.read()
+        gcloud_stderr = stderr.read().decode('utf-8')
         if 'WARNING' in gcloud_stderr:
             sys.stderr.write(gcloud_stderr)
     return
@@ -177,7 +177,7 @@ def prompt_for_zone(args, gcloud_compute, instance=None):
             gcloud_compute(args, list_cmd,
                            stdout=stdout, stderr=stderr)
             stdout.seek(0)
-            matching_zones = stdout.read().strip().splitlines()
+            matching_zones = stdout.read().decode('utf-8').strip().splitlines()
         except subprocess.CalledProcessError:
             stderr.seek(0)
             sys.stderr.write(stderr.read())

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -19,6 +19,8 @@
 This tool is specific to the use case of running in the Google Cloud Platform.
 """
 
+from __future__ import absolute_import
+
 from commands import create, creategpu, connect, list, stop, delete, utils
 
 import argparse
@@ -26,7 +28,11 @@ import json
 import os
 import subprocess
 import traceback
-import urllib2
+try:
+    from urllib.request import urlopen
+    from urllib.error import HTTPError
+except ImportError:
+    from urllib2 import urlopen, HTTPError
 
 
 _SUBCOMMANDS = {
@@ -129,9 +135,9 @@ except Exception:
 
 def report_known_issues(sdk_version, datalab_version):
     try:
-        version_issues_resp = urllib2.urlopen(version_issues_url)
-        version_issues = json.loads(version_issues_resp.read())
-    except urllib2.HTTPError as e:
+        version_issues_resp = urlopen(version_issues_url)
+        version_issues = json.loads(version_issues_resp.read().decode('utf-8'))
+    except HTTPError as e:
         print('Error downloading the version information: {}'.format(e))
         return
 
@@ -250,7 +256,7 @@ def get_email_address():
     """
     return subprocess.check_output([
         gcloud_cmd, 'auth', 'list', '--quiet', '--format',
-        'value(account)', '--filter', 'status:ACTIVE']).strip()
+        'value(account)', '--filter', 'status:ACTIVE']).decode('utf-8').strip()
 
 
 def get_gcloud_zone():
@@ -261,7 +267,8 @@ def get_gcloud_zone():
     """
     return subprocess.check_output([
         gcloud_cmd, 'config', 'config-helper', '--format',
-        'value(configuration.properties.compute.zone)']).strip()
+        'value(configuration.properties.compute.zone)']).decode(
+            'utf-8').strip()
 
 
 def add_sub_parser(subcommand, command_config, subparsers, prog):
@@ -352,6 +359,7 @@ def run():
         help='Print additional information for diagnosing issues.')
 
     subparsers = parser.add_subparsers(dest='subcommand')
+    subparsers.required = True
     for subcommand in _SUBCOMMANDS:
         add_sub_parser(subcommand, _SUBCOMMANDS[subcommand], subparsers, prog)
 
@@ -378,7 +386,7 @@ def run():
         args.diagnose_me = args.top_level_diagnose_me
 
     gcloud_version_json = subprocess.check_output([
-        gcloud_cmd, 'version', '--format=json']).strip()
+        gcloud_cmd, 'version', '--format=json']).decode('utf-8').strip()
     component_versions = json.loads(gcloud_version_json)
     sdk_version = component_versions.get(sdk_core_component, 'UNKNOWN')
     datalab_version = component_versions.get(datalab_component, 'UNKNOWN')

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -430,7 +430,7 @@ def run():
                   'use --verbosity=debug for more info.')
     except Exception as e:
         if utils.print_debug_messages(args):
-            traceback.print_exc(e)
+            traceback.print_exc()
         print(e)
 
 

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -27,12 +27,17 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: '/usr/bin/env'
   args: ['python', 'tools/cli/tests/end-to-end.py']
-  id:   'testCLI'
+  id:   'testCLIpy2'
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: '/usr/bin/env'
+  args: ['python3', 'tools/cli/tests/end-to-end.py']
+  id:   'testCLIpy3'
+  waitFor: ['testCLIpy2']
 - name: 'debian'
   args: ['tar', '-cvzf', '/workspace/datalab-cli-${REVISION_ID}.tgz',
          '--transform', 's,^tools/cli,datalab,', 'tools/cli']
   id:   'createTarball'
-  waitFor: ['testCLI']
+  waitFor: ['testCLIpy2', 'testCLIpy3']
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['cp',
          '/workspace/datalab-cli-${REVISION_ID}.tgz',


### PR DESCRIPTION
This change fixes all of the incompatibilities in the command
line tool with regard to running in Python 3.

This also extends the build to run the end-to-end tests in
both Python 2 and Python 3.