### PR TITLE
Increase our automated build timeout to 3 hours

### DIFF
--- a/tools/release/cloudbuild.yaml
+++ b/tools/release/cloudbuild.yaml
@@ -187,4 +187,4 @@ images:
   - 'gcr.io/${PROJECT_ID}/datalab-preview'
   - 'gcr.io/${PROJECT_ID}/datalab-gpu-preview'
 
-timeout: '7200s'
+timeout: '10600s'


### PR DESCRIPTION
Our automated Cloud Builds run multiple long-running integration tests in both Python 2 and Python 3 environments.

As such, they've started taking longer than the previous timeout of 2 hours.