### PR TITLE
Separate Py3 package installations in Conda

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -56,10 +56,9 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     cd / && \
 # Set our locale to en_US.UTF-8.
     locale-gen en_US.UTF-8 && \
-    update-locale LANG=en_US.UTF-8
-
+    update-locale LANG=en_US.UTF-8 && \
 # Install MiniConda, set up Python 2.7 Conda env, and install packages.
-RUN wget --quiet -O ~/miniconda.sh \
+    wget --quiet -O ~/miniconda.sh \
     http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh && \
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -f -p $DATALAB_CONDA_DIR && \
@@ -220,7 +219,6 @@ RUN wget --quiet -O ~/miniconda.sh \
     rm -rf /root/.cache/* && \
     rm -rf /usr/share/locale/* && \
     rm -rf /usr/share/i18n/locales/*
-
 
 # Install Python3 packages that aren't available or up-to-date in Conda.
 RUN source activate $PYTHON_3_ENV && \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -171,12 +171,7 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
 # Install Python3 packages that aren't available or up-to-date in Conda.
     source activate $PYTHON_3_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
-        apache-airflow==1.9.0 \
-        bs4==0.0.1 \
-        ggplot==0.6.8 \
-        google-cloud-monitoring==0.28.0 \
-        lime==0.1.1.23 \
-        tensorflow==1.8.0
+        google-cloud-monitoring==0.28.0
 
 
 # Make pip3 a copy of pip for the Python 3 environment.

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -169,9 +169,16 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         widgetsnbextension==3.2.1 \
         xgboost==0.6a2 && \
 # Install Python3 packages that aren't available or up-to-date in Conda.
+    sleep 2 && \
     source activate $PYTHON_3_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
-        google-cloud-monitoring==0.28.0
+        apache-airflow==1.9.0 \
+        bs4==0.0.1 \
+        ggplot==0.6.8 \
+        google-cloud-monitoring==0.28.0 \
+        lime==0.1.1.23 \
+        protobuf==3.6.1 \
+        tensorflow==1.8.0
 
 
 # Make pip3 a copy of pip for the Python 3 environment.

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -56,9 +56,10 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     cd / && \
 # Set our locale to en_US.UTF-8.
     locale-gen en_US.UTF-8 && \
-    update-locale LANG=en_US.UTF-8 && \
+    update-locale LANG=en_US.UTF-8
+
 # Install MiniConda, set up Python 2.7 Conda env, and install packages.
-    wget --quiet -O ~/miniconda.sh \
+RUN wget --quiet -O ~/miniconda.sh \
     http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh && \
     chmod +x ~/miniconda.sh && \
     ~/miniconda.sh -b -f -p $DATALAB_CONDA_DIR && \
@@ -107,9 +108,10 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         sympy==0.7.6.1 \
         tornado==4.5.1 \
         widgetsnbextension==3.2.1 \
-        xgboost==0.6a2 && \
+        xgboost==0.6a2
+
 # Install Python2 packages that aren't available or up-to-date in Conda.
-    source activate $PYTHON_2_ENV && \
+RUN source activate $PYTHON_2_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
         apache-airflow==1.9.0 \
         apache-beam[gcp]==2.7.0 \
@@ -124,9 +126,10 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     conda clean -tipsy && \
 # This var needs to be unset before installing the Python3 Conda env to
 # avoid subtle dependency issues.
-    unset OLDPWD && \
+    unset OLDPWD
 # Set up Python 3.5 Conda env and install packages.
-    conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
+
+RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         crcmod==1.7 \
         dask==0.17.1 \
         dill==0.2.6 \
@@ -165,9 +168,10 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         sympy==0.7.6.1 \
         tornado==4.5.1 \
         widgetsnbextension==3.2.1 \
-        xgboost==0.6a2 && \
+        xgboost==0.6a2
+
 # Install Python3 packages that aren't available or up-to-date in Conda.
-    source activate $PYTHON_3_ENV && \
+RUN source activate $PYTHON_3_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
         apache-airflow==1.9.0 \
         bs4==0.0.1 \
@@ -175,9 +179,10 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         google-cloud-monitoring==0.28.0 \
         lime==0.1.1.23 \
         protobuf==3.6.1 \
-        tensorflow==1.8.0 && \
+        tensorflow==1.8.0
+
 # Make pip3 a copy of pip for the Python 3 environment.
-    cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
+RUN cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
     source deactivate && \
     # Install Python2 IPython kernel within the Python3 Jupyter directory since
     # we will be running Jupyter from the Python3 conda env.

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -149,7 +149,7 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         pandas==0.22.0 \
         pandocfilters==1.4.2 \
         pillow==5.0.0 \
-        pip==18.0 \
+        pip==9.0.3 \
         plotly==1.12.5 \
         psutil==4.3.0 \
         pygments==2.1.3 \
@@ -169,7 +169,6 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         widgetsnbextension==3.2.1 \
         xgboost==0.6a2 && \
 # Install Python3 packages that aren't available or up-to-date in Conda.
-    sleep 2 && \
     source activate $PYTHON_3_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
         apache-airflow==1.9.0 \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -177,9 +177,11 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         google-cloud-monitoring==0.28.0 \
         lime==0.1.1.23 \
         protobuf==3.6.1 \
-        tensorflow==1.8.0 && \
+        tensorflow==1.8.0
+
+
 # Make pip3 a copy of pip for the Python 3 environment.
-    cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
+RUN cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
     source deactivate && \
     # Install Python2 IPython kernel within the Python3 Jupyter directory since
     # we will be running Jupyter from the Python3 conda env.

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -167,10 +167,9 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         sympy==0.7.6.1 \
         tornado==4.5.1 \
         widgetsnbextension==3.2.1 \
-        xgboost==0.6a2
-
+        xgboost==0.6a2 && \
 # Install Python3 packages that aren't available or up-to-date in Conda.
-RUN source activate $PYTHON_3_ENV && \
+    source activate $PYTHON_3_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
         apache-airflow==1.9.0 \
         bs4==0.0.1 \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -108,10 +108,9 @@ RUN wget --quiet -O ~/miniconda.sh \
         sympy==0.7.6.1 \
         tornado==4.5.1 \
         widgetsnbextension==3.2.1 \
-        xgboost==0.6a2
-
+        xgboost==0.6a2 && \
 # Install Python2 packages that aren't available or up-to-date in Conda.
-RUN source activate $PYTHON_2_ENV && \
+    source activate $PYTHON_2_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
         apache-airflow==1.9.0 \
         apache-beam[gcp]==2.7.0 \
@@ -168,10 +167,9 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         sympy==0.7.6.1 \
         tornado==4.5.1 \
         widgetsnbextension==3.2.1 \
-        xgboost==0.6a2
-
+        xgboost==0.6a2 && \
 # Install Python3 packages that aren't available or up-to-date in Conda.
-RUN source activate $PYTHON_3_ENV && \
+    source activate $PYTHON_3_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
         apache-airflow==1.9.0 \
         bs4==0.0.1 \
@@ -179,10 +177,9 @@ RUN source activate $PYTHON_3_ENV && \
         google-cloud-monitoring==0.28.0 \
         lime==0.1.1.23 \
         protobuf==3.6.1 \
-        tensorflow==1.8.0
-
+        tensorflow==1.8.0 && \
 # Make pip3 a copy of pip for the Python 3 environment.
-RUN cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
+    cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
     source deactivate && \
     # Install Python2 IPython kernel within the Python3 Jupyter directory since
     # we will be running Jupyter from the Python3 conda env.

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -125,10 +125,9 @@ RUN wget --quiet -O ~/miniconda.sh \
     conda clean -tipsy && \
 # This var needs to be unset before installing the Python3 Conda env to
 # avoid subtle dependency issues.
-    unset OLDPWD
+    unset OLDPWD && \
 # Set up Python 3.5 Conda env and install packages.
-
-RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
+    conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         crcmod==1.7 \
         dask==0.17.1 \
         dill==0.2.6 \
@@ -149,7 +148,7 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         pandas==0.22.0 \
         pandocfilters==1.4.2 \
         pillow==5.0.0 \
-        pip==9.0.3 \
+        pip==18.0 \
         plotly==1.12.5 \
         psutil==4.3.0 \
         pygments==2.1.3 \
@@ -168,20 +167,8 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         tornado==4.5.1 \
         widgetsnbextension==3.2.1 \
         xgboost==0.6a2 && \
-# Install Python3 packages that aren't available or up-to-date in Conda.
-    source activate $PYTHON_3_ENV && \
-    pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
-        apache-airflow==1.9.0 \
-        bs4==0.0.1 \
-        ggplot==0.6.8 \
-        google-cloud-monitoring==0.28.0 \
-        lime==0.1.1.23 \
-        protobuf==3.6.1 \
-        tensorflow==1.8.0
-
-
 # Make pip3 a copy of pip for the Python 3 environment.
-RUN cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
+    cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
     source deactivate && \
     # Install Python2 IPython kernel within the Python3 Jupyter directory since
     # we will be running Jupyter from the Python3 conda env.
@@ -233,6 +220,18 @@ RUN cp /usr/local/envs/py3env/bin/pip /usr/local/envs/py3env/bin/pip3 && \
     rm -rf /root/.cache/* && \
     rm -rf /usr/share/locale/* && \
     rm -rf /usr/share/i18n/locales/*
+
+
+# Install Python3 packages that aren't available or up-to-date in Conda.
+RUN source activate $PYTHON_3_ENV && \
+    pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
+        apache-airflow==1.9.0 \
+        bs4==0.0.1 \
+        ggplot==0.6.8 \
+        google-cloud-monitoring==0.28.0 \
+        lime==0.1.1.23 \
+        protobuf==3.6.1 \
+        tensorflow==1.8.0
 
 ENV LANG en_US.UTF-8
 

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -176,7 +176,6 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         ggplot==0.6.8 \
         google-cloud-monitoring==0.28.0 \
         lime==0.1.1.23 \
-        protobuf==3.6.1 \
         tensorflow==1.8.0
 
 

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -167,9 +167,10 @@ RUN conda create --yes --quiet --name $PYTHON_3_ENV python=3.5 \
         sympy==0.7.6.1 \
         tornado==4.5.1 \
         widgetsnbextension==3.2.1 \
-        xgboost==0.6a2 && \
+        xgboost==0.6a2
+
 # Install Python3 packages that aren't available or up-to-date in Conda.
-    source activate $PYTHON_3_ENV && \
+RUN source activate $PYTHON_3_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
         apache-airflow==1.9.0 \
         bs4==0.0.1 \

--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -221,6 +221,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
     rm -rf /usr/share/i18n/locales/*
 
 # Install Python3 packages that aren't available or up-to-date in Conda.
+# For some reasons, merging it with the commands above does not work so creating a separate one.
 RUN source activate $PYTHON_3_ENV && \
     pip install --quiet -U --upgrade-strategy only-if-needed --no-cache-dir \
         apache-airflow==1.9.0 \


### PR DESCRIPTION
I have to move PY3 package installation to a different command group to work around a build problem.

For some reasons, if we merge them, local docker build works but cloud build fails mysteriously with error:

Step #13 - "buildBase": /bin/bash: /usr/local/envs/py3env/bin/pip: /usr/local/envs/py3env/bin/python: bad interpreter: Invalid argument
ERROR: (gcloud.builds.submit) build 8b66a0db-d857-4dff-b31c-bd2442ce1d1e completed with status "FAILURE"
Step #13 - "buildBase": The command '/bin/bash -c ...

The change may increase the docker image size a bit.

