### PR TITLE
Update dependency third party license

### DIFF
--- a/containers/base/third_party_licenses.csv
+++ b/containers/base/third_party_licenses.csv
@@ -6,7 +6,7 @@ Mako,https://raw.githubusercontent.com/zzzeek/mako/master/LICENSE,MIT
 python-editor,https://raw.githubusercontent.com/fmoo/python-editor/master/LICENSE,Apache v2
 tzlocal,https://raw.githubusercontent.com/regebro/tzlocal/master/LICENSE.txt,MIT
 itsdangerous,https://raw.githubusercontent.com/pallets/itsdangerous/master/LICENSE.rst,3-Clause BSD
-Werkzeug,https://raw.githubusercontent.com/pallets/werkzeug/master/LICENSE,3-Clause BSD
+Werkzeug,https://raw.githubusercontent.com/pallets/werkzeug/master/LICENSE.rst,3-Clause BSD
 click,https://raw.githubusercontent.com/pallets/click/master/LICENSE,3-Clause BSD
 alembic,https://raw.githubusercontent.com/zzzeek/alembic/master/LICENSE,MIT
 sqlalchemy,https://raw.githubusercontent.com/zzzeek/sqlalchemy/master/LICENSE,MIT


### PR DESCRIPTION
License for dependency werkzeug has renamed their license file location. This updates the URL location to the new renamed file. See #2120 .