### PR TITLE
Pin six==1.11.0 -> six==1.10.0

### DIFF
--- a/containers/base/Dockerfile
+++ b/containers/base/Dockerfile
@@ -105,7 +105,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian stretch main" >> /etc/apt/sour
         scikit-learn==0.19.1 \
         scipy==1.0.0 \
         seaborn==0.9.0 \
-        six==1.11.0 \
+        six==1.10.0 \
         statsmodels==0.8.0 \
         sympy==1.1.1 \
         tornado==4.5.1 \
@@ -164,7 +164,7 @@ RUN echo "deb-src http://ftp.us.debian.org/debian stretch main" >> /etc/apt/sour
         scikit-learn==0.19.1 \
         scipy==1.0.0 \
         seaborn==0.9.0 \
-        six==1.11.0 \
+        six==1.10.0 \
         statsmodels==0.8.0 \
         sympy==1.1.1 \
         tornado==4.5.1 \


### PR DESCRIPTION
Avoids https://github.com/google/apitools/issues/175, matches six version in
current container (sha256:d8826f5df792ddde9e152da08309edefc79b5ef30bf9232ef98c6772dffe6f7b).