### PR TITLE
Removed the creation of the firewall rule for --beta-no-external-ip.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -919,8 +919,11 @@ def prepare(args, gcloud_compute, gcloud_repos):
     """
     network_name = args.network_name
     ensure_network_exists(args, gcloud_compute, network_name)
-    prompt_on_unexpected_firewall_rules(args, gcloud_compute, network_name)
-    ensure_firewall_rule_exists(args, gcloud_compute, network_name)
+
+    # Remove Firewall Rule Creation for no external IP Address
+    if not args.no_external_ip:
+        prompt_on_unexpected_firewall_rules(args, gcloud_compute, network_name)
+        ensure_firewall_rule_exists(args, gcloud_compute, network_name)
 
     disk_name = args.disk_name or '{0}-pd'.format(args.instance)
     ensure_disk_exists(args, gcloud_compute, disk_name)


### PR DESCRIPTION
Public firewall creation for no-external-ip doesn't make sense as there will be no external access. Removing the firewall creation for this flag. This resolves both issue #2126 and #2125 .

