### PR TITLE
Update pytz and replace google-cloud-dataflow lib with apache-beam[gcp]

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -95,7 +95,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         pygments==2.1.3 \
         python-dateutil==2.5.0 \
         python-snappy==0.5.1 \
-        pytz==2016.7 \
+        pytz==2018.4 \
         pyzmq==17.1.0 \
         requests==2.18.4 \
         scikit-image==0.13.0 \
@@ -112,9 +112,9 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     source activate $PYTHON_2_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
         apache-airflow==1.9.0 \
+        apache-beam[gcp]==2.7.0 \
         bs4==0.0.1 \
         ggplot==0.6.8 \
-        google-cloud-dataflow==2.0.0 \
         google-cloud-monitoring==0.28.0 \
         lime==0.1.1.23 \
         protobuf==3.5.2 \
@@ -153,7 +153,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         pygments==2.1.3 \
         python-dateutil==2.5.0 \
         python-snappy==0.5.1 \
-        pytz==2016.7 \
+        pytz==2018.4 \
         pyzmq==17.1.0 \
         requests==2.18.4 \
         scikit-image==0.13.0 \


### PR DESCRIPTION
We are replacing the `google-cloud-dataflow` package with `apache-beam` as, according to the Google Cloud Dataflow project's release notes, "The Cloud Dataflow SDK 2.5.0 is the last Cloud Dataflow SDK release that is separate from the Apache Beam SDK releases."
https://cloud.google.com/dataflow/release-notes/release-notes-python