### PR TITLE
Fixed issue in which datalab does not start for GPU instances

### DIFF
--- a/tools/cli/commands/create.py
+++ b/tools/cli/commands/create.py
@@ -296,6 +296,8 @@ write_files:
        --env='DATALAB_GIT_AUTHOR={3}' \
        --env='DATALAB_INITIAL_USER_SETTINGS={4}' \
        {0}
+    ExecStop=-/usr/bin/docker stop datalab
+    ExecStopPost=-/usr/bin/docker rm -f datalab
     Restart=always
     RestartSec=1
 

--- a/tools/cli/commands/creategpu.py
+++ b/tools/cli/commands/creategpu.py
@@ -75,7 +75,7 @@ write_files:
   permissions: 0755
   owner: root
   content: |
-    NVIDIA_DRIVER_VERSION=390.46
+    NVIDIA_DRIVER_VERSION=418.67
     COS_NVIDIA_INSTALLER_CONTAINER=gcr.io/cos-cloud/cos-gpu-installer:latest
     NVIDIA_INSTALL_DIR_HOST=/var/lib/nvidia
     NVIDIA_INSTALL_DIR_CONTAINER=/usr/local/nvidia
@@ -96,8 +96,9 @@ write_files:
     User=root
     Type=oneshot
     RemainAfterExit=true
+    Environment="HOME=/home/datalab"
     EnvironmentFile=/etc/nvidia-installer-env
-    ExecStartPre=docker-credential-gcr configure-docker
+    ExecStartPre=/usr/bin/docker-credential-gcr configure-docker
     ExecStartPre=/bin/bash -c 'mkdir -p "${{NVIDIA_INSTALL_DIR_HOST}}" && \
         mount --bind "${{NVIDIA_INSTALL_DIR_HOST}}" \
         "${{NVIDIA_INSTALL_DIR_HOST}}" && \
@@ -124,8 +125,9 @@ write_files:
 
     [Service]
     Environment="HOME=/home/datalab"
-    ExecStartPre=docker-credential-gcr configure-docker
-    ExecStart=/usr/bin/docker run --restart always \
+    ExecStartPre=/usr/bin/docker-credential-gcr configure-docker
+    ExecStart=/usr/bin/docker run \
+       --name=datalab \
        -p '127.0.0.1:8080:8080' \
        -v /mnt/disks/datalab-pd/content:/content \
        -v /mnt/disks/datalab-pd/tmp:/tmp \
@@ -144,6 +146,8 @@ write_files:
        --env='DATALAB_GIT_AUTHOR={3}' \
        --env='DATALAB_INITIAL_USER_SETTINGS={4}' \
        {0} -c /datalab/run.sh
+    ExecStop=-/usr/bin/docker stop datalab
+    ExecStopPost=-/usr/bin/docker rm -f datalab
     Restart=always
     RestartSec=1
 


### PR DESCRIPTION
- Fixed issue for the GPU instance in which it does not start because it fails to pull down the docker container (https://github.com/googledatalab/datalab/issues/2133)

- Updated the NVIDA driver to 418.67

- Added ExecStop and ExecStopPost to the datalab service so systemctl can be used to stop the service.