### PR TITLE
Retry integration tests on any exception.

### DIFF
--- a/tools/cli/tests/end-to-end.py
+++ b/tools/cli/tests/end-to-end.py
@@ -187,8 +187,8 @@ class TestEndToEnd(unittest.TestCase):
             try:
                 test_method()
                 return
-            except AssertionError as ae:
-                last_error = ae
+            except Exception as ex:
+                last_error = ex
         raise last_error
 
     def test_create_delete(self):


### PR DESCRIPTION
The previous version of this logic retried a test if any of its
`self.assert...` calls failed.

However, that does not handle the case where a nested call to
`datalab` fails. In those cases a `CalledProcessError` would be
raised.

To retry on those scenarios as well, we extend the retry logic
to retry on any instance of the `Exception` class.