### PR TITLE
Upgrade the GPU images to use version 9.1 of the CUDA toolkit.

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -87,6 +87,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         pandas==0.22.0 \
         pandocfilters==1.4.2 \
         pillow==5.0.0 \
+        pip==9.0.3 \
         plotly==1.12.5 \
         psutil==4.3.0 \
         pygments==2.1.3 \
@@ -139,6 +140,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         pandas==0.22.0 \
         pandocfilters==1.4.2 \
         pillow==5.0.0 \
+        pip==9.0.3 \
         plotly==1.12.5 \
         psutil==4.3.0 \
         pygments==2.1.3 \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -15,7 +15,7 @@
 # We use different base images for GPU vs CPU Dockerfiles, so we expect
 # that the appropriate image is pulled and tagged locally.
 # CPU should use ubuntu:16.04
-# and GPU uses nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
+# and GPU uses nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04
 FROM datalab-external-base-image
 MAINTAINER Google Cloud DataLab
 

--- a/containers/base/build.gpu.sh
+++ b/containers/base/build.gpu.sh
@@ -32,11 +32,11 @@ fi
 
 trap 'rm -rf pydatalab' exit
 
-docker pull nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
+docker pull nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04
 # Docker tag flags changed in an incompatible way between versions.
 # The Datalab Jenkins build still uses the old one, so try it both ways.
-if ! $(docker tag -f nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 datalab-external-base-image); then
-  docker tag nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 datalab-external-base-image
+if ! $(docker tag -f nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04 datalab-external-base-image); then
+  docker tag nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04 datalab-external-base-image
 fi
 docker build ${DOCKER_BUILD_ARGS} -t datalab-core-gpu .
 docker build ${DOCKER_BUILD_ARGS} -f Dockerfile.gpu -t datalab-base-gpu .

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -76,10 +76,10 @@ steps:
 
 ## Second, we build the GPU base image
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['pull', 'nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04']
+  args: ['pull', 'nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04']
   id:   'pullNvidiaUbuntu'
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['tag', 'nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04', 'datalab-external-base-image']
+  args: ['tag', 'nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04', 'datalab-external-base-image']
   id:   'tagNvidiaUbuntu'
   waitFor: ['buildBase', 'pullNvidiaUbuntu']
 - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
PR #1994 upgraded GPU instances to use version 390.46 of the
NVIDIA drivers, but that version is meant to be used against
version 9.1 of the CUDA toolkit and we were using version
9.0 of the toolkit.

This change fixes this by upgrading to the base image that
includes the newer version of the CUDA toolkit.