### PR TITLE
Added the Word Highlighter Jupyter Extention

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -115,8 +115,9 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         google-cloud-dataflow==2.0.0 \
         lime==0.1.1.23 \
         protobuf==3.5.2 \
+        pyreadline==2.1 \
         tensorflow==1.8.0 && \
-        pyreadline \
+
     source deactivate && \
 # Clean up before setting up the Python3 env.
     conda clean -tipsy && \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -79,6 +79,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         ipywidgets==6.0.0 \
         jinja2==2.8 \
         jsonschema==2.6.0 \
+        jupyter_highlight_selected_word==0.2.0\
         matplotlib==2.1.2 \
         mock==2.0.0 \
         nltk==3.2.1 \
@@ -115,7 +116,6 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         google-cloud-dataflow==2.0.0 \
         lime==0.1.1.23 \
         protobuf==3.5.2 \
-        pyreadline==2.1 \
         tensorflow==1.8.0 && \
     source deactivate && \
 # Clean up before setting up the Python3 env.
@@ -261,6 +261,7 @@ RUN if [ -d /datalab/lib/pydatalab/.git ]; then \
     jupyter nbextension install --py datalab.notebook && \
     jupyter nbextension install --py google.datalab.notebook && \
     jupyter nbextension enable --py widgetsnbextension && \
+    jupyter nbextension enable highlight_selected_word/main
     source deactivate && \
 # Clean up
     rm datalab/notebook/static/*.js google/datalab/notebook/static/*.js && \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -117,7 +117,6 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         protobuf==3.5.2 \
         pyreadline==2.1 \
         tensorflow==1.8.0 && \
-
     source deactivate && \
 # Clean up before setting up the Python3 env.
     conda clean -tipsy && \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -116,6 +116,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         lime==0.1.1.23 \
         protobuf==3.5.2 \
         tensorflow==1.8.0 && \
+        pyreadline \
     source deactivate && \
 # Clean up before setting up the Python3 env.
     conda clean -tipsy && \

--- a/third_party/license.txt
+++ b/third_party/license.txt
@@ -4759,58 +4759,38 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-pyreadline
-""""""""""
-pyreadline copyright and licensing notes
-========================================
 
-Unless indicated otherwise, files in this project are covered by a BSD-type
-license, included below.
+jupyter_highlight_selected_word
+""""""
+This project is licensed under the terms of the Modified BSD License
+(also known as New or Revised or 3-Clause BSD), as follows:
 
-Individual authors are the holders of the copyright for their code and are
-listed in each file.
-
-Some files may be licensed under different conditions. Ultimately each file
-indicates clearly the conditions under which its author/authors have
-decided to publish the code.
-
-
-pyreadline license
-------------------
-
-pyreadline is released under a BSD-type license.
-
-Copyright (c) 2006 J�rgen Stenarson <jorgen.stenarson@bostream.nu>.
-
-Copyright (c) 2003-2006 Gary Bishop
-
-Copyright (c) 2003-2006 Jack Trainor
-
+- Copyright (c) 2016, Joshua Cooke Barnes
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-  a. Redistributions of source code must retain the above copyright notice,
-     this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-  b. Redistributions in binary form must reproduce the above copyright
-     notice, this list of conditions and the following disclaimer in the
-     documentation and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
-  c. Neither the name of the copyright holders nor the names of any
-     contributors to this software may be used to endorse or promote products
-     derived from this software without specific prior written permission.
+* Neither the name of jupyter_highlight_selected_word nor the names of any
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
 
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
 DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
 SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+

--- a/third_party/license.txt
+++ b/third_party/license.txt
@@ -4758,3 +4758,59 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+"""
+pyreadline
+""""""""""
+pyreadline copyright and licensing notes
+========================================
+
+Unless indicated otherwise, files in this project are covered by a BSD-type
+license, included below.
+
+Individual authors are the holders of the copyright for their code and are
+listed in each file.
+
+Some files may be licensed under different conditions. Ultimately each file
+indicates clearly the conditions under which its author/authors have
+decided to publish the code.
+
+
+pyreadline license
+------------------
+
+pyreadline is released under a BSD-type license.
+
+Copyright (c) 2006 J�rgen Stenarson <jorgen.stenarson@bostream.nu>.
+
+Copyright (c) 2003-2006 Gary Bishop
+
+Copyright (c) 2003-2006 Jack Trainor
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  a. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  b. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  c. Neither the name of the copyright holders nor the names of any
+     contributors to this software may be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.


### PR DESCRIPTION
Added Jupyter extension to highlight the selected word.
https://github.com/jcb91/jupyter_highlight_selected_word

This nbextension highlights all instances of the selected word in either the current cell's editor, or in all cells in the notebook.

I have added and enabled it on the Dockerfile and also added its BSD license on licenses.txt
Let me know if any change is required :)
@yebrahim @ojarjur @nikhilk 

