### PR TITLE
Create a mock Datalab image that can be used when testing changes to the CLI

### DIFF
--- a/containers/mock/Dockerfile
+++ b/containers/mock/Dockerfile
@@ -1,0 +1,32 @@
+# Copyright 2018 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file defines a mock Datalab image that can be used for testing
+# the command line tool. This is meant to be significantly smaller than
+# the real image so that CLI tests can be run much faster.
+#
+# This only implements the subset of the server that is checked by the
+# CLI.
+#
+# This should not be used when testing a build or release; for those
+# scenarios use the real image. Instead, this is meant for developers
+# modifying the CLI and wanting to quickly check their changes.
+
+FROM nginx
+MAINTAINER Google Cloud DataLab
+EXPOSE 8080
+
+RUN mkdir -p /usr/share/nginx/html && \
+    sed -i -e "s/listen       80;/listen       8080;/g" /etc/nginx/conf.d/default.conf && \
+    echo "<html><body>Hello from mock Datalab</body></html>" >> /usr/share/nginx/html/_info

--- a/containers/mock/Dockerfile
+++ b/containers/mock/Dockerfile
@@ -17,7 +17,11 @@
 # the real image so that CLI tests can be run much faster.
 #
 # This only implements the subset of the server that is checked by the
-# CLI.
+# CLI. That, in turn, means that it must require the following:
+#
+# 1. The Cloud SDK, which is used for cloning the source repo.
+# 2. The git command line tool, which is used for populating the source repo.
+# 3. A webserver that serves a 200 response to the "/_info" path.
 #
 # This should not be used when testing a build or release; for those
 # scenarios use the real image. Instead, this is meant for developers
@@ -27,6 +31,14 @@ FROM nginx
 MAINTAINER Google Cloud DataLab
 EXPOSE 8080
 
-RUN mkdir -p /usr/share/nginx/html && \
-    sed -i -e "s/listen       80;/listen       8080;/g" /etc/nginx/conf.d/default.conf && \
-    echo "<html><body>Hello from mock Datalab</body></html>" >> /usr/share/nginx/html/_info
+RUN sed -i -e "s/listen       80;/listen       8080;/g" /etc/nginx/conf.d/default.conf && \
+    mkdir -p /usr/share/nginx/html/_info && \
+    echo "<html><body>Hello from mock Datalab</body></html>" >> /usr/share/nginx/html/_info/index.html && \
+    apt-get update -y && \
+    apt-get install -y -q git wget unzip python && \
+    wget -nv https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && \
+    unzip -qq google-cloud-sdk.zip -d tools && \
+    rm google-cloud-sdk.zip && \
+    tools/google-cloud-sdk/install.sh --usage-reporting=false \
+        --path-update=false --bash-completion=false \
+        --disable-installation-options

--- a/containers/mock/README.md
+++ b/containers/mock/README.md
@@ -1,0 +1,4 @@
+# Mock DataLab Docker Image
+
+This directory contains a Docker image that can be used in the place of the real
+Docker image when testing changes to the command line tool.

--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -132,6 +132,11 @@ steps:
   id:   'buildDatalabGPU'
   waitFor: ['prepareDatalabGPU']
 
+## Build the mock image used for testing...
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/${PROJECT_ID}/mock-datalab:latest', '/workspace/containers/mock/']
+  id:   'buildMockDatalab'
+
 ## Tag all of the images as "commit-latest-master-build" so that other processes
 ## can easily pick up the latest one.
 - name: gcr.io/cloud-builders/docker
@@ -172,6 +177,7 @@ steps:
   waitFor: ['pushConfigLocal', 'buildDatalab', 'buildDatalabGPU', 'buildGateway']
 
 images:
+  - 'gcr.io/${PROJECT_ID}/mock-datalab:latest'
   - 'gcr.io/${PROJECT_ID}/datalab-gateway:commit-${REVISION_ID}'
   - 'gcr.io/${PROJECT_ID}/datalab:commit-${REVISION_ID}'
   - 'gcr.io/${PROJECT_ID}/datalab-gpu:commit-${REVISION_ID}'


### PR DESCRIPTION
This is meant to greatly reduce the turn-around time for debugging changes to the creation/connection logic of the CLI.

By having a much smaller mock image we should be able to get a much lower latency between making a change and seeing whether or not the connection still works.