### PR TITLE
Uses allow_origin_pat to fix Cloud Shell connections

### DIFF
--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -19,6 +19,7 @@
     "--no-browser",
     "--log-level=DEBUG",
     "--debug",
+    "--NotebookApp.allow_origin_pat=\".*-dot-devshell.appspot.com$\"",
     "--NotebookApp.log_format=\"%(message)s\"",
     "--NotebookApp.token=",
     "--Session.key=b'\"\"'",


### PR DESCRIPTION
Fixes #2022

I verified that the previous issues seen with connections via Cloud Shell when using the `allow_origin` flag are not present, and that localhost works as well.