### PR TITLE
Fix Issue with Build

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -96,6 +96,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian testing main" >> /etc/apt/sour
         python-dateutil==2.5.0 \
         python-snappy==0.5.1 \
         pytz==2018.4 \
+        pyyaml==3.13 \
         pyzmq==17.1.0 \
         requests==2.18.4 \
         scikit-image==0.13.0 \

--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -919,8 +919,11 @@ def prepare(args, gcloud_compute, gcloud_repos):
     """
     network_name = args.network_name
     ensure_network_exists(args, gcloud_compute, network_name)
-    prompt_on_unexpected_firewall_rules(args, gcloud_compute, network_name)
-    ensure_firewall_rule_exists(args, gcloud_compute, network_name)
+
+    # Remove Firewall Rule Creation for no external IP Address
+    if not args.no_external_ip:
+        prompt_on_unexpected_firewall_rules(args, gcloud_compute, network_name)
+        ensure_firewall_rule_exists(args, gcloud_compute, network_name)
 
     disk_name = args.disk_name or '{0}-pd'.format(args.instance)
     ensure_disk_exists(args, gcloud_compute, disk_name)


### PR DESCRIPTION
Fix for build issue #2128. The pyyaml that gets deployed by conda by default is not supported with google-cloud-dataflow. Setting the version for pyyaml fixes this problem. 

This only requires a change for python 2, not python 3.