### PR TITLE
Remove the `apache-beam` library.

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -112,7 +112,6 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     source activate $PYTHON_2_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
         apache-airflow==1.9.0 \
-        apache-beam==2.4.0 \
         bs4==0.0.1 \
         ggplot==0.6.8 \
         google-cloud-dataflow==2.0.0 \


### PR DESCRIPTION
This was conflicting with the (older) `google-cloud-dataflow` library
which is what the `mltoolbox` modules in the `pydatalab` library are
written against.

We could alternatively update the mltoolbox modules to work with the
newer apache-beam library, but that is a more involved process.

The `apache-beam` installation was just added this week (when I was
trying to fix a regression caused by an update to `dill`), so no one
should be depending on this yet, as it was never included in a
released image.