### PR TITLE
Enable Datalab to run in a read-only mode.

### DIFF
--- a/sources/web/datalab/common.d.ts
+++ b/sources/web/datalab/common.d.ts
@@ -25,6 +25,11 @@ declare module common {
   interface AppSettings {
 
     /**
+     * Whether or not to turn on read-only mode, where only GET requests are allowed.
+     */
+    readOnly: boolean;
+
+    /**
      * Whether or not to write log statements to stderr
      */
     consoleLogging: boolean;

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -42,11 +42,11 @@
   "numHourlyBackups": 10,
   "numWeeklyBackups": 20,
   "proxyWebSockets": false,
+  "readOnly": false,
   "release": "beta",
   "serverPort": 8080,
   "socketioPort": 8084,
   "supportedFileBrowserSources": ["jupyter"],
   "supportUserOverride": false,
-  "useWorkspace": false,
-  "readOnly": false
+  "useWorkspace": false
 }

--- a/sources/web/datalab/config/settings.json
+++ b/sources/web/datalab/config/settings.json
@@ -47,5 +47,6 @@
   "socketioPort": 8084,
   "supportedFileBrowserSources": ["jupyter"],
   "supportUserOverride": false,
-  "useWorkspace": false
+  "useWorkspace": false,
+  "readOnly": false
 }


### PR DESCRIPTION
In this mode, Datalab will refuse all websocket requests, and any
HTTP requests other than 'HEAD' or 'GET' requests.