### PR TITLE
Resolves Issue with firewall rule creation when no public IP address is specified

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -919,8 +919,10 @@ def prepare(args, gcloud_compute, gcloud_repos):
     """
     network_name = args.network_name
     ensure_network_exists(args, gcloud_compute, network_name)
-    prompt_on_unexpected_firewall_rules(args, gcloud_compute, network_name)
-    ensure_firewall_rule_exists(args, gcloud_compute, network_name)
+    # Remove Firewall Rule Creation for no external IP Address
+    if not args.no_external_ip:
+        prompt_on_unexpected_firewall_rules(args, gcloud_compute, network_name)
+        ensure_firewall_rule_exists(args, gcloud_compute, network_name)
 
     disk_name = args.disk_name or '{0}-pd'.format(args.instance)
     ensure_disk_exists(args, gcloud_compute, disk_name)


### PR DESCRIPTION
Fixes Issue #2126 & #2125 
--no-public-ip currently attempts the creation of the public firewall rule, even though there is no public ip address specified. This results in 2 issues, it blocks the use of shared vpcs and also doesn't behave as expected as a firewall rule is not required. This change disables firewall rule creation when the --no-public-ip address is specified. Build will fail as a result of #2128.