### PR TITLE
redirect stderr to /dev/null for local "docker tag -f" failures

### DIFF
--- a/containers/base/build.gpu.sh
+++ b/containers/base/build.gpu.sh
@@ -35,7 +35,7 @@ trap 'rm -rf pydatalab' exit
 docker pull nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04
 # Docker tag flags changed in an incompatible way between versions.
 # The Datalab Jenkins build still uses the old one, so try it both ways.
-if ! $(docker tag -f nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 datalab-external-base-image); then
+if ! $(docker tag -f nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 datalab-external-base-image 2> /dev/null); then
   docker tag nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04 datalab-external-base-image
 fi
 docker build ${DOCKER_BUILD_ARGS} -t datalab-core-gpu .

--- a/containers/base/build.sh
+++ b/containers/base/build.sh
@@ -35,7 +35,7 @@ trap 'rm -rf pydatalab' exit
 docker pull ubuntu:16.04
 # Docker tag flags changed in an incompatible way between versions.
 # The Datalab Jenkins build still uses the old one, so try it both ways.
-if ! $(docker tag -f ubuntu:16.04 datalab-external-base-image); then
+if ! $(docker tag -f ubuntu:16.04 datalab-external-base-image 2> /dev/null); then
   docker tag ubuntu:16.04 datalab-external-base-image
 fi
 docker build ${DOCKER_BUILD_ARGS} -t datalab-base .


### PR DESCRIPTION
The Datalab Jenkins build still uses an old Docker version with incompatible flags; this causes confusing output during local builds. E.g.

```bash
$ cd containers/datalab && ./build.sh
...
unknown shorthand flag: 'f' in -f
See 'docker tag --help'.
....
```

I've updated both build scripts to redirect these errors to `/dev/null`.