### PR TITLE
Update the version of Node JS installed when building.

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -25,7 +25,7 @@ function install_node() {
 
   echo "Installing NodeJS"
   mkdir -p /tools/node
-  wget -nv https://nodejs.org/dist/v6.10.0/node-v6.10.0-linux-x64.tar.gz -O node.tar.gz
+  wget -nv https://nodejs.org/dist/v8.9.0/node-v8.9.0-linux-x64.tar.gz -O node.tar.gz
   tar xzf node.tar.gz -C /tools/node --strip-components=1
   rm node.tar.gz
   export "PATH=${PATH}:/tools/node/bin"


### PR DESCRIPTION
This updates the portion of the build script that installs
NodeJS if it is not already installed on the build machine.

This mainly affects our Cloud Build config, as the build takes
place inside of a container that does not already have NodeJS
installed.

The reason for this change is that Polymer CLI recently updated,
and the new version fails if the version of NodeJS is older than
7.0. This change has broken our Cloud Build config, and is
blocking the Datalab release.