### PR TITLE
Fix build at HEAD

### DIFF
--- a/containers/base/third_party_licenses.csv
+++ b/containers/base/third_party_licenses.csv
@@ -6,7 +6,7 @@ Mako,https://raw.githubusercontent.com/zzzeek/mako/master/LICENSE,MIT
 python-editor,https://raw.githubusercontent.com/fmoo/python-editor/master/LICENSE,Apache v2
 tzlocal,https://raw.githubusercontent.com/regebro/tzlocal/master/LICENSE.txt,MIT
 itsdangerous,https://raw.githubusercontent.com/pallets/itsdangerous/master/LICENSE.rst,3-Clause BSD
-Werkzeug,https://raw.githubusercontent.com/pallets/werkzeug/master/LICENSE,3-Clause BSD
+Werkzeug,https://raw.githubusercontent.com/pallets/werkzeug/master/LICENSE.rst,3-Clause BSD
 click,https://raw.githubusercontent.com/pallets/click/master/LICENSE,3-Clause BSD
 alembic,https://raw.githubusercontent.com/zzzeek/alembic/master/LICENSE,MIT
 sqlalchemy,https://raw.githubusercontent.com/zzzeek/sqlalchemy/master/LICENSE,MIT

--- a/tools/cli/datalab.py
+++ b/tools/cli/datalab.py
@@ -406,7 +406,7 @@ def run():
     datalab_version = component_versions.get(datalab_component, 'UNKNOWN')
 
     if args.diagnose_me:
-        if args.verbosity is 'default':
+        if args.verbosity == 'default':
             args.verbosity = 'debug'
         print('Running with diagnostic messages enabled')
         print('Using the command "{}" to invoke gcloud'.format(gcloud_cmd))


### PR DESCRIPTION
Two issues are fixed here:
- The most recent flake8 version breaks on a cli string comparison.
- One of our third party license locations has changed, so updating accordingly. This was originally discovered and fixed by @bnajlis in #2121.

Fixes https://github.com/googledatalab/datalab/issues/2120.