### PR TITLE
Disable CORS for the notebook server

### DIFF
--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -19,7 +19,6 @@
     "--no-browser",
     "--log-level=DEBUG",
     "--debug",
-    "--NotebookApp.allow_origin=\"*\"",
     "--NotebookApp.log_format=\"%(message)s\"",
     "--NotebookApp.token=",
     "--Session.key=b'\"\"'",


### PR DESCRIPTION
I don't see a need for this. Comment if you think otherwise.