### PR TITLE
Conda custom packages support

### DIFF
--- a/containers/datalab/custom-packages-example.conda
+++ b/containers/datalab/custom-packages-example.conda
@@ -1,0 +1,5 @@
+# Use this file to add additional conda python packages to datalab 
+
+
+# The following line will install package xlrd, as an example
+xlrd

--- a/containers/datalab/custom-packages-example.pip
+++ b/containers/datalab/custom-packages-example.pip
@@ -1,0 +1,6 @@
+# Use this file to add additional python packages to datalab using pip
+# You can use also wheel packages using the URL
+# ex : http://h2o-release.s3.amazonaws.com/h2o/rel-xia/2/Python/h2o-3.22.0.2-py2.py3-none-any.whl
+
+# The following line will install package xlrd, as an example
+xlrd

--- a/containers/datalab/custom-packages-example.txt
+++ b/containers/datalab/custom-packages-example.txt
@@ -1,4 +1,0 @@
-# Use this file to add additional python packages to datalab
-
-# The following line will install package xlrd, as an example
-xlrd


### PR DESCRIPTION
Small changes for adding support for Conda custom packages in addition to the pip ones.

- Deleted custom-packages-example.txt and replaced by two files : custom-packages-example.conda (for Conda packages) and custom-packages-example.pip (for Pip ones).
- Renamed custom-packages to custom-packages.pip.
- Modified run-extended.sh to be able to insert into the generated Dockerfile the conda install command only if the custom-packages.conda exists.

