### PR TITLE
Make the installed nbextensions more consistent.

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -76,7 +76,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         httplib2==0.10.3 \
         h5py==2.7.1 \
         ipykernel==4.5.2 \
-        ipywidgets==6.0.0 \
+        ipywidgets==7.2.1 \
         jinja2==2.8 \
         jsonschema==2.6.0 \
         matplotlib==2.1.2 \
@@ -105,6 +105,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         statsmodels==0.8.0 \
         sympy==0.7.6.1 \
         tornado==4.5.1 \
+        widgetsnbextension==3.2.1 \
         xgboost==0.6a2 && \
 # Install Python2 packages that aren't available or up-to-date in Conda.
     source activate $PYTHON_2_ENV && \
@@ -130,7 +131,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         httplib2==0.10.3 \
         h5py==2.7.1 \
         ipykernel==4.5.2 \
-        ipywidgets==6.0.0 \
+        ipywidgets==7.2.1 \
         jinja2==2.8 \
         jsonschema==2.6.0 \
         matplotlib==2.1.2 \
@@ -160,6 +161,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         statsmodels==0.8.0 \
         sympy==0.7.6.1 \
         tornado==4.5.1 \
+        widgetsnbextension==3.2.1 \
         xgboost==0.6a2 && \
 # Install Python3 packages that aren't available or up-to-date in Conda.
     source activate $PYTHON_3_ENV && \
@@ -257,11 +259,12 @@ RUN if [ -d /datalab/lib/pydatalab/.git ]; then \
     pip install --upgrade-strategy only-if-needed --no-cache-dir . && \
     pip install --upgrade-strategy only-if-needed /datalab/lib/pydatalab/solutionbox/image_classification/. && \
     pip install --upgrade-strategy only-if-needed /datalab/lib/pydatalab/solutionbox/structured_data/. && \
-    pip install --upgrade-strategy only-if-needed jupyter_highlight_selected_word && \
+    pip install --upgrade-strategy only-if-needed jupyter_highlight_selected_word==0.2.0 && \
     jupyter nbextension install --py datalab.notebook && \
     jupyter nbextension install --py google.datalab.notebook && \
+    jupyter nbextension install --py jupyter_highlight_selected_word && \
     jupyter nbextension enable --sys-prefix --py jupyter_highlight_selected_word && \
-    jupyter nbextension enable --py widgetsnbextension && \
+    jupyter nbextension enable --sys-prefix --py widgetsnbextension && \
     source deactivate && \
 # Clean up
     rm datalab/notebook/static/*.js google/datalab/notebook/static/*.js && \

--- a/containers/datalab/content/run.sh
+++ b/containers/datalab/content/run.sh
@@ -93,11 +93,6 @@ fi
 # Verify that we can write to the /tmp directory
 check_tmp_directory
 
-# Make sure widgets notebook extension is installed correctly at /content/.jupyter after the docker volume is mounted.
-source activate ${PYTHON3_ENV}
-jupyter nbextension enable --py widgetsnbextension
-source deactivate
-
 # Make sure the notebooks directory exists
 mkdir -p /content/datalab/notebooks
 


### PR DESCRIPTION
This change fixes some inconsistencies and potential issues around
assorted notebook extensions.

1. Make sure that every installed extension package has a pinned
   verison.
2. Update the pinned versions of ipywidgets and widgetsnbextension to
   be compatible.
3. Install the jupyter_highlight_selected_widget extension prior to
   enabling it.
4. Enable all of the extensions system wide. Previously, the widgets
   extension was enabled for the user, and then re-enabled at startup
   after the user's home directory was changed.