### PR TITLE
Fix a potential source of CI test flakiness.

### DIFF
--- a/tools/cli/tests/end-to-end.py
+++ b/tools/cli/tests/end-to-end.py
@@ -135,6 +135,9 @@ class DatalabConnection(object):
 
     def __enter__(self):
         self.port = free_port()
+        # Give a moment for the temporarily-acquired port to
+        # free up before trying to reuse it.
+        time.sleep(10)
         cmd = [python_executable, '-u', './tools/cli/datalab.py', '--quiet',
                '--project', self.project, '--zone', self.zone,
                'connect', '--no-launch-browser',


### PR DESCRIPTION
Our automated Container-Builder test runs have been failing a lot
recenty with errors saying that the selected port for a Datalab
connection was already in use.

Since we pick a free port for the connection, and nothing else
is running in the container, the only explanation I can think of
is that the port has not yet been freed from when we initially
connected to it (in order to find a free port).

To fix this, we add a sleep of 10 seconds between picking the
port and trying to use it.