### PR TITLE
Update the Drive scopes used by the polymer UI

### DIFF
--- a/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
+++ b/sources/web/datalab/polymer/modules/gapi-manager/gapi-manager.ts
@@ -271,7 +271,7 @@ class ClientAuth implements GapiAuth {
       case GapiScopes.DRIVE:
         const driveScopeList = [
             'https://www.googleapis.com/auth/drive',
-            'https://www.googleapis.com/auth/drive.appfolder',
+            'https://www.googleapis.com/auth/drive.appdata',
             'https://www.googleapis.com/auth/drive.install',
         ];
         return driveScopeList.join(' ');


### PR DESCRIPTION
Apparently, "drive.appfolder" has been renamed "drive.appdata"