### PR TITLE
Pin the version of the protobuf library installed.

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -113,6 +113,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         ggplot==0.6.8 \
         google-cloud-dataflow==2.0.0 \
         lime==0.1.1.23 \
+        protobuf==3.5.2 \
         tensorflow==1.8.0 && \
     source deactivate && \
 # Clean up before setting up the Python3 env.
@@ -165,6 +166,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         bs4==0.0.1 \
         ggplot==0.6.8 \
         lime==0.1.1.23 \
+        protobuf==3.5.2 \
         tensorflow==1.8.0 && \
 # Make pip3 a copy of pip for the Python 3 environment.
     cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \


### PR DESCRIPTION
Previously, we were picking the version of protobuf implicitly,
and the version in the Python 2 env (3.2.0) was different from
the version in the Python 3 env (3.5.2).

With the upgrade of the tensorflow library to 1.8.0, it is no longer
compatible with version 3.2.0 of the protobuf library, so this
is required for the new version of tensorflow to work in the
python 2 environment.