### PR TITLE
Add back jquery-ui dependency

### DIFF
--- a/sources/web/datalab/static/datalab.css
+++ b/sources/web/datalab/static/datalab.css
@@ -285,6 +285,7 @@ i.material-icons {
 /* List page */
 #button-select-all {
   border-color: transparent;
+  box-shadow: none;
   background-color: transparent;
   min-width: 20px;
 }

--- a/sources/web/datalab/static/notebook-list.js
+++ b/sources/web/datalab/static/notebook-list.js
@@ -1,4 +1,4 @@
-define(['util'], (util) => {
+define(['util', 'jquery-ui'], (util) => {
 
   // Compare two arrays, each representing a semantic version in the form of [0,1,2]
   // Returns -1, 0, 1. Returns null if they're malformed

--- a/sources/web/datalab/templates/tree.html
+++ b/sources/web/datalab/templates/tree.html
@@ -108,7 +108,7 @@
                     <div id="notebook_list_header" class="row list_header">
                       <div class="btn-group dropdown" id="tree-selector">
                         <button title="Select All / None" type="button" class="btn btn-default btn-xs" id="button-select-all">
-                          <input type="checkbox" class="pull-left tree-selector" id="select-all"></input>
+                          <input type="checkbox" class="pull-left tree-selector" id="select-all">
                         </button>
                       </div>
                       <div id="project_name">
@@ -146,7 +146,10 @@
         '*': {
           'contents': 'services/contents',
         }
-      }
+      },
+      paths: {
+        'jquery-ui': 'components/jquery-ui/ui/minified/jquery-ui.min',
+      },
     });
     $("#appBar").load("<%baseUrl%>static/appbar.html", function() {
         requirejs(['websocket'], (websocket) => {

--- a/test/client-unit/notebook-list_spec.js
+++ b/test/client-unit/notebook-list_spec.js
@@ -23,6 +23,9 @@ requirejs.config({
   nodeRequire: require,
 });
 
+// Stub the jquery-ui needed by the notebook-list module
+requirejs.define('jquery-ui', [], () => {});
+
 const notebookList = requirejs('notebook-list');
 const util = requirejs('util');
 


### PR DESCRIPTION
The file search auto-complete functionality depends on the jquery-ui library, but its reference and import were removed in the migration to notebook==5.0.0.

Fixes #2073.