### PR TITLE
Resolves Firewall Rule Created when no public IP specified.

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -919,8 +919,10 @@ def prepare(args, gcloud_compute, gcloud_repos):
     """
     network_name = args.network_name
     ensure_network_exists(args, gcloud_compute, network_name)
-    prompt_on_unexpected_firewall_rules(args, gcloud_compute, network_name)
-    ensure_firewall_rule_exists(args, gcloud_compute, network_name)
+    # Remove Firewall Rule Creation for no external IP Address
+    if not args.no_external_ip:
+        prompt_on_unexpected_firewall_rules(args, gcloud_compute, network_name)
+        ensure_firewall_rule_exists(args, gcloud_compute, network_name)
 
     disk_name = args.disk_name or '{0}-pd'.format(args.instance)
     ensure_disk_exists(args, gcloud_compute, disk_name)


### PR DESCRIPTION
Resolves Issue #2126 

Does not create firewall rule when --beta-no-external-ip is selected.

Issue #2128 prevents this from building.